### PR TITLE
fix: #674 Fixed automatic size change on priority/size/label selection

### DIFF
--- a/apps/web/lib/features/task/task-status.tsx
+++ b/apps/web/lib/features/task/task-status.tsx
@@ -77,7 +77,7 @@ export function useMapToTaskStatusValues<T extends ITaskStatusItemList>(
 				bgColor: item.color,
 				bordered,
 				icon: (
-					<div className="relative w-5 h-5">
+					<div className="relative w-5 h-4">
 						{item.fullIconUrl && (
 							<Image
 								layout="fill"
@@ -581,7 +581,6 @@ export function TaskStatus({
 	active = true,
 	issueType = 'status',
 	showIssueLabels,
-	forDetails,
 	bordered,
 }: PropsWithChildren<
 	TStatusItem &
@@ -595,10 +594,8 @@ export function TaskStatus({
 	return (
 		<div
 			className={clsxm(
-				'py-2 md:px-4 px-2 flex items-center text-sm space-x-3',
-				forDetails ? 'rounded-sm' : 'rounded-xl',
-
-				issueType === 'issue' && ['rounded-md px-2 text-white'],
+				'py-2 md:px-4 px-2 flex items-center text-sm space-x-3 rounded-xl',
+				issueType === 'issue' && ['px-2 text-white'],
 				active ? ['dark:text-default'] : ['bg-gray-200 dark:bg-gray-700'],
 				bordered && ['input-border'],
 				bordered &&


### PR DESCRIPTION
#674 - size of Status, Sizes, Priorities, Labels are getting bigger on User card once user selected items inside each (size should be no more than Title size)

<img width="1347" alt="image" src="https://user-images.githubusercontent.com/81486442/229019413-1230a15e-bf0f-41d2-9ab4-04aeb1a93d05.png">

![image](https://user-images.githubusercontent.com/81486442/229019461-aad49b84-c2d5-4c63-bf20-23abc80125ac.png)
