### PR TITLE
fix: #674 Added Loading and Disabled button while Creating Task Status/Size/Priority/Label to prevent double click

### DIFF
--- a/apps/web/lib/settings/task-labels-form.tsx
+++ b/apps/web/lib/settings/task-labels-form.tsx
@@ -55,6 +55,8 @@ export const TaskLabelForm = () => {
 		deleteTaskLabels,
 		createTaskLabels,
 		editTaskLabels,
+		createTaskLabelsLoading,
+		editTaskLabelsLoading,
 	} = useTaskLabels();
 
 	useEffect(() => {
@@ -181,6 +183,10 @@ export const TaskLabelForm = () => {
 											variant="primary"
 											className="font-normal py-4 px-4 rounded-xl text-md"
 											type="submit"
+											disabled={
+												createTaskLabelsLoading || editTaskLabelsLoading
+											}
+											loading={createTaskLabelsLoading || editTaskLabelsLoading}
 										>
 											{edit ? 'Save' : 'Create'}
 										</Button>

--- a/apps/web/lib/settings/task-priorities-form.tsx
+++ b/apps/web/lib/settings/task-priorities-form.tsx
@@ -56,6 +56,8 @@ export const TaskPrioritiesForm = () => {
 		deleteTaskPriorities,
 		createTaskPriorities,
 		editTaskPriorities,
+		createTaskPrioritiesLoading,
+		editTaskPrioritiesLoading,
 	} = useTaskPriorities();
 
 	useEffect(() => {
@@ -182,6 +184,12 @@ export const TaskPrioritiesForm = () => {
 											variant="primary"
 											className="font-normal py-4 px-4 rounded-xl text-md"
 											type="submit"
+											disabled={
+												createTaskPrioritiesLoading || editTaskPrioritiesLoading
+											}
+											loading={
+												createTaskPrioritiesLoading || editTaskPrioritiesLoading
+											}
 										>
 											{edit ? 'Save' : 'Create'}
 										</Button>

--- a/apps/web/lib/settings/task-sizes-form.tsx
+++ b/apps/web/lib/settings/task-sizes-form.tsx
@@ -56,6 +56,8 @@ export const TaskSizesForm = () => {
 		createTaskSizes,
 		deleteTaskSizes,
 		editTaskSizes,
+		createTaskSizesLoading,
+		editTaskSizesLoading,
 	} = useTaskSizes();
 
 	useEffect(() => {
@@ -182,6 +184,8 @@ export const TaskSizesForm = () => {
 											variant="primary"
 											className="font-normal py-4 px-4 rounded-xl text-md"
 											type="submit"
+											disabled={createTaskSizesLoading || editTaskSizesLoading}
+											loading={createTaskSizesLoading || editTaskSizesLoading}
 										>
 											{edit ? 'Save' : 'Create'}
 										</Button>

--- a/apps/web/lib/settings/task-statuses-form.tsx
+++ b/apps/web/lib/settings/task-statuses-form.tsx
@@ -55,6 +55,8 @@ export const TaskStatusesForm = () => {
 		createTaskStatus,
 		deleteTaskStatus,
 		editTaskStatus,
+		createTaskStatusLoading,
+		editTaskStatusLoading,
 	} = useTaskStatus();
 
 	useEffect(() => {
@@ -188,6 +190,10 @@ export const TaskStatusesForm = () => {
 											variant="primary"
 											className="font-normal py-4 px-4 rounded-xl text-md"
 											type="submit"
+											disabled={
+												createTaskStatusLoading || editTaskStatusLoading
+											}
+											loading={createTaskStatusLoading || editTaskStatusLoading}
 										>
 											{edit ? 'Save' : 'Create'}
 										</Button>


### PR DESCRIPTION
Fixed #674: `Custom/New Size upon creating occasionally clicked two times on button 'create' and the system created two similar sizes with different colors (should create only one size item per click on create button)`