### PR TITLE
User name overlap issue

### DIFF
--- a/apps/mobile/app/screens/Authenticated/TeamScreen/components/UserHeaderCard.tsx
+++ b/apps/mobile/app/screens/Authenticated/TeamScreen/components/UserHeaderCard.tsx
@@ -89,7 +89,9 @@ const UserHeaderCard = ({ member, user }: { member: OT_Member; user: IUser }) =>
 						: member?.timerStatus || "idle"
 				}
 			/>
-			<Text style={[styles.name, { color: colors.primary }]}>{user.name}</Text>
+			<Text style={[styles.name, { color: colors.primary }]} numberOfLines={1} ellipsizeMode="tail">
+				{user.name}
+			</Text>
 		</View>
 	)
 }
@@ -102,6 +104,7 @@ const styles = StyleSheet.create({
 		fontFamily: typography.fonts.PlusJakartaSans.semiBold,
 		fontSize: 12,
 		left: 15,
+		maxWidth: "70%",
 	},
 	prefix: {
 		fontFamily: typography.fonts.PlusJakartaSans.semiBold,


### PR DESCRIPTION
truncated the name of user if it takes more than 70% of parent width

![WhatsApp Image 2023-08-21 at 01 54 23](https://github.com/ever-co/ever-teams/assets/124465103/ee8973dc-2800-4681-b9c2-006aecf53558)
