### PR TITLE
improved card header and estimate card size

### DIFF
--- a/web/components/home/header.tsx
+++ b/web/components/home/header.tsx
@@ -3,17 +3,19 @@ import { IHeader } from "../../app/interfaces/hooks";
 const Header = ({ style }: IHeader) => {
   return (
     <li>
-      <div className="flex justify-between text-primary font-bold dark:text-[#FFFFFF]">
+      <div className="flex items-center justify-between text-primary font-bold dark:text-[#FFFFFF]">
         <div className="w-[60px]  text-center">Status</div>
         <div className="w-[215px]  text-center">Name</div>
         <div></div>
         <div className="w-[334px]  text-center">Task</div>
         <div></div>
-        <div className="w-[122px]  text-center">Current time</div>
+        <div className="w-[122px]  text-center">Worked on task</div>
         <div></div>
         <div className="w-[245px]  text-center">Estimate</div>
         <div></div>
-        <div className="w-[184px]  text-center">Total worked today</div>
+        <div className="w-[184px]  text-center flex items-center justify-center">
+          <span className="w-[104px]">Total worked 24 hours</span>
+        </div>
       </div>
     </li>
   );

--- a/web/components/home/team-member.tsx
+++ b/web/components/home/team-member.tsx
@@ -45,7 +45,7 @@ const TeamMemberSection = ({ started, setStarted }: IStartSection) => {
   ];
   const style = { width: `${100 / members.length}%` };
   return (
-    <div className="mt-[72px]">
+    <div className="mt-[42px]">
       <ul className="w-full">
         <Header style={style} />
         {members.map((item, i) => (

--- a/web/components/home/timer-tasks.tsx
+++ b/web/components/home/timer-tasks.tsx
@@ -13,7 +13,7 @@ interface ITimerTasksSection {
 
 export function TimerTasksSection({ started, setStarted }: ITimerTasksSection) {
   return (
-    <div className="bg-[#FFFF] dark:bg-[#202023] mt-[100px] rounded-[20px] w-full h-[130px] flex items-center">
+    <div className="bg-[#FFFF] dark:bg-[#202023] mt-[120px] rounded-[20px] w-full h-[130px] flex items-center">
       <div className="ml-[16px] flex flex-col space-y-[15px] w-full">
         <div className="w-full">
           <TaskInput />

--- a/web/components/main/card.tsx
+++ b/web/components/main/card.tsx
@@ -146,7 +146,7 @@ ICardProps) => {
       <Separator />
       <div className="w-[245px]  flex justify-center items-center">
         <div>
-          <div className="flex w-[245px]">
+          <div className="flex w-[200px]">
             <div className="bg-[#28D581] w-[211px] h-[8px] rounded-l-full"></div>
             <div className="bg-[#E8EBF8] dark:bg-[#18181B] w-[73px] h-[8px] rounded-r-full" />
           </div>


### PR DESCRIPTION
I have improved the card header and fixed estimate width as shown below

<img width="1792" alt="Screen Shot 2022-11-03 at 19 47 33" src="https://user-images.githubusercontent.com/38250874/199808744-779acd72-4b0e-473f-a582-c5cd589ce1b7.png">
<img width="1792" alt="Screen Shot 2022-11-03 at 19 47 37" src="https://user-images.githubusercontent.com/38250874/199808772-1404a2e1-3f4a-400c-9736-89cff9570553.png">

Fix #81 