### PR TITLE
Bug/issue type x icon remove

### DIFF
--- a/apps/web/components/pages/task/title-block/task-title-block.tsx
+++ b/apps/web/components/pages/task/title-block/task-title-block.tsx
@@ -199,8 +199,9 @@ const TaskTitleBlock = () => {
 							taskStatusClassName="h-5 text-[0.5rem] rounded-[0.1875rem] border-none"
 						/>
 					</div>
-
-					<div className="w-[0.0625rem] h-5 bg-[#DBDBDB]"></div>
+					{task?.issueType !== 'Epic' && (
+						<div className="w-[0.0625rem] h-5 bg-[#DBDBDB]"></div>
+					)}
 
 					<div className="flex flex-row gap-1">
 						{/* Creator Name */}

--- a/apps/web/lib/features/task/task-status.tsx
+++ b/apps/web/lib/features/task/task-status.tsx
@@ -1062,24 +1062,26 @@ export function StatusDropdown<T extends TStatusItem>({
 																)}
 															/>
 
-															{open && current_value === item_value && (
-																<Listbox.Button
-																	as="button"
-																	onClick={(e: any) => {
-																		e.stopPropagation();
-																		onRemoveSelected && onRemoveSelected();
-																		onChange && onChange(null as any);
-																	}}
-																	className="absolute top-2.5 right-2 h-4 w-4 bg-transparent"
-																>
-																	<XMarkIcon
-																		className="text-dark"
-																		height={16}
-																		width={16}
-																		aria-hidden="true"
-																	/>
-																</Listbox.Button>
-															)}
+															{open &&
+																current_value === item_value &&
+																issueType !== 'issue' && (
+																	<Listbox.Button
+																		as="button"
+																		onClick={(e: any) => {
+																			e.stopPropagation();
+																			onRemoveSelected && onRemoveSelected();
+																			onChange && onChange(null as any);
+																		}}
+																		className="absolute top-2.5 right-2 h-4 w-4 bg-transparent"
+																	>
+																		<XMarkIcon
+																			className="text-dark"
+																			height={16}
+																			width={16}
+																			aria-hidden="true"
+																		/>
+																	</Listbox.Button>
+																)}
 														</li>
 													</Listbox.Option>
 												);


### PR DESCRIPTION
- Rendering the X icon dynamically, on Issue Type dropdowns it's not present anymore
- Removed seperator for Epic tasks, from title block

![image](https://github.com/ever-co/ever-teams/assets/124465103/f4972411-1521-458c-ad93-85ce860387e8)


Non-epic:
![image](https://github.com/ever-co/ever-teams/assets/124465103/b6d74091-fa8d-4945-956e-904690c8e5df)

Epic:
![image](https://github.com/ever-co/ever-teams/assets/124465103/ebedca5f-7ee6-458b-9054-27c8440c4ad7)
