### PR TITLE
fixed task sidebar creator showing null if user has no firstname

### DIFF
--- a/apps/web/components/pages/task/details-section/blocks/task-main-info.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-main-info.tsx
@@ -48,7 +48,7 @@ const TaskMainInfo = () => {
 				{task?.creator && (
 					<ProfileInfo
 						profilePicSrc={task?.creator?.imageUrl}
-						names={`${task?.creator?.firstName} ${
+						names={`${task?.creator?.firstName || ''} ${
 							task?.creator?.lastName || ''
 						}`}
 					/>


### PR DESCRIPTION
When task creator's first name wasn't set(was null) in task description sidebar it was showing "null LastName". Fixed that


https://github.com/ever-co/ever-teams/assets/124465103/988afc31-76cc-480c-81c1-a33f708ef34a

