### PR TITLE
fixed the task title crash when has no value

### DIFF
--- a/apps/web/components/pages/task/title-block/task-title-block.tsx
+++ b/apps/web/components/pages/task/title-block/task-title-block.tsx
@@ -94,7 +94,7 @@ const TaskTitleBlock = () => {
 	return (
 		<>
 			<div className="flex mb-6">
-				{title !== '' ? (
+				{task !== null ? (
 					<>
 						<div className="w-full flex flex-wrap relative">
 							<textarea

--- a/apps/web/components/pages/task/title-block/task-title-block.tsx
+++ b/apps/web/components/pages/task/title-block/task-title-block.tsx
@@ -94,7 +94,7 @@ const TaskTitleBlock = () => {
 	return (
 		<>
 			<div className="flex mb-6">
-				{task !== null ? (
+				{task ? (
 					<>
 						<div className="w-full flex flex-wrap relative">
 							<textarea


### PR DESCRIPTION
#1167
Fixed the task title break when has no value

Before:

https://github.com/ever-co/ever-teams/assets/124465103/b4924506-7c9d-4a19-bde2-e63428f994a9

After:

https://github.com/ever-co/ever-teams/assets/124465103/719d9124-3fbb-4795-8057-14c925acc37b

