### PR TITLE
Remove for now button "play" near time value in current time column

### DIFF
--- a/web/components/main/card.tsx
+++ b/web/components/main/card.tsx
@@ -22,9 +22,9 @@ const Card = ({
   task,
   image,
   admin,
-  started,
-  setStarted,
-}: ICardProps) => {
+}: // started,
+// setStarted,
+ICardProps) => {
   const [nameEdit, setNameEdit] = useState(false);
   const [taskEdit, setTaskEdit] = useState(false);
   const [formValues, setFormValues] = useState({
@@ -130,7 +130,7 @@ const Card = ({
       <Separator />
       <div className="w-[122px]  text-center flex justify-center items-center">
         {current}
-        {admin && (
+        {/* {admin && (
           <div
             className="ml-[10px] cursor-pointer"
             onClick={() => setStarted(!started)}
@@ -141,7 +141,7 @@ const Card = ({
               <PlayIcon width={24} height={24} />
             )}
           </div>
-        )}
+        )} */}
       </div>
       <Separator />
       <div className="w-[245px]  flex justify-center items-center">


### PR DESCRIPTION
I have removed (commented) for now button "play" near the time value in current time column as it looks a bit confusing.

<img width="1792" alt="Screen Shot 2022-11-02 at 22 03 54" src="https://user-images.githubusercontent.com/38250874/199603107-3ab547ec-2e3a-47ec-b285-1354efa3eb92.png">
