### PR TITLE
Bug/task description dark mode

### DIFF
--- a/apps/web/components/pages/task/description-block/editor-components/BlockButton.tsx
+++ b/apps/web/components/pages/task/description-block/editor-components/BlockButton.tsx
@@ -40,7 +40,7 @@ const BlockButton = ({
 				className,
 				'my-1 rounded-md transition duration-300 p-[2px]',
 				isBlockActiveMemo(format)
-					? 'dark:bg-[#6a6a6a] bg-[#ddd]'
+					? 'dark:bg-[#47484D] bg-[#ddd]'
 					: 'bg-transparent'
 			)}
 			onMouseDown={(event) => {

--- a/apps/web/components/pages/task/description-block/editor-components/LinkElement.tsx
+++ b/apps/web/components/pages/task/description-block/editor-components/LinkElement.tsx
@@ -37,17 +37,17 @@ const LinkElement = ({ attributes, element, children }: any) => {
 				className="text-[#5000B9] dark:text-primary-xlight"
 				{...attributes}
 				ref={anchorRef}
-				href={element.href}
+				href={element?.href}
 				onClick={handleVisibility}
 			>
 				{children}
 			</a>
 			{selected && focused && visible && (
 				<div
-					className="absolute left-0 flex items-center max-w-xs bg-white p-2 gap-1 rounded-md border border-gray-300 z-10 "
+					className="absolute left-0 flex items-center max-w-xs bg-white dark:bg-dark--theme-light p-2 gap-1 rounded-md border border-gray-300 dark:border-[#7B8089] z-10 "
 					contentEditable="false"
 				>
-					<div className="flex items-center pr-2  border-r border-gray-300">
+					<div className="flex items-center pr-2 text-xs border-r dark:bg-dark--theme-light border-gray-300">
 						<ExternalLinkIcon className="mr-1" />
 						<a
 							href={href}

--- a/apps/web/components/pages/task/description-block/editor-components/MarkButton.tsx
+++ b/apps/web/components/pages/task/description-block/editor-components/MarkButton.tsx
@@ -17,20 +17,9 @@ const MarkButton = ({ format, icon: Icon, isMarkActive }: IMarkButtonProps) => {
 			className={clsxm(
 				'my-1 rounded-md transition duration-300 p-[2px]',
 				isMarkActive(editor, format)
-					? 'dark:bg-[#6a6a6a] bg-[#ddd]'
+					? 'dark:bg-[#47484D] bg-[#ddd]'
 					: 'bg-transparent'
 			)}
-			// style={{
-			// 	cursor: 'pointer',
-			// 	background: isMarkActive(editor, format) ? '#ddd' : 'transparent',
-			// 	border: 'none',
-			// 	borderRadius: '5px',
-			// 	transition: '0.3s',
-			// 	padding: '2px',
-			// 	// display: 'flex',
-			// 	// alignItems: 'center',
-			// 	// justifyContent: 'center',
-			// }}
 			onMouseDown={(event) => {
 				event.preventDefault();
 				TextEditorService.toggleMark(editor, format, isMarkActive);

--- a/apps/web/components/pages/task/description-block/editor-components/MarkButton.tsx
+++ b/apps/web/components/pages/task/description-block/editor-components/MarkButton.tsx
@@ -1,3 +1,4 @@
+import { clsxm } from '@app/utils';
 import { TextEditorService } from './TextEditorService';
 import React from 'react';
 import { useSlate } from 'slate-react';
@@ -13,18 +14,23 @@ const MarkButton = ({ format, icon: Icon, isMarkActive }: IMarkButtonProps) => {
 
 	return (
 		<button
-			className="my-1"
-			style={{
-				cursor: 'pointer',
-				background: isMarkActive(editor, format) ? '#ddd' : 'transparent',
-				border: 'none',
-				borderRadius: '5px',
-				transition: '0.3s',
-				padding: '2px',
-				// display: 'flex',
-				// alignItems: 'center',
-				// justifyContent: 'center',
-			}}
+			className={clsxm(
+				'my-1 rounded-md transition duration-300 p-[2px]',
+				isMarkActive(editor, format)
+					? 'dark:bg-[#6a6a6a] bg-[#ddd]'
+					: 'bg-transparent'
+			)}
+			// style={{
+			// 	cursor: 'pointer',
+			// 	background: isMarkActive(editor, format) ? '#ddd' : 'transparent',
+			// 	border: 'none',
+			// 	borderRadius: '5px',
+			// 	transition: '0.3s',
+			// 	padding: '2px',
+			// 	// display: 'flex',
+			// 	// alignItems: 'center',
+			// 	// justifyContent: 'center',
+			// }}
 			onMouseDown={(event) => {
 				event.preventDefault();
 				TextEditorService.toggleMark(editor, format, isMarkActive);

--- a/apps/web/components/pages/task/description-block/editor-footer.tsx
+++ b/apps/web/components/pages/task/description-block/editor-footer.tsx
@@ -59,7 +59,9 @@ const EditorFooter = ({
 			)}
 			<div className="flex justify-between items-end mt-0 border-b-2 dark:border-[#7B8089]">
 				<div>
-					<label className="text-xs text-[##7B8089]">Acceptance Criteria</label>
+					<label className="text-xs dark:text-[#7B8089] text-gray-300">
+						Acceptance Criteria
+					</label>
 				</div>
 				<Image
 					src="/assets/svg/arrow-up.svg"

--- a/apps/web/components/pages/task/description-block/editor-footer.tsx
+++ b/apps/web/components/pages/task/description-block/editor-footer.tsx
@@ -57,9 +57,9 @@ const EditorFooter = ({
 					</Button>
 				</div>
 			)}
-			<div className="flex justify-between items-end mt-0 border-b-2">
+			<div className="flex justify-between items-end mt-0 border-b-2 dark:border-[#7B8089]">
 				<div>
-					<label className="text-xs text-gray-300">Acceptance Criteria</label>
+					<label className="text-xs text-[##7B8089]">Acceptance Criteria</label>
 				</div>
 				<Image
 					src="/assets/svg/arrow-up.svg"

--- a/apps/web/components/pages/task/description-block/editor-toolbar.tsx
+++ b/apps/web/components/pages/task/description-block/editor-toolbar.tsx
@@ -174,7 +174,7 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 	}, [editor, isBlockActive]);
 
 	return (
-		<div className="flex flex-row justify-end items-center mb-3 mt-8 gap-1 border-b-2">
+		<div className="flex flex-row justify-end items-center mb-3 mt-8 gap-1 border-b-2 dark:border-[#7B8089] ">
 			<p className="flex-1 text-lg font-[500] dark:text-white my-1 hidden md:block">
 				{trans.DESCRIPTION}
 			</p>

--- a/apps/web/components/pages/task/description-block/editor-toolbar.tsx
+++ b/apps/web/components/pages/task/description-block/editor-toolbar.tsx
@@ -373,7 +373,7 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 				<div
 					onKeyDown={handleInsertLinkOnEnter}
 					ref={popupRef}
-					className="absolute flex items-center bg-white p-2 gap-1 rounded-md border border-gray-300 z-10"
+					className="absolute flex items-center bg-white dark:bg-dark--theme-light p-2 gap-1 rounded-md border border-gray-300 dark:border-[#7B8089] z-10"
 					style={{
 						left: linkPopupPosition.left,
 						top: linkPopupPosition.top + 3,
@@ -382,7 +382,7 @@ const Toolbar = ({ isMarkActive, isBlockActive }: IToolbarProps) => {
 					<ExternalLinkIcon />
 					<input
 						type="text"
-						className="outline-none font-[500] text-[#5000B9] dark:text-primary-light border-r border-gray-300 pr-2"
+						className="outline-none font-[500] text-xs text-[#5000B9] dark:text-primary-light border-r dark:bg-dark--theme-light pr-2"
 						onChange={(e) => setLink(e.target.value)}
 						value={link}
 						ref={inputRef}

--- a/apps/web/lib/components/svgs/icons.tsx
+++ b/apps/web/lib/components/svgs/icons.tsx
@@ -2018,9 +2018,9 @@ export function ExternalLinkIcon({ className }: IClassName) {
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 24 24"
-			width="21"
-			height="21"
-			className={clsxm(className)}
+			width="18"
+			height="18"
+			className={clsxm(className, 'dark:fill-white')}
 		>
 			<g>
 				<path fill="none" d="M0 0h24v24H0z" />{' '}
@@ -2034,18 +2034,16 @@ export function UnlinkIcon({ className }: IClassName) {
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="21"
-			height="21"
-			className={clsxm(className, 'dark:fill-white')}
+			width="18"
+			height="18"
+			className={clsxm(className, 'stroke-black dark:stroke-white')}
 		>
-			<rect width="256" height="256" fill="none" />
 			<line
 				x1="96"
 				y1="68"
 				x2="96"
 				y2="48"
 				fill="none"
-				stroke="#000"
 				strokeLinecap="round"
 				strokeLinejoin="round"
 				strokeWidth="24"
@@ -2056,7 +2054,6 @@ export function UnlinkIcon({ className }: IClassName) {
 				x2="160"
 				y2="188"
 				fill="none"
-				stroke="#000"
 				strokeLinecap="round"
 				strokeLinejoin="round"
 				strokeWidth="24"
@@ -2067,7 +2064,6 @@ export function UnlinkIcon({ className }: IClassName) {
 				x2="48"
 				y2="96"
 				fill="none"
-				stroke="#000"
 				strokeLinecap="round"
 				strokeLinejoin="round"
 				strokeWidth="24"
@@ -2078,7 +2074,6 @@ export function UnlinkIcon({ className }: IClassName) {
 				x2="188"
 				y2="160"
 				fill="none"
-				stroke="#000"
 				strokeLinecap="round"
 				strokeLinejoin="round"
 				strokeWidth="24"
@@ -2086,7 +2081,6 @@ export function UnlinkIcon({ className }: IClassName) {
 			<path
 				d="M67,132.4l-7.3,7.3a40,40,0,0,0,56.6,56.6l7.3-7.3"
 				fill="none"
-				stroke="#000"
 				strokeLinecap="round"
 				strokeLinejoin="round"
 				strokeWidth="24"
@@ -2094,7 +2088,6 @@ export function UnlinkIcon({ className }: IClassName) {
 			<path
 				d="M189,123.6l7.3-7.3a40,40,0,0,0-56.6-56.6L132.4,67"
 				fill="none"
-				stroke="#000"
 				strokeLinecap="round"
 				strokeLinejoin="round"
 				strokeWidth="24"

--- a/apps/web/lib/components/svgs/icons.tsx
+++ b/apps/web/lib/components/svgs/icons.tsx
@@ -1705,8 +1705,8 @@ export function TinySizeIcon({ className }: IClassName) {
 export function BoldIcon({ className }: IClassName) {
 	return (
 		<svg
-			width="21"
-			height="21"
+			width="23"
+			height="23"
 			viewBox="0 0 21 21"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
@@ -1720,8 +1720,8 @@ export function BoldIcon({ className }: IClassName) {
 export function ItalicIcon({ className }: IClassName) {
 	return (
 		<svg
-			width="21"
-			height="21"
+			width="23"
+			height="23"
 			viewBox="0 0 21 21"
 			xmlns="http://www.w3.org/2000/svg"
 			className={clsxm(className, 'dark:fill-white')}
@@ -1737,8 +1737,8 @@ export function UnderlineIcon({ className }: IClassName) {
 			viewBox="0 0 20 20"
 			version="1.1"
 			id="svg321"
-			width="20"
-			height="20"
+			width="23"
+			height="23"
 			xmlns="http://www.w3.org/2000/svg"
 			className={clsxm(className, 'dark:fill-white')}
 		>
@@ -1771,8 +1771,8 @@ export function AlignRightIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="25"
-			height="25"
+			width="23"
+			height="23"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M34,68a6.00029,6.00029,0,0,1,6-6H216a6,6,0,0,1,0,12H40A6.00029,6.00029,0,0,1,34,68Zm182,34H88a6,6,0,0,0,0,12H216a6,6,0,0,0,0-12Zm0,40H40.00586a6,6,0,1,0,0,12H216a6,6,0,0,0,0-12Zm0,40H88.00586a6,6,0,1,0,0,12H216a6,6,0,0,0,0-12Z"></path>
@@ -1786,8 +1786,8 @@ export function AlignLeftIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="25"
-			height="25"
+			width="23"
+			height="23"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M34,68a6.00029,6.00029,0,0,1,6-6H216a6,6,0,0,1,0,12H40A6.00029,6.00029,0,0,1,34,68Zm6,46H168a6,6,0,0,0,0-12H40a6,6,0,0,0,0,12Zm176,28H40.00586a6,6,0,1,0,0,12H216a6,6,0,0,0,0-12Zm-48,40H40.00586a6,6,0,1,0,0,12H168a6,6,0,0,0,0-12Z"></path>
@@ -1801,8 +1801,8 @@ export function AlignCenterIcon({ className }: IClassName) {
 			xmlns="http://www.w3.org/2000/svg"
 			enableBackground="new 0 0 24 24"
 			viewBox="0 0 24 24"
-			width="25"
-			height="25"
+			width="23"
+			height="23"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M6.5,10C6.223877,10,6,10.223877,6,10.5S6.223877,11,6.5,11h11c0.276123,0,0.5-0.223877,0.5-0.5S17.776123,10,17.5,10H6.5z M2.5,7h19C21.776123,7,22,6.776123,22,6.5S21.776123,6,21.5,6h-19C2.223877,6,2,6.223877,2,6.5S2.223877,7,2.5,7z M17.5,18h-11C6.223877,18,6,18.223877,6,18.5S6.223877,19,6.5,19h11c0.276123,0,0.5-0.223877,0.5-0.5S17.776123,18,17.5,18z M21.5,14h-19C2.223877,14,2,14.223877,2,14.5S2.223877,15,2.5,15h19c0.276123,0,0.5-0.223877,0.5-0.5S21.776123,14,21.5,14z"></path>
@@ -1816,8 +1816,8 @@ export function AlignJustifyIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="25"
-			height="25"
+			width="23"
+			height="23"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M36,68a4.0002,4.0002,0,0,1,4-4H216a4,4,0,0,1,0,8H40A4.0002,4.0002,0,0,1,36,68Zm180,36H40a4,4,0,0,0,0,8H216a4,4,0,0,0,0-8Zm0,40H40.00586a4,4,0,1,0,0,8H216a4,4,0,0,0,0-8Zm0,40H40.00586a4,4,0,1,0,0,8H216a4,4,0,0,0,0-8Z"></path>
@@ -2107,8 +2107,8 @@ export function CodeBlockIcon({ className }: IClassName) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
-			width="24"
-			height="24"
+			width="23"
+			height="23"
 			fill="currentColor"
 			viewBox="0 0 16 16"
 			className={clsxm(className, 'dark:fill-white')}

--- a/apps/web/lib/components/svgs/icons.tsx
+++ b/apps/web/lib/components/svgs/icons.tsx
@@ -1990,7 +1990,7 @@ export function LinkIcon({ className }: IClassName) {
 			viewBox="0 0 20 21"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
-			className={clsxm('stroke-[#282048]', className, 'dark:fill-white')}
+			className={clsxm('stroke-[#282048]', className, 'dark:stroke-white')}
 		>
 			<path
 				d="M12.4917 15.0832H13.75C16.2667 15.0832 18.3334 13.0248 18.3334 10.4998C18.3334 7.98317 16.275 5.9165 13.75 5.9165H12.4917"

--- a/apps/web/lib/components/svgs/icons.tsx
+++ b/apps/web/lib/components/svgs/icons.tsx
@@ -1705,8 +1705,8 @@ export function TinySizeIcon({ className }: IClassName) {
 export function BoldIcon({ className }: IClassName) {
 	return (
 		<svg
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			viewBox="0 0 21 21"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
@@ -1720,8 +1720,8 @@ export function BoldIcon({ className }: IClassName) {
 export function ItalicIcon({ className }: IClassName) {
 	return (
 		<svg
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			viewBox="0 0 21 21"
 			xmlns="http://www.w3.org/2000/svg"
 			className={clsxm(className, 'dark:fill-white')}
@@ -1737,8 +1737,8 @@ export function UnderlineIcon({ className }: IClassName) {
 			viewBox="0 0 20 20"
 			version="1.1"
 			id="svg321"
-			width="23"
-			height="23"
+			width="21"
+			height="21"
 			xmlns="http://www.w3.org/2000/svg"
 			className={clsxm(className, 'dark:fill-white')}
 		>
@@ -1771,8 +1771,8 @@ export function AlignRightIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M34,68a6.00029,6.00029,0,0,1,6-6H216a6,6,0,0,1,0,12H40A6.00029,6.00029,0,0,1,34,68Zm182,34H88a6,6,0,0,0,0,12H216a6,6,0,0,0,0-12Zm0,40H40.00586a6,6,0,1,0,0,12H216a6,6,0,0,0,0-12Zm0,40H88.00586a6,6,0,1,0,0,12H216a6,6,0,0,0,0-12Z"></path>
@@ -1786,8 +1786,8 @@ export function AlignLeftIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M34,68a6.00029,6.00029,0,0,1,6-6H216a6,6,0,0,1,0,12H40A6.00029,6.00029,0,0,1,34,68Zm6,46H168a6,6,0,0,0,0-12H40a6,6,0,0,0,0,12Zm176,28H40.00586a6,6,0,1,0,0,12H216a6,6,0,0,0,0-12Zm-48,40H40.00586a6,6,0,1,0,0,12H168a6,6,0,0,0,0-12Z"></path>
@@ -1801,8 +1801,8 @@ export function AlignCenterIcon({ className }: IClassName) {
 			xmlns="http://www.w3.org/2000/svg"
 			enableBackground="new 0 0 24 24"
 			viewBox="0 0 24 24"
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M6.5,10C6.223877,10,6,10.223877,6,10.5S6.223877,11,6.5,11h11c0.276123,0,0.5-0.223877,0.5-0.5S17.776123,10,17.5,10H6.5z M2.5,7h19C21.776123,7,22,6.776123,22,6.5S21.776123,6,21.5,6h-19C2.223877,6,2,6.223877,2,6.5S2.223877,7,2.5,7z M17.5,18h-11C6.223877,18,6,18.223877,6,18.5S6.223877,19,6.5,19h11c0.276123,0,0.5-0.223877,0.5-0.5S17.776123,18,17.5,18z M21.5,14h-19C2.223877,14,2,14.223877,2,14.5S2.223877,15,2.5,15h19c0.276123,0,0.5-0.223877,0.5-0.5S21.776123,14,21.5,14z"></path>
@@ -1816,8 +1816,8 @@ export function AlignJustifyIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M36,68a4.0002,4.0002,0,0,1,4-4H216a4,4,0,0,1,0,8H40A4.0002,4.0002,0,0,1,36,68Zm180,36H40a4,4,0,0,0,0,8H216a4,4,0,0,0,0-8Zm0,40H40.00586a4,4,0,1,0,0,8H216a4,4,0,0,0,0-8Zm0,40H40.00586a4,4,0,1,0,0,8H216a4,4,0,0,0,0-8Z"></path>
@@ -1830,8 +1830,8 @@ export function HeaderOneIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M152,56V176a8,8,0,0,1-16,0V124H48v52a8,8,0,0,1-16,0V56a8,8,0,0,1,16,0v52h88V56a8,8,0,0,1,16,0Zm71.77539,44.94727a7.99755,7.99755,0,0,0-8.21191.3955l-24,15.99317a8.00008,8.00008,0,1,0,8.873,13.31445L212,122.94434V200a8,8,0,0,0,16,0V108A7.99932,7.99932,0,0,0,223.77539,100.94727Z"></path>
@@ -1844,8 +1844,8 @@ export function HeaderTwoIcon({ className }: IClassName) {
 			id="Flat"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 256 256"
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			className={clsxm(className, 'dark:fill-white')}
 		>
 			<path d="M152,56V176a8,8,0,0,1-16,0V124H48v52a8,8,0,0,1-16,0V56a8,8,0,0,1,16,0v52h88V56a8,8,0,0,1,16,0Zm88,135.99414H207.99707l34.30566-45.77734c.07911-.1045.1543-.21094.22754-.31934A32.00406,32.00406,0,1,0,186.51758,115.542a8,8,0,1,0,14.73633,6.23242A16.00416,16.00416,0,1,1,229.37012,136.794l-43.67285,58.27539A8.00367,8.00367,0,0,0,191.999,208.001c.10547,0,.21192-.00293.31836-.00684H240a8,8,0,0,0,0-16Z"></path>
@@ -1885,7 +1885,7 @@ export function CopyIcon({ className }: IClassName) {
 export function CheckBoxIcon({ className }: IClassName) {
 	return (
 		<svg
-			width="18"
+			width="17"
 			height="17"
 			viewBox="0 0 18 17"
 			fill="none"
@@ -1924,8 +1924,8 @@ export function UnorderedListIcon({ className }: IClassName) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			fill="currentColor"
 			viewBox="0 0 16 16"
 			className={clsxm(className, 'dark:fill-white')}
@@ -1941,8 +1941,8 @@ export function OrderedListIcon({ className }: IClassName) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			fill="currentColor"
 			className={clsxm(className, 'dark:fill-white')}
 			viewBox="0 0 16 16"
@@ -1985,8 +1985,8 @@ export function MoreIcon2({ className }: IClassName) {
 export function LinkIcon({ className }: IClassName) {
 	return (
 		<svg
-			width="25"
-			height="25"
+			width="20"
+			height="20"
 			viewBox="0 0 20 21"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
@@ -2107,8 +2107,8 @@ export function CodeBlockIcon({ className }: IClassName) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
-			width="23"
-			height="23"
+			width="20"
+			height="20"
 			fill="currentColor"
 			viewBox="0 0 16 16"
 			className={clsxm(className, 'dark:fill-white')}
@@ -2122,8 +2122,8 @@ export function QuoteBlockIcon({ className }: IClassName) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
-			width="25"
-			height="25"
+			width="20"
+			height="20"
 			fill="currentColor"
 			viewBox="0 0 16 16"
 			className={clsxm(className, 'dark:fill-white')}

--- a/apps/web/lib/components/svgs/icons.tsx
+++ b/apps/web/lib/components/svgs/icons.tsx
@@ -1737,8 +1737,8 @@ export function UnderlineIcon({ className }: IClassName) {
 			viewBox="0 0 20 20"
 			version="1.1"
 			id="svg321"
-			width="21"
-			height="21"
+			width="20"
+			height="20"
 			xmlns="http://www.w3.org/2000/svg"
 			className={clsxm(className, 'dark:fill-white')}
 		>


### PR DESCRIPTION
#1184 
- Fixed the icons sizes and background colors when selected
- Changed the horizontal line colors to match the dark theme
- Styled the hyper-link poup to fit both themes

![image](https://github.com/ever-co/ever-teams/assets/124465103/6e22f289-0e6b-4b8d-acb3-78df0a68bad1)

![image](https://github.com/ever-co/ever-teams/assets/124465103/507e6a02-d5c7-40ec-a0bf-ece00ebbd018)
