### PR TITLE
Feat/#508 sidebar time

### DIFF
--- a/apps/web/app/interfaces/ITimer.ts
+++ b/apps/web/app/interfaces/ITimer.ts
@@ -90,3 +90,8 @@ export interface ITasksTimesheet {
 	duration: number;
 	durationPercentage: number;
 }
+
+export interface ITime {
+	hours: number;
+	minutes: number;
+}

--- a/apps/web/app/interfaces/index.ts
+++ b/apps/web/app/interfaces/index.ts
@@ -29,3 +29,4 @@ export * from './IDay';
 export * from './INotify';
 export * from './ITheme';
 export * from './IRolePermissions';
+export * from './ITimer';

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -39,6 +39,7 @@ const TaskProgress = () => {
 		hours: 0,
 		minutes: 0,
 	});
+	const [numMembersToShow, setNumMembersToShow] = useState(5);
 
 	//const seconds = useRecoilValue(timerSecondsState);
 	//const { activeTaskTotalStat, addSeconds } = useTaskStatistics(seconds);
@@ -54,31 +55,6 @@ const TaskProgress = () => {
 
 	const memberInfo = useTeamMemberCard(currentUser);
 	// console.log(memberInfo.member?.duration);
-
-	/*const TotalWork = () => {
-		if (memberInfo.isAuthUser) {
-			const { h, m } = secondsToTime(
-				//returns empty array
-				((currentUser?.totalTodayTasks &&
-					currentUser?.totalTodayTasks.reduce(
-						(previousValue, currentValue) =>
-							previousValue + currentValue.duration,
-						0
-					)) ||
-					activeTaskTotalStat?.duration ||
-					0) + addSeconds
-			);
-			return (
-
-					<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
-						{h}h : {m}m
-					</div>
-
-			);
-		}
-	};*/
-
-	// console.log('task:', task);
 
 	useEffect(() => {
 		const userTotalTimeOnTask = () => {
@@ -145,20 +121,6 @@ const TaskProgress = () => {
 		setTimeRemaining({ hours: h, minutes: m });
 	}, [activeTeam?.members, task?.members, task?.id, task?.estimate]);
 
-	// useEffect(() => {
-	// 	if (task && task?.members) {
-	// 		const profiles = Array.isArray(task?.members) ? [...task.members] : [];
-
-	// 		if (profiles) {
-	// 			profiles.push(profiles[0]);
-	// 			profiles.push(profiles[0]);
-	// 			profiles.push(profiles[0]);
-	// 		}
-
-	// 		setDummyProfiles(profiles);
-	// 	}
-	// }, [task]);
-
 	return (
 		<section className="flex flex-col p-[15px]">
 			<TaskRow labelTitle={trans.PROGRESS} wrapperClassName="mb-3">
@@ -188,16 +150,35 @@ const TaskProgress = () => {
 								<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
 									{groupTotalTime.hours}h : {groupTotalTime.minutes}m
 								</div>
-								<ChevronUpIcon
-									className={clsx(
-										open ? 'rotate-180 transform' : '',
-										'h-5 w-5 text-[#292D32]'
-									)}
-								/>
+								{task?.members !== undefined && task?.members.length >= 1 && (
+									<ChevronUpIcon
+										className={clsx(
+											open ? 'rotate-180 transform' : '',
+											'h-5 w-5 text-[#292D32]'
+										)}
+									/>
+								)}
 							</Disclosure.Button>
-							<Disclosure.Panel>
-								<IndividualMembersTotalTime />
-							</Disclosure.Panel>
+							{task?.members !== undefined && task?.members.length >= 1 && (
+								<Disclosure.Panel>
+									<IndividualMembersTotalTime
+										numMembersToShow={numMembersToShow}
+									/>
+									{task?.members?.length !== undefined &&
+										task?.members?.length - 1 >= numMembersToShow && (
+											<div className="w-full flex justify-end my-1 text-[rgba(40,32,72,0.5)]">
+												<button
+													onClick={() =>
+														setNumMembersToShow((prev) => prev + 5)
+													}
+													className="text-xs"
+												>
+													Show More
+												</button>
+											</div>
+										)}
+								</Disclosure.Panel>
+							)}
 						</div>
 					)}
 				</Disclosure>
@@ -213,7 +194,7 @@ const TaskProgress = () => {
 
 export default TaskProgress;
 
-const IndividualMembersTotalTime = () => {
+const IndividualMembersTotalTime = ({ numMembersToShow }: any) => {
 	const [task] = useRecoilState(detailedTaskState);
 	const { activeTeam } = useOrganizationTeams();
 
@@ -227,7 +208,7 @@ const IndividualMembersTotalTime = () => {
 
 	return (
 		<>
-			{matchingMembers?.map((member) => {
+			{matchingMembers?.slice(0, numMembersToShow)?.map((member) => {
 				const taskDurationInSeconds = findUserTotalWorked(member, task?.id)
 					? findUserTotalWorked(member, task?.id)
 					: 0;

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -15,6 +15,13 @@ import {
 } from '@app/hooks';
 import { useTranslation } from 'lib/i18n';
 import { secondsToTime } from '@app/helpers';
+import { OT_Member } from '@app/interfaces';
+import { ITasksTimesheet } from '@app/interfaces/ITimer';
+
+interface ITime {
+	hours: number;
+	minutes: number;
+}
 
 const TaskProgress = () => {
 	const [task] = useRecoilState(detailedTaskState);
@@ -22,32 +29,35 @@ const TaskProgress = () => {
 	const { activeTeam } = useOrganizationTeams();
 	const { trans } = useTranslation('taskDetails');
 
-	const [userTotalTime, setUserTotalTime] = useState({ hours: 0, minutes: 0 });
-	const [userTotalTimeToday, setUserTotalTimeToday] = useState({
+	const [userTotalTime, setUserTotalTime] = useState<ITime>({
 		hours: 0,
 		minutes: 0,
 	});
-	const [timeRemaining, setTimeRemaining] = useState({
+	const [userTotalTimeToday, setUserTotalTimeToday] = useState<ITime>({
 		hours: 0,
 		minutes: 0,
 	});
-	const [groupTotalTime, setGroupTotalTime] = useState({
+	const [timeRemaining, setTimeRemaining] = useState<ITime>({
 		hours: 0,
 		minutes: 0,
 	});
-	const [numMembersToShow, setNumMembersToShow] = useState(5);
+	const [groupTotalTime, setGroupTotalTime] = useState<ITime>({
+		hours: 0,
+		minutes: 0,
+	});
+	const [numMembersToShow, setNumMembersToShow] = useState<number>(5);
 
 	const members = activeTeam?.members || [];
 
-	const currentUser = members.find((m) => {
+	const currentUser: OT_Member | undefined = members.find((m) => {
 		return m.employee.user?.id === user?.id;
 	});
 
 	const memberInfo = useTeamMemberCard(currentUser);
 
 	useEffect(() => {
-		const userTotalTimeOnTask = () => {
-			const totalOnTaskInSeconds =
+		const userTotalTimeOnTask = (): void => {
+			const totalOnTaskInSeconds: number =
 				currentUser?.totalWorkedTasks.find((object) => object.id === task?.id)
 					?.duration || 0;
 
@@ -59,8 +69,8 @@ const TaskProgress = () => {
 	}, [currentUser?.totalWorkedTasks, task?.id]);
 
 	useEffect(() => {
-		const userTotalTimeOnTaskToday = () => {
-			const totalOnTaskInSeconds =
+		const userTotalTimeOnTaskToday = (): void => {
+			const totalOnTaskInSeconds: number =
 				currentUser?.totalTodayTasks.find((object) => object.id === task?.id)
 					?.duration || 0;
 
@@ -72,21 +82,22 @@ const TaskProgress = () => {
 	}, [currentUser?.totalTodayTasks, task?.id]);
 
 	useEffect(() => {
-		const matchingMembers = activeTeam?.members.filter((member) =>
-			task?.members.some((taskMember) => taskMember.id === member.employeeId)
+		const matchingMembers: OT_Member[] | undefined = activeTeam?.members.filter(
+			(member) =>
+				task?.members.some((taskMember) => taskMember.id === member.employeeId)
 		);
 		console.log('matchingMembers:', matchingMembers);
 
-		const usersTaskArray = matchingMembers
+		const usersTaskArray: ITasksTimesheet[] | undefined = matchingMembers
 			?.flatMap((obj) => obj.totalWorkedTasks)
 			.filter((taskObj) => taskObj.id === task?.id);
 
-		const usersTotalTimeInSeconds = usersTaskArray?.reduce(
+		const usersTotalTimeInSeconds: number | undefined = usersTaskArray?.reduce(
 			(totalDuration, item) => totalDuration + item.duration,
 			0
 		);
 
-		const usersTotalTime =
+		const usersTotalTime: number =
 			usersTotalTimeInSeconds === null || usersTotalTimeInSeconds === undefined
 				? 0
 				: usersTotalTimeInSeconds;
@@ -95,7 +106,7 @@ const TaskProgress = () => {
 		const { h: hoursTotal, m: minutesTotal } = timeObj;
 		setGroupTotalTime({ hours: hoursTotal, minutes: minutesTotal });
 
-		const remainingTime =
+		const remainingTime: number =
 			task?.estimate === null ||
 			task?.estimate === 0 ||
 			task?.estimate === undefined ||
@@ -189,8 +200,9 @@ const IndividualMembersTotalTime = ({ numMembersToShow }: any) => {
 	const [task] = useRecoilState(detailedTaskState);
 	const { activeTeam } = useOrganizationTeams();
 
-	const matchingMembers = activeTeam?.members.filter((member) =>
-		task?.members.some((taskMember) => taskMember.id === member.employeeId)
+	const matchingMembers: OT_Member[] | undefined = activeTeam?.members.filter(
+		(member) =>
+			task?.members.some((taskMember) => taskMember.id === member.employeeId)
 	);
 
 	const findUserTotalWorked = (user: any, id: any) => {

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -192,7 +192,11 @@ const TaskProgress = () => {
 
 export default TaskProgress;
 
-const IndividualMembersTotalTime = ({ numMembersToShow }: any) => {
+const IndividualMembersTotalTime = ({
+	numMembersToShow,
+}: {
+	numMembersToShow: number;
+}) => {
 	const [task] = useRecoilState(detailedTaskState);
 	const { activeTeam } = useOrganizationTeams();
 
@@ -201,7 +205,7 @@ const IndividualMembersTotalTime = ({ numMembersToShow }: any) => {
 			task?.members.some((taskMember) => taskMember.id === member.employeeId)
 	);
 
-	const findUserTotalWorked = (user: any, id: any) => {
+	const findUserTotalWorked = (user: OT_Member, id: string | undefined) => {
 		return (
 			user?.totalWorkedTasks.find((task: any) => task?.id === id)?.duration || 0
 		);

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -97,6 +97,7 @@ const TaskProgress = () => {
 
 		const remainingTime =
 			task?.estimate === null ||
+			task?.estimate === 0 ||
 			task?.estimate === undefined ||
 			usersTotalTimeInSeconds === undefined
 				? 0

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -10,7 +10,7 @@ import clsx from 'clsx';
 import {
 	useAuthenticateUser,
 	useOrganizationTeams,
-	useTeamMemberCard,
+	// useTeamMemberCard,
 	//useTaskStatistics,
 } from '@app/hooks';
 import { useTranslation } from 'lib/i18n';
@@ -53,7 +53,7 @@ const TaskProgress = () => {
 		return m.employee.user?.id === user?.id;
 	});
 
-	const memberInfo = useTeamMemberCard(currentUser);
+	// const memberInfo = useTeamMemberCard(currentUser);
 
 	useEffect(() => {
 		const userTotalTimeOnTask = (): void => {
@@ -126,7 +126,7 @@ const TaskProgress = () => {
 					isAuthUser={true}
 					activeAuthTask={true}
 					showPercents={true}
-					memberInfo={memberInfo}
+					// memberInfo={memberInfo}
 				/>
 			</TaskRow>
 			<TaskRow labelTitle={trans.TOTAL_TIME} wrapperClassName="mb-3">

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -152,7 +152,7 @@ const TaskProgress = () => {
 									<ChevronUpIcon
 										className={clsx(
 											open ? 'rotate-180 transform' : '',
-											'h-5 w-5 text-[#292D32]'
+											'h-5 w-5 text-[#292D32] dark:text-white'
 										)}
 									/>
 								</Disclosure.Button>

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -31,6 +31,10 @@ const TaskProgress = () => {
 		hours: 0,
 		minutes: 0,
 	});
+	const [timeRemaining, setTimeRemaining] = useState({
+		hours: 0,
+		minutes: 0,
+	});
 
 	//const seconds = useRecoilValue(timerSecondsState);
 	//const { activeTaskTotalStat, addSeconds } = useTaskStatistics(seconds);
@@ -40,7 +44,9 @@ const TaskProgress = () => {
 	const currentUser = members.find((m) => {
 		return m.employee.user?.id === user?.id;
 	});
-	console.log(currentUser);
+	// console.log(currentUser);
+
+	// console.log('active:', activeTeam?.members);
 
 	const memberInfo = useTeamMemberCard(currentUser);
 	// console.log(memberInfo.member?.duration);
@@ -68,7 +74,7 @@ const TaskProgress = () => {
 		}
 	};*/
 
-	console.log('task:', task?.id);
+	// console.log('task:', task?.id);
 
 	useEffect(() => {
 		const userTotalTimeOnTask = () => {
@@ -95,6 +101,27 @@ const TaskProgress = () => {
 		};
 		userTotalTimeOnTaskToday();
 	}, [currentUser?.totalTodayTasks, task?.id]);
+
+	useEffect(() => {
+		const matchingMembers = activeTeam?.members.filter((member) =>
+			task?.members.some((taskMember) => taskMember.id === member.employeeId)
+		);
+		// console.log('matchingMembers:', matchingMembers);
+		const usersTotalTime = matchingMembers
+			?.flatMap((obj) => obj.totalWorkedTasks)
+			.filter((taskObj) => taskObj.id === task?.id)
+			.reduce((totalDuration, item) => totalDuration + item.duration, 0);
+		console.log('all duration:', usersTotalTime);
+
+		const remainingTime =
+			task?.estimate === null ||
+			task?.estimate === undefined ||
+			usersTotalTime === undefined
+				? 0
+				: task?.estimate - usersTotalTime;
+		const { h, m } = secondsToTime(remainingTime);
+		setTimeRemaining({ hours: h, minutes: m });
+	}, [activeTeam?.members, task?.members, task?.id, task?.estimate]);
 
 	useEffect(() => {
 		if (task && task?.members) {
@@ -163,7 +190,7 @@ const TaskProgress = () => {
 			</TaskRow>
 			<TaskRow labelTitle={trans.TIME_REMAINING}>
 				<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
-					2h : 12m
+					{timeRemaining.hours}h : {timeRemaining.minutes}m
 				</div>
 			</TaskRow>
 		</section>

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -146,7 +146,7 @@ const TaskProgress = () => {
 				<Disclosure>
 					{({ open }) => (
 						<div className="flex flex-col w-full">
-							{task?.members !== undefined && task?.members.length > 1 ? (
+							{task?.members && task?.members.length > 1 ? (
 								<Disclosure.Button className="flex justify-between items-center w-full">
 									<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
 										{groupTotalTime.hours}h : {groupTotalTime.minutes}m
@@ -164,12 +164,12 @@ const TaskProgress = () => {
 									{groupTotalTime.hours}h : {groupTotalTime.minutes}m
 								</div>
 							)}
-							{task?.members !== undefined && task?.members.length > 1 && (
+							{task?.members && task?.members.length && (
 								<Disclosure.Panel>
 									<IndividualMembersTotalTime
 										numMembersToShow={numMembersToShow}
 									/>
-									{task?.members?.length !== undefined &&
+									{task?.members?.length &&
 										task?.members?.length - 1 >= numMembersToShow && (
 											<div className="w-full flex justify-end my-1 text-[rgba(40,32,72,0.5)]">
 												<button

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -127,7 +127,7 @@ const TaskProgress = () => {
 			</TaskRow>
 			<TaskRow labelTitle={trans.TOTAL_TIME} wrapperClassName="mb-3">
 				<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
-					{userTotalTime.hours}h : {userTotalTime?.minutes}m
+					{userTotalTime.hours}h : {userTotalTime.minutes}m
 				</div>
 			</TaskRow>
 			<TaskRow labelTitle={trans.TIME_TODAY} wrapperClassName="mb-3">
@@ -157,12 +157,12 @@ const TaskProgress = () => {
 									{groupTotalTime.hours}h : {groupTotalTime.minutes}m
 								</div>
 							)}
-							{task?.members && task?.members.length && (
+							{task?.members && task?.members.length > 0 && (
 								<Disclosure.Panel>
 									<IndividualMembersTotalTime
 										numMembersToShow={numMembersToShow}
 									/>
-									{task?.members?.length &&
+									{task?.members?.length > 0 &&
 										task?.members?.length - 1 >= numMembersToShow && (
 											<div className="w-full flex justify-end my-1 text-[rgba(40,32,72,0.5)]">
 												<button
@@ -202,15 +202,15 @@ const IndividualMembersTotalTime = ({ numMembersToShow }: any) => {
 	);
 
 	const findUserTotalWorked = (user: any, id: any) => {
-		return user.totalWorkedTasks.find((task: any) => task.id === id)?.duration;
+		return (
+			user?.totalWorkedTasks.find((task: any) => task?.id === id)?.duration || 0
+		);
 	};
 
 	return (
 		<>
 			{matchingMembers?.slice(0, numMembersToShow)?.map((member) => {
-				const taskDurationInSeconds = findUserTotalWorked(member, task?.id)
-					? findUserTotalWorked(member, task?.id)
-					: 0;
+				const taskDurationInSeconds = findUserTotalWorked(member, task?.id);
 
 				const { h, m } = secondsToTime(taskDurationInSeconds);
 
@@ -220,8 +220,8 @@ const IndividualMembersTotalTime = ({ numMembersToShow }: any) => {
 					<div key={member.id} className="mt-2.5">
 						<ProfileInfoWithTime
 							key={member.id}
-							profilePicSrc={member?.employee.user?.imageUrl}
-							names={member.employee?.fullName}
+							profilePicSrc={member.employee.user?.imageUrl}
+							names={member.employee.fullName}
 							time={time}
 						/>
 					</div>

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -16,12 +16,7 @@ import {
 import { useTranslation } from 'lib/i18n';
 import { secondsToTime } from '@app/helpers';
 import { OT_Member } from '@app/interfaces';
-import { ITasksTimesheet } from '@app/interfaces/ITimer';
-
-interface ITime {
-	hours: number;
-	minutes: number;
-}
+import { ITasksTimesheet, ITime } from '@app/interfaces';
 
 const TaskProgress = () => {
 	const [task] = useRecoilState(detailedTaskState);
@@ -86,7 +81,6 @@ const TaskProgress = () => {
 			(member) =>
 				task?.members.some((taskMember) => taskMember.id === member.employeeId)
 		);
-		console.log('matchingMembers:', matchingMembers);
 
 		const usersTaskArray: ITasksTimesheet[] | undefined = matchingMembers
 			?.flatMap((obj) => obj.totalWorkedTasks)

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -15,7 +15,7 @@ import {
 	//useTaskStatistics,
 } from '@app/hooks';
 import { useTranslation } from 'lib/i18n';
-//import { secondsToTime } from '@app/helpers';
+import { secondsToTime } from '@app/helpers';
 //import { useRecoilValue } from 'recoil';
 //import { timerSecondsState } from '@app/stores';
 
@@ -26,6 +26,8 @@ const TaskProgress = () => {
 	const { activeTeam } = useOrganizationTeams();
 	const { trans } = useTranslation('taskDetails');
 
+	const [userTotalTime, setUserTotalTime] = useState({ hours: 0, minutes: 0 });
+
 	//const seconds = useRecoilValue(timerSecondsState);
 	//const { activeTaskTotalStat, addSeconds } = useTaskStatistics(seconds);
 
@@ -34,8 +36,10 @@ const TaskProgress = () => {
 	const currentUser = members.find((m) => {
 		return m.employee.user?.id === user?.id;
 	});
+	console.log(currentUser);
 
 	const memberInfo = useTeamMemberCard(currentUser);
+	// console.log(memberInfo.member?.duration);
 
 	/*const TotalWork = () => {
 		if (memberInfo.isAuthUser) {
@@ -59,6 +63,21 @@ const TaskProgress = () => {
 			);
 		}
 	};*/
+
+	console.log('task:', task?.id);
+
+	useEffect(() => {
+		const userTotalTimeOnTask = () => {
+			const totalOnTaskInSeconds =
+				currentUser?.totalWorkedTasks.find((object) => object.id === task?.id)
+					?.duration || 0;
+
+			const { h, m } = secondsToTime(totalOnTaskInSeconds);
+
+			setUserTotalTime({ hours: h, minutes: m });
+		};
+		userTotalTimeOnTask();
+	}, [currentUser?.totalWorkedTasks, task?.id]);
 
 	useEffect(() => {
 		if (task && task?.members) {
@@ -87,7 +106,7 @@ const TaskProgress = () => {
 			</TaskRow>
 			<TaskRow labelTitle={trans.TOTAL_TIME} wrapperClassName="mb-3">
 				<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
-					2h : 12m
+					{userTotalTime.hours}h : {userTotalTime?.minutes}m
 				</div>
 			</TaskRow>
 			<TaskRow labelTitle={trans.TIME_TODAY} wrapperClassName="mb-3">

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -49,18 +49,19 @@ const TaskProgress = () => {
 
 	// const memberInfo = useTeamMemberCard(currentUser);
 
-	useEffect(() => {
-		const userTotalTimeOnTask = (): void => {
-			const totalOnTaskInSeconds: number =
-				currentUser?.totalWorkedTasks.find((object) => object.id === task?.id)
-					?.duration || 0;
+	const userTotalTimeOnTask = useCallback((): void => {
+		const totalOnTaskInSeconds: number =
+			currentUser?.totalWorkedTasks.find((object) => object.id === task?.id)
+				?.duration || 0;
 
-			const { h, m } = secondsToTime(totalOnTaskInSeconds);
+		const { h, m } = secondsToTime(totalOnTaskInSeconds);
 
-			setUserTotalTime({ hours: h, minutes: m });
-		};
-		userTotalTimeOnTask();
+		setUserTotalTime({ hours: h, minutes: m });
 	}, [currentUser?.totalWorkedTasks, task?.id]);
+
+	useEffect(() => {
+		userTotalTimeOnTask();
+	}, [userTotalTimeOnTask]);
 
 	const userTotalTimeOnTaskToday = useCallback((): void => {
 		const totalOnTaskInSeconds: number =

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -3,7 +3,7 @@ import { TaskProgressBar } from 'lib/features';
 import { useRecoilState } from 'recoil';
 import TaskRow from '../components/task-row';
 import { Disclosure } from '@headlessui/react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import ProfileInfoWithTime from '../components/profile-info-with-time';
 import { ChevronUpIcon } from '@heroicons/react/20/solid';
 import clsx from 'clsx';
@@ -62,18 +62,19 @@ const TaskProgress = () => {
 		userTotalTimeOnTask();
 	}, [currentUser?.totalWorkedTasks, task?.id]);
 
-	useEffect(() => {
-		const userTotalTimeOnTaskToday = (): void => {
-			const totalOnTaskInSeconds: number =
-				currentUser?.totalTodayTasks.find((object) => object.id === task?.id)
-					?.duration || 0;
+	const userTotalTimeOnTaskToday = useCallback((): void => {
+		const totalOnTaskInSeconds: number =
+			currentUser?.totalTodayTasks.find((object) => object.id === task?.id)
+				?.duration || 0;
 
-			const { h, m } = secondsToTime(totalOnTaskInSeconds);
+		const { h, m } = secondsToTime(totalOnTaskInSeconds);
 
-			setUserTotalTimeToday({ hours: h, minutes: m });
-		};
-		userTotalTimeOnTaskToday();
+		setUserTotalTimeToday({ hours: h, minutes: m });
 	}, [currentUser?.totalTodayTasks, task?.id]);
+
+	useEffect(() => {
+		userTotalTimeOnTaskToday();
+	}, [userTotalTimeOnTaskToday]);
 
 	useEffect(() => {
 		const matchingMembers: OT_Member[] | undefined = activeTeam?.members.filter(

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -116,6 +116,9 @@ const TaskProgress = () => {
 
 		const { h, m } = secondsToTime(remainingTime);
 		setTimeRemaining({ hours: h, minutes: m });
+		if (remainingTime <= 0) {
+			setTimeRemaining({ hours: 0, minutes: 0 });
+		}
 	}, [activeTeam?.members, task?.members, task?.id, task?.estimate]);
 
 	return (

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -15,8 +15,7 @@ import {
 } from '@app/hooks';
 import { useTranslation } from 'lib/i18n';
 import { secondsToTime } from '@app/helpers';
-import { OT_Member } from '@app/interfaces';
-import { ITasksTimesheet, ITime } from '@app/interfaces';
+import { ITasksTimesheet, ITime, OT_Member } from '@app/interfaces';
 
 const TaskProgress = () => {
 	const [task] = useRecoilState(detailedTaskState);

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -5,7 +5,6 @@ import TaskRow from '../components/task-row';
 import { Disclosure } from '@headlessui/react';
 import { useEffect, useState } from 'react';
 import ProfileInfoWithTime from '../components/profile-info-with-time';
-// import { IEmployee } from '@app/interfaces';
 import { ChevronUpIcon } from '@heroicons/react/20/solid';
 import clsx from 'clsx';
 import {
@@ -16,12 +15,9 @@ import {
 } from '@app/hooks';
 import { useTranslation } from 'lib/i18n';
 import { secondsToTime } from '@app/helpers';
-//import { useRecoilValue } from 'recoil';
-//import { timerSecondsState } from '@app/stores';
 
 const TaskProgress = () => {
 	const [task] = useRecoilState(detailedTaskState);
-	// const [dummyProfiles, setDummyProfiles] = useState<IEmployee[]>([]);
 	const { user } = useAuthenticateUser();
 	const { activeTeam } = useOrganizationTeams();
 	const { trans } = useTranslation('taskDetails');
@@ -41,20 +37,13 @@ const TaskProgress = () => {
 	});
 	const [numMembersToShow, setNumMembersToShow] = useState(5);
 
-	//const seconds = useRecoilValue(timerSecondsState);
-	//const { activeTaskTotalStat, addSeconds } = useTaskStatistics(seconds);
-
 	const members = activeTeam?.members || [];
 
 	const currentUser = members.find((m) => {
 		return m.employee.user?.id === user?.id;
 	});
-	// console.log(currentUser);
-
-	// console.log('active:', activeTeam?.members);
 
 	const memberInfo = useTeamMemberCard(currentUser);
-	// console.log(memberInfo.member?.duration);
 
 	useEffect(() => {
 		const userTotalTimeOnTask = () => {
@@ -92,14 +81,10 @@ const TaskProgress = () => {
 			?.flatMap((obj) => obj.totalWorkedTasks)
 			.filter((taskObj) => taskObj.id === task?.id);
 
-		// console.log(usersTaskArray);
-
 		const usersTotalTimeInSeconds = usersTaskArray?.reduce(
 			(totalDuration, item) => totalDuration + item.duration,
 			0
 		);
-
-		// console.log('all duration:', usersTotalTimeInSeconds);
 
 		const usersTotalTime =
 			usersTotalTimeInSeconds === null || usersTotalTimeInSeconds === undefined
@@ -146,20 +131,25 @@ const TaskProgress = () => {
 				<Disclosure>
 					{({ open }) => (
 						<div className="flex flex-col w-full">
-							<Disclosure.Button className="flex justify-between items-center w-full">
-								<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
-									{groupTotalTime.hours}h : {groupTotalTime.minutes}m
-								</div>
-								{task?.members !== undefined && task?.members.length >= 1 && (
+							{task?.members !== undefined && task?.members.length > 1 ? (
+								<Disclosure.Button className="flex justify-between items-center w-full">
+									<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
+										{groupTotalTime.hours}h : {groupTotalTime.minutes}m
+									</div>
+
 									<ChevronUpIcon
 										className={clsx(
 											open ? 'rotate-180 transform' : '',
 											'h-5 w-5 text-[#292D32]'
 										)}
 									/>
-								)}
-							</Disclosure.Button>
-							{task?.members !== undefined && task?.members.length >= 1 && (
+								</Disclosure.Button>
+							) : (
+								<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
+									{groupTotalTime.hours}h : {groupTotalTime.minutes}m
+								</div>
+							)}
+							{task?.members !== undefined && task?.members.length > 1 && (
 								<Disclosure.Panel>
 									<IndividualMembersTotalTime
 										numMembersToShow={numMembersToShow}

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -27,6 +27,10 @@ const TaskProgress = () => {
 	const { trans } = useTranslation('taskDetails');
 
 	const [userTotalTime, setUserTotalTime] = useState({ hours: 0, minutes: 0 });
+	const [userTotalTimeToday, setUserTotalTimeToday] = useState({
+		hours: 0,
+		minutes: 0,
+	});
 
 	//const seconds = useRecoilValue(timerSecondsState);
 	//const { activeTaskTotalStat, addSeconds } = useTaskStatistics(seconds);
@@ -80,6 +84,19 @@ const TaskProgress = () => {
 	}, [currentUser?.totalWorkedTasks, task?.id]);
 
 	useEffect(() => {
+		const userTotalTimeOnTaskToday = () => {
+			const totalOnTaskInSeconds =
+				currentUser?.totalTodayTasks.find((object) => object.id === task?.id)
+					?.duration || 0;
+
+			const { h, m } = secondsToTime(totalOnTaskInSeconds);
+
+			setUserTotalTimeToday({ hours: h, minutes: m });
+		};
+		userTotalTimeOnTaskToday();
+	}, [currentUser?.totalTodayTasks, task?.id]);
+
+	useEffect(() => {
 		if (task && task?.members) {
 			const profiles = Array.isArray(task?.members) ? [...task.members] : [];
 
@@ -111,7 +128,7 @@ const TaskProgress = () => {
 			</TaskRow>
 			<TaskRow labelTitle={trans.TIME_TODAY} wrapperClassName="mb-3">
 				<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
-					1h : 10m
+					{userTotalTimeToday.hours}h : {userTotalTimeToday.minutes}m
 				</div>
 			</TaskRow>
 			<TaskRow labelTitle={trans.TOTAL_GROUP_TIME} wrapperClassName="mb-3">

--- a/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-progress.tsx
@@ -35,6 +35,10 @@ const TaskProgress = () => {
 		hours: 0,
 		minutes: 0,
 	});
+	const [groupTotalTime, setGroupTotalTime] = useState({
+		hours: 0,
+		minutes: 0,
+	});
 
 	//const seconds = useRecoilValue(timerSecondsState);
 	//const { activeTaskTotalStat, addSeconds } = useTaskStatistics(seconds);
@@ -107,18 +111,28 @@ const TaskProgress = () => {
 			task?.members.some((taskMember) => taskMember.id === member.employeeId)
 		);
 		// console.log('matchingMembers:', matchingMembers);
-		const usersTotalTime = matchingMembers
+		const usersTotalTimeInSeconds = matchingMembers
 			?.flatMap((obj) => obj.totalWorkedTasks)
 			.filter((taskObj) => taskObj.id === task?.id)
 			.reduce((totalDuration, item) => totalDuration + item.duration, 0);
-		console.log('all duration:', usersTotalTime);
+		console.log('all duration:', usersTotalTimeInSeconds);
+
+		const usersTotalTime =
+			usersTotalTimeInSeconds === null || usersTotalTimeInSeconds === undefined
+				? 0
+				: usersTotalTimeInSeconds;
+
+		const timeObj = secondsToTime(usersTotalTime);
+		const { h: hoursTotal, m: minutesTotal } = timeObj;
+		setGroupTotalTime({ hours: hoursTotal, minutes: minutesTotal });
 
 		const remainingTime =
 			task?.estimate === null ||
 			task?.estimate === undefined ||
-			usersTotalTime === undefined
+			usersTotalTimeInSeconds === undefined
 				? 0
-				: task?.estimate - usersTotalTime;
+				: task?.estimate - usersTotalTimeInSeconds;
+
 		const { h, m } = secondsToTime(remainingTime);
 		setTimeRemaining({ hours: h, minutes: m });
 	}, [activeTeam?.members, task?.members, task?.id, task?.estimate]);
@@ -164,7 +178,7 @@ const TaskProgress = () => {
 						<div className="flex flex-col w-full">
 							<Disclosure.Button className="flex justify-between items-center w-full">
 								<div className="not-italic font-semibold text-xs leading-[140%] tracking-[-0.02em] text-[#282048] dark:text-white">
-									9h : 11m
+									{groupTotalTime.hours}h : {groupTotalTime.minutes}m
 								</div>
 								<ChevronUpIcon
 									className={clsx(

--- a/apps/web/lib/features/task/task-progress-bar.tsx
+++ b/apps/web/lib/features/task/task-progress-bar.tsx
@@ -13,8 +13,8 @@ export function TaskProgressBar({
 	task,
 	activeAuthTask,
 	showPercents,
-	memberInfo,
-}: {
+}: // memberInfo,
+{
 	isAuthUser: boolean | undefined;
 	task: Nullable<ITeamTask>;
 	activeAuthTask: boolean;
@@ -27,9 +27,10 @@ export function TaskProgressBar({
 	);
 
 	const { activeTeam } = useOrganizationTeams();
-	const currentMember = activeTeam?.members.find(
-		(member) => member.id === memberInfo?.member?.id
-	);
+	//removed as when certain task's timer was active it was affecting the timers with no estimations. Was taking user's previous task's estimation
+	// const currentMember = activeTeam?.members.find(
+	// 	(member) => member.id === memberInfo?.member?.id
+	// );
 	let totalWorkedTasksTimer = 0;
 	activeTeam?.members?.forEach((member) => {
 		const totalWorkedTasks =
@@ -43,7 +44,7 @@ export function TaskProgressBar({
 		null,
 		task,
 		/*addSeconds || */ totalWorkedTasksTimer || 0,
-		task?.estimate || currentMember?.lastWorkedTask?.estimate || 0
+		task?.estimate || 0 //<-- task?.estimate || currentMember?.lastWorkedTask?.estimate || 0 - removed as when certain task's timer was active it was affecting the timers with no estimations. Was taking user's previous task's estimation
 	);
 
 	return (


### PR DESCRIPTION
Added functionality to the task sidebar progress section

- Fixed progressbar bug, When task with estimation was running, and we enter another task without estimation's page, the another task was showing previous task's estimation in progress bar
- Displayed current user work time
- Displayed current user work time for the day on task
- Total group time
- When dropdown clicked shows each member how much time worked on task(if task's member count is less than 2 the dropdown is not rendered)
- Added Show More button. Initially 5 members are rendered in dropdown, if there are more Show Button renders, and once pressed renders 5 more members
- Time remaining, shows estimate time minus the total worked time

For DEMONSTRATION purpose in the video one member is rendered each time when Show More is pressed. Normally 5 members will be rendered
https://github.com/ever-co/ever-teams/assets/124465103/80dfa027-5058-42f4-9990-ec473fc566a5

