### PR TITLE
Improved indicator color into dark mode on create new team

### DIFF
--- a/web/pages/team.tsx
+++ b/web/pages/team.tsx
@@ -141,7 +141,7 @@ const Team = () => {
 function Spinner() {
   return (
     <svg
-      className="animate-spin h-5 w-5 mr-3 text-white"
+      className="animate-spin h-5 w-5 mr-3 text-white dark:text-primary"
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"


### PR DESCRIPTION
I have improved indicator color into dark mode on create new team as shown below

<img width="1792" alt="Screen Shot 2022-11-01 at 14 59 59" src="https://user-images.githubusercontent.com/38250874/199251258-23b5bcaf-9fac-4327-9ace-6bba67fdaea5.png">
<img width="1792" alt="Screen Shot 2022-11-01 at 15 00 03" src="https://user-images.githubusercontent.com/38250874/199251269-743e3b45-7ec7-4ce2-b101-3343e6414f76.png">

