### PR TITLE
fix: Task Number and Title alignement in Member Tasks page

### DIFF
--- a/apps/web/lib/features/task/task-displays.tsx
+++ b/apps/web/lib/features/task/task-displays.tsx
@@ -36,18 +36,18 @@ export function TaskNameInfoDisplay({
 									task={task}
 								/>
 							</div>
-							<span
-								className={clsxm(
-									'text-gray-500 mr-1 font-normal',
-									taskNumberClassName
-								)}
-							>
-								#{task.taskNumber} {dash && '-'}
-							</span>
 						</div>
 					</div>
 				)}
 				<span className={clsxm('font-normal', taskTitleClassName)}>
+					<span
+						className={clsxm(
+							'text-gray-500 mr-1 font-normal',
+							taskNumberClassName
+						)}
+					>
+						#{task?.taskNumber} {dash && '-'}
+					</span>
 					{task?.title}
 				</span>
 			</span>


### PR DESCRIPTION
https://github.com/ever-co/ever-teams/issues/1469

<img width="1474" alt="image" src="https://github.com/ever-co/ever-teams/assets/81486442/7d05f8af-b334-4400-936e-f84c2331894e">
