### PR TITLE
Bug/task description responsiveness

### DIFF
--- a/apps/web/components/pages/task/description-block/editor-components/BlockButton.tsx
+++ b/apps/web/components/pages/task/description-block/editor-components/BlockButton.tsx
@@ -8,7 +8,6 @@ interface IMarkButtonProps {
 	icon: React.ComponentType;
 	isBlockActive: (editor: any, format: any, blockType?: string) => boolean;
 	className?: string;
-	visibleOnLargeScreenOnly?: boolean;
 }
 
 const TEXT_ALIGN_TYPES = ['left', 'center', 'right', 'justify'];
@@ -19,7 +18,6 @@ const BlockButton = ({
 	icon: Icon,
 	isBlockActive,
 	className,
-	visibleOnLargeScreenOnly = false,
 }: IMarkButtonProps) => {
 	const editor = useSlate();
 
@@ -27,24 +25,15 @@ const BlockButton = ({
 		<button
 			className={clsxm(
 				className,
-				'my-1',
-				visibleOnLargeScreenOnly ? 'hidden md:block' : ''
-			)}
-			style={{
-				background: isBlockActive(
+				'my-1 rounded-md transition duration-300 p-[2px]',
+				isBlockActive(
 					editor,
 					format,
 					TEXT_ALIGN_TYPES.includes(format) ? 'align' : 'type'
 				)
-					? '#ddd'
-					: 'transparent',
-				borderRadius: '5px',
-				padding: '2px',
-				// display: 'flex',
-				// alignItems: 'center',
-				// justifyContent: 'center',
-				transition: '0.3s',
-			}}
+					? 'dark:bg-[#6a6a6a] bg-[#ddd]'
+					: 'bg-transparent'
+			)}
 			onMouseDown={(event) => {
 				event.preventDefault();
 				TextEditorService.toggleBlock(

--- a/apps/web/components/pages/task/description-block/editor-components/BlockButton.tsx
+++ b/apps/web/components/pages/task/description-block/editor-components/BlockButton.tsx
@@ -1,6 +1,6 @@
 import { clsxm } from '@app/utils';
 import { TextEditorService } from './TextEditorService';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSlate } from 'slate-react';
 
 interface IMarkButtonProps {
@@ -21,16 +21,25 @@ const BlockButton = ({
 }: IMarkButtonProps) => {
 	const editor = useSlate();
 
+	const isBlockActiveMemo = useMemo(() => {
+		return (
+			isBlockActive &&
+			((format: string) => {
+				return isBlockActive(
+					editor,
+					format,
+					TEXT_ALIGN_TYPES.includes(format) ? 'align' : 'type'
+				);
+			})
+		);
+	}, [editor, isBlockActive]);
+
 	return (
 		<button
 			className={clsxm(
 				className,
 				'my-1 rounded-md transition duration-300 p-[2px]',
-				isBlockActive(
-					editor,
-					format,
-					TEXT_ALIGN_TYPES.includes(format) ? 'align' : 'type'
-				)
+				isBlockActiveMemo(format)
 					? 'dark:bg-[#6a6a6a] bg-[#ddd]'
 					: 'bg-transparent'
 			)}

--- a/apps/web/components/pages/task/description-block/editor-components/BlockButton.tsx
+++ b/apps/web/components/pages/task/description-block/editor-components/BlockButton.tsx
@@ -1,3 +1,4 @@
+import { clsxm } from '@app/utils';
 import { TextEditorService } from './TextEditorService';
 import React from 'react';
 import { useSlate } from 'slate-react';
@@ -6,6 +7,8 @@ interface IMarkButtonProps {
 	format: string;
 	icon: React.ComponentType;
 	isBlockActive: (editor: any, format: any, blockType?: string) => boolean;
+	className?: string;
+	visibleOnLargeScreenOnly?: boolean;
 }
 
 const TEXT_ALIGN_TYPES = ['left', 'center', 'right', 'justify'];
@@ -15,12 +18,18 @@ const BlockButton = ({
 	format,
 	icon: Icon,
 	isBlockActive,
+	className,
+	visibleOnLargeScreenOnly = false,
 }: IMarkButtonProps) => {
 	const editor = useSlate();
 
 	return (
 		<button
-			className="my-1"
+			className={clsxm(
+				className,
+				'my-1',
+				visibleOnLargeScreenOnly ? 'hidden md:block' : ''
+			)}
 			style={{
 				background: isBlockActive(
 					editor,
@@ -31,9 +40,9 @@ const BlockButton = ({
 					: 'transparent',
 				borderRadius: '5px',
 				padding: '2px',
-				display: 'flex',
-				alignItems: 'center',
-				justifyContent: 'center',
+				// display: 'flex',
+				// alignItems: 'center',
+				// justifyContent: 'center',
 				transition: '0.3s',
 			}}
 			onMouseDown={(event) => {

--- a/apps/web/components/pages/task/description-block/editor-components/MarkButton.tsx
+++ b/apps/web/components/pages/task/description-block/editor-components/MarkButton.tsx
@@ -20,9 +20,10 @@ const MarkButton = ({ format, icon: Icon, isMarkActive }: IMarkButtonProps) => {
 				border: 'none',
 				borderRadius: '5px',
 				transition: '0.3s',
-				display: 'flex',
-				alignItems: 'center',
-				justifyContent: 'center',
+				padding: '2px',
+				// display: 'flex',
+				// alignItems: 'center',
+				// justifyContent: 'center',
 			}}
 			onMouseDown={(event) => {
 				event.preventDefault();

--- a/apps/web/components/pages/task/description-block/editor-toolbar.tsx
+++ b/apps/web/components/pages/task/description-block/editor-toolbar.tsx
@@ -25,6 +25,7 @@ import {
 	QuoteBlockIcon,
 	ExternalLinkIcon,
 	CheckBoxIcon,
+	ArrowDown,
 } from 'lib/components/svgs';
 import { useTranslation } from 'lib/i18n';
 import { useSlateStatic } from 'slate-react';
@@ -201,6 +202,7 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 			<p className="flex-1 text-lg font-[500] dark:text-white my-1 hidden md:block">
 				{trans.DESCRIPTION}
 			</p>
+
 			<MarkButton
 				format="bold"
 				icon={BoldIcon}
@@ -224,6 +226,7 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 			/>
 
 			<BlockButton
+				className="hidden md:block"
 				format="h1"
 				icon={HeaderOneIcon}
 				isBlockActive={
@@ -235,6 +238,7 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 				}
 			/>
 			<BlockButton
+				className="hidden md:block"
 				format="h2"
 				icon={HeaderTwoIcon}
 				isBlockActive={
@@ -257,6 +261,7 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 				}
 			/>
 			<BlockButton
+				className="hidden md:block"
 				format="ol"
 				icon={OrderedListIcon}
 				isBlockActive={
@@ -268,6 +273,7 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 				}
 			/>
 			<BlockButton
+				className="hidden md:block"
 				format="ul"
 				icon={UnorderedListIcon}
 				isBlockActive={
@@ -278,12 +284,64 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 					) => boolean
 				}
 			/>
+
+			<BlockButton
+				className="hidden md:block"
+				format="left"
+				icon={AlignLeftIcon}
+				isBlockActive={
+					isBlockActive as (
+						editor: any,
+						format: any,
+						blockType?: string | undefined
+					) => boolean
+				}
+			/>
+			<BlockButton
+				className="hidden md:block"
+				format="center"
+				icon={AlignCenterIcon}
+				isBlockActive={
+					isBlockActive as (
+						editor: any,
+						format: any,
+						blockType?: string | undefined
+					) => boolean
+				}
+			/>
+			<BlockButton
+				className="hidden md:block"
+				format="right"
+				icon={AlignRightIcon}
+				isBlockActive={
+					isBlockActive as (
+						editor: any,
+						format: any,
+						blockType?: string | undefined
+					) => boolean
+				}
+			/>
+			<BlockButton
+				className="hidden md:block"
+				format="justify"
+				icon={AlignJustifyIcon}
+				isBlockActive={
+					isBlockActive as (
+						editor: any,
+						format: any,
+						blockType?: string | undefined
+					) => boolean
+				}
+			/>
 			<div className="relative md:hidden">
 				<button
-					className="flex items-center gap-2 px-2 py-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded focus:outline-none"
+					className="flex items-center gap-2 px-2 py-1 bg-transparent dark:bg-gray-800 rounded focus:outline-none"
 					onClick={() => setShowDropdown((prev) => !prev)}
 				>
-					<span>Select</span>
+					<span className="flex items-center gap-1">
+						More
+						<ArrowDown className={`${showDropdown && 'rotate-180'}`} />
+					</span>
 				</button>
 				{showDropdown && (
 					<div className="absolute top-full left-0 z-10 w-40 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded shadow">
@@ -318,58 +376,6 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 					</div>
 				)}
 			</div>
-			<BlockButton
-				visibleOnLargeScreenOnly
-				className="hidden md:block"
-				format="left"
-				icon={AlignLeftIcon}
-				isBlockActive={
-					isBlockActive as (
-						editor: any,
-						format: any,
-						blockType?: string | undefined
-					) => boolean
-				}
-			/>
-			<BlockButton
-				visibleOnLargeScreenOnly
-				className="hidden md:block"
-				format="center"
-				icon={AlignCenterIcon}
-				isBlockActive={
-					isBlockActive as (
-						editor: any,
-						format: any,
-						blockType?: string | undefined
-					) => boolean
-				}
-			/>
-			<BlockButton
-				visibleOnLargeScreenOnly
-				className="hidden md:block"
-				format="right"
-				icon={AlignRightIcon}
-				isBlockActive={
-					isBlockActive as (
-						editor: any,
-						format: any,
-						blockType?: string | undefined
-					) => boolean
-				}
-			/>
-			<BlockButton
-				visibleOnLargeScreenOnly
-				className="hidden md:block"
-				format="justify"
-				icon={AlignJustifyIcon}
-				isBlockActive={
-					isBlockActive as (
-						editor: any,
-						format: any,
-						blockType?: string | undefined
-					) => boolean
-				}
-			/>
 			<BlockButton
 				format="checklist"
 				icon={CheckBoxIcon}
@@ -433,6 +439,8 @@ export default Toolbar;
 const blockOptions = [
 	{ format: 'h1', icon: HeaderOneIcon, label: 'Heading 1' },
 	{ format: 'h2', icon: HeaderTwoIcon, label: 'Heading 2' },
+	{ format: 'ol', icon: OrderedListIcon, label: 'Ordered List' },
+	{ format: 'ul', icon: UnorderedListIcon, label: 'Unordered List' },
 	{ format: 'left', icon: AlignLeftIcon, label: 'Align Left' },
 	{ format: 'center', icon: AlignCenterIcon, label: 'Align Center' },
 	{ format: 'right', icon: AlignRightIcon, label: 'Align Right' },

--- a/apps/web/components/pages/task/description-block/editor-toolbar.tsx
+++ b/apps/web/components/pages/task/description-block/editor-toolbar.tsx
@@ -1,6 +1,6 @@
 import BlockButton from './editor-components/BlockButton';
 import MarkButton from './editor-components/MarkButton';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import {
 	insertLink,
 	TextEditorService,
@@ -152,6 +152,19 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 			document.removeEventListener('click', onClickOutsideOfDropdown);
 		};
 	}, []);
+
+	const isBlockActiveMemo = useMemo(() => {
+		return (
+			isBlockActive &&
+			((format: string) => {
+				return isBlockActive(
+					editor,
+					format,
+					TEXT_ALIGN_TYPES.includes(format) ? 'align' : 'type'
+				);
+			})
+		);
+	}, [editor, isBlockActive]);
 
 	return (
 		<div className="flex flex-row justify-end items-center mb-3 mt-8 gap-1 border-b-2">
@@ -306,16 +319,10 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 							<button
 								key={option.format}
 								className={`flex items-center gap-1 px-2 py-1 w-full focus:outline-none rounded-sm transition duration-300 ${
-									isBlockActive &&
-									isBlockActive(
-										editor,
-										option.format,
-										TEXT_ALIGN_TYPES.includes(option.format) ? 'align' : 'type'
-									)
+									isBlockActiveMemo && isBlockActiveMemo(option.format)
 										? 'dark:bg-[#6a6a6a] bg-[#ddd]'
 										: 'bg-transparent'
 								} `}
-								// onClick={() => handleChange(option.format)}
 								onMouseDown={(event) => {
 									event.preventDefault();
 									TextEditorService.toggleBlock(
@@ -328,21 +335,6 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 									);
 									setShowDropdown(false);
 								}}
-								// style={{
-								// 	background: isBlockActive(
-								// 		editor,
-								// 		option.format,
-								// 		TEXT_ALIGN_TYPES.includes(option.format) ? 'align' : 'type'
-								// 	)
-								// 		? '#6a6a6a'
-								// 		: 'transparent',
-								// 	borderRadius: '2px',
-								// 	padding: '2px',
-								// 	// display: 'flex',
-								// 	// alignItems: 'center',
-								// 	// justifyContent: 'center',
-								// 	transition: '0.3s',
-								// }}
 							>
 								<BlockButton
 									format={option.format}

--- a/apps/web/components/pages/task/description-block/editor-toolbar.tsx
+++ b/apps/web/components/pages/task/description-block/editor-toolbar.tsx
@@ -1,6 +1,12 @@
 import BlockButton from './editor-components/BlockButton';
 import MarkButton from './editor-components/MarkButton';
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, {
+	useEffect,
+	useRef,
+	useState,
+	useMemo,
+	useCallback,
+} from 'react';
 import {
 	insertLink,
 	TextEditorService,
@@ -30,6 +36,7 @@ import {
 import { useTranslation } from 'lib/i18n';
 import { useSlateStatic } from 'slate-react';
 import { Node, Element } from 'slate';
+import { Button } from 'lib/components';
 
 interface IToolbarProps {
 	isMarkActive?: (editor: any, format: string) => boolean;
@@ -138,20 +145,20 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 		}, 1000);
 	};
 
-	useEffect(() => {
-		const onClickOutsideOfDropdown = (event: MouseEvent) => {
-			const target = event.target as HTMLElement;
-			if (dropdownRef.current && !dropdownRef.current.contains(target)) {
-				setShowDropdown(false);
-			}
-		};
+	const onClickOutsideOfDropdown = useCallback((event: MouseEvent) => {
+		const target = event.target as HTMLElement;
+		if (dropdownRef.current && !dropdownRef.current.contains(target)) {
+			setShowDropdown(false);
+		}
+	}, []);
 
+	useEffect(() => {
 		document.addEventListener('click', onClickOutsideOfDropdown);
 
 		return () => {
 			document.removeEventListener('click', onClickOutsideOfDropdown);
 		};
-	}, []);
+	}, [onClickOutsideOfDropdown]);
 
 	const isBlockActiveMemo = useMemo(() => {
 		return (
@@ -302,17 +309,16 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 					) => boolean
 				}
 			/>
-			<div className="relative md:hidden">
-				<button
-					ref={dropdownRef}
-					className={`flex items-center px-2 py-[2px] bg-transparent dark:bg-dark--theme rounded-md focus:outline-none`}
+			<div className="relative md:hidden" ref={dropdownRef}>
+				<Button
+					className={`flex items-center text-md px-2 min-w-[3.125rem] py-[2px] bg-transparent dark:bg-dark--theme rounded-md focus:outline-none`}
 					onClick={() => setShowDropdown((prev) => !prev)}
 				>
 					<span className="flex items-center my-0 gap-1 text-black dark:text-white">
 						More
 						<ArrowDown className={`${showDropdown && 'rotate-180'}`} />
 					</span>
-				</button>
+				</Button>
 				{showDropdown && (
 					<div className="absolute top-full left-0 z-10 w-40 py-2 bg-white dark:bg-dark--theme-light border border-gray-300 dark:border-gray-700 rounded shadow">
 						{blockOptions.map((option) => (

--- a/apps/web/lib/components/svgs/icons.tsx
+++ b/apps/web/lib/components/svgs/icons.tsx
@@ -1770,8 +1770,8 @@ export function AlignRightIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="27"
-			height="27"
+			width="25"
+			height="25"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M34,68a6.00029,6.00029,0,0,1,6-6H216a6,6,0,0,1,0,12H40A6.00029,6.00029,0,0,1,34,68Zm182,34H88a6,6,0,0,0,0,12H216a6,6,0,0,0,0-12Zm0,40H40.00586a6,6,0,1,0,0,12H216a6,6,0,0,0,0-12Zm0,40H88.00586a6,6,0,1,0,0,12H216a6,6,0,0,0,0-12Z"></path>
@@ -1785,8 +1785,8 @@ export function AlignLeftIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="27"
-			height="27"
+			width="25"
+			height="25"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M34,68a6.00029,6.00029,0,0,1,6-6H216a6,6,0,0,1,0,12H40A6.00029,6.00029,0,0,1,34,68Zm6,46H168a6,6,0,0,0,0-12H40a6,6,0,0,0,0,12Zm176,28H40.00586a6,6,0,1,0,0,12H216a6,6,0,0,0,0-12Zm-48,40H40.00586a6,6,0,1,0,0,12H168a6,6,0,0,0,0-12Z"></path>
@@ -1800,8 +1800,8 @@ export function AlignCenterIcon({ className }: IClassName) {
 			xmlns="http://www.w3.org/2000/svg"
 			enableBackground="new 0 0 24 24"
 			viewBox="0 0 24 24"
-			width="27"
-			height="27"
+			width="25"
+			height="25"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M6.5,10C6.223877,10,6,10.223877,6,10.5S6.223877,11,6.5,11h11c0.276123,0,0.5-0.223877,0.5-0.5S17.776123,10,17.5,10H6.5z M2.5,7h19C21.776123,7,22,6.776123,22,6.5S21.776123,6,21.5,6h-19C2.223877,6,2,6.223877,2,6.5S2.223877,7,2.5,7z M17.5,18h-11C6.223877,18,6,18.223877,6,18.5S6.223877,19,6.5,19h11c0.276123,0,0.5-0.223877,0.5-0.5S17.776123,18,17.5,18z M21.5,14h-19C2.223877,14,2,14.223877,2,14.5S2.223877,15,2.5,15h19c0.276123,0,0.5-0.223877,0.5-0.5S21.776123,14,21.5,14z"></path>
@@ -1815,8 +1815,8 @@ export function AlignJustifyIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="27"
-			height="27"
+			width="25"
+			height="25"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M36,68a4.0002,4.0002,0,0,1,4-4H216a4,4,0,0,1,0,8H40A4.0002,4.0002,0,0,1,36,68Zm180,36H40a4,4,0,0,0,0,8H216a4,4,0,0,0,0-8Zm0,40H40.00586a4,4,0,1,0,0,8H216a4,4,0,0,0,0-8Zm0,40H40.00586a4,4,0,1,0,0,8H216a4,4,0,0,0,0-8Z"></path>
@@ -1984,8 +1984,8 @@ export function MoreIcon2({ className }: IClassName) {
 export function LinkIcon({ className }: IClassName) {
 	return (
 		<svg
-			width="27"
-			height="27"
+			width="25"
+			height="25"
 			viewBox="0 0 20 21"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
@@ -2106,8 +2106,8 @@ export function CodeBlockIcon({ className }: IClassName) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
-			width="26"
-			height="26"
+			width="24"
+			height="24"
 			fill="currentColor"
 			viewBox="0 0 16 16"
 			className={clsxm(className, 'dark:fill-white')}
@@ -2121,8 +2121,8 @@ export function QuoteBlockIcon({ className }: IClassName) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
-			width="26"
-			height="26"
+			width="25"
+			height="25"
 			fill="currentColor"
 			viewBox="0 0 16 16"
 			className={clsxm(className, 'dark:fill-white')}

--- a/apps/web/pages/task/[id].tsx
+++ b/apps/web/pages/task/[id].tsx
@@ -64,7 +64,7 @@ const TaskDetails = () => {
 			<Container className="mb-10">
 				<div className="flex flex-col w-full min-h-screen pt-5">
 					<section className="flex justify-between lg:flex-row flex-col lg:items-start">
-						<section className="mr-5 max-w-[900px] xl:w-full mb-4 md:mb-0">
+						<section className=" md:mr-5 max-w-[900px] xl:w-full mb-4 md:mb-0">
 							<TaskTitleBlock />
 							<RichTextEditor />
 							{/* <TaskDescriptionBlock /> */}


### PR DESCRIPTION
Made the task description responsive, by adding dropdown for some of the items in smailler screens, and by removing the margin right of the entire right side of tasks page also in smaller screens

Before:
https://github.com/ever-co/ever-teams/assets/124465103/36411038-c416-4afc-9a32-47f8d2c7f834

After:
https://github.com/ever-co/ever-teams/assets/124465103/9a3b1eb6-30c6-42a0-885e-a22c67adc319

