### PR TITLE
Restricted users to change issue if the current task's type is 'Epic'

### DIFF
--- a/apps/mobile/app/components/IssuesModal.tsx
+++ b/apps/mobile/app/components/IssuesModal.tsx
@@ -50,7 +50,9 @@ const IssuesModal: FC<IssuesModalProps> = ({ task, readonly = false }) => {
 			<View
 				style={[styles.wrapButton, { backgroundColor: currentIssue?.color }]}
 				onTouchStart={() => {
-					!readonly && setIsModalOpen(true)
+					if (currentIssue.name !== "Epic" && !readonly) {
+						setIsModalOpen(true)
+					}
 				}}
 			>
 				<SvgUri width={iconDimension} height={iconDimension} uri={currentIssue?.fullIconUrl} />


### PR DESCRIPTION
Part of #852

When the issue is "Epic", pressing to open the modal, but it's not visible on phone screen
https://github.com/ever-co/ever-teams/assets/124465103/493bf5ad-7af7-4348-acfe-c6654e854cff

