### PR TITLE
improve team screen design and remove Welcome screen

### DIFF
--- a/mobile/app/navigators/AppNavigator.tsx
+++ b/mobile/app/navigators/AppNavigator.tsx
@@ -70,15 +70,15 @@ const AppStack = observer(function AppStack() {
   return (
     <Stack.Navigator
       screenOptions={{ headerShown: false }}
-      initialRouteName={isAuthenticated ? "Welcome" : "Login"} // @demo remove-current-line
+      initialRouteName={isAuthenticated ? "Authenticated" : "Login"} // @demo remove-current-line
     >
       {/* @demo remove-block-start */}
       {isAuthenticated ? (
         <>
           {/* @demo remove-block-end */}
-          <Stack.Screen name="Welcome" component={WelcomeScreen} />
+          {/* <Stack.Screen name="Welcome" component={WelcomeScreen} /> */}
           {/* @demo remove-block-start */}
-          <Stack.Screen name="Demo" component={DemoNavigator} />
+          {/* <Stack.Screen name="Demo" component={DemoNavigator} /> */}
           {/* @app custom-block */}
           <Stack.Screen name="Authenticated" component={AuthenticatedNavigator} />
         </>


### PR DESCRIPTION
#220 #246 
1. Team manager screen (is already good)

<img width="328" alt="Screenshot 2022-11-18 at 23 42 59" src="https://user-images.githubusercontent.com/54764431/202815287-1b785bd6-bf4a-4fbe-b076-cdb515dba4c3.png">

2. Remove Welcome page (Screen with smile)

![WhatsApp Image 2022-11-19 at 06 44 57](https://user-images.githubusercontent.com/54764431/202815794-4b0e2f08-5e46-4235-9480-bdc3d9ff0410.jpeg)
