### PR TITLE
Bug/now 24hours tab logic

### DIFF
--- a/apps/mobile/app/components/WorkedDayHours.tsx
+++ b/apps/mobile/app/components/WorkedDayHours.tsx
@@ -35,7 +35,8 @@ const WorkedOnTaskHours = ({
 				</Text>
 			)}
 			<Text style={totalTimeText}>
-				{pad(dh)} {title && "h"}:{pad(dm)} {title && "m"}
+				{pad(dh)}
+				{title && " h"}:{pad(dm)} {title && "m"}
 			</Text>
 		</View>
 	)

--- a/apps/mobile/app/components/WorkedDayHours.tsx
+++ b/apps/mobile/app/components/WorkedDayHours.tsx
@@ -14,7 +14,7 @@ const WorkedOnTaskHours = ({
 	memberTask,
 	totalTimeText,
 }: {
-	title: string
+	title?: string
 	memberTask: ITeamTask
 	containerStyle: ViewStyle
 	totalTimeText: TextStyle
@@ -26,9 +26,9 @@ const WorkedOnTaskHours = ({
 
 	return (
 		<View style={containerStyle}>
-			<Text style={styles.totalTimeTitle}>{title} : </Text>
+			{title && <Text style={styles.totalTimeTitle}>{title} : </Text>}
 			<Text style={totalTimeText}>
-				{pad(dh)} h:{pad(dm)} m
+				{pad(dh)} {title && "h"}:{pad(dm)} {title && "m"}
 			</Text>
 		</View>
 	)

--- a/apps/mobile/app/screens/Authenticated/ProfileScreen/components/UserProfileTasks.tsx
+++ b/apps/mobile/app/screens/Authenticated/ProfileScreen/components/UserProfileTasks.tsx
@@ -10,6 +10,7 @@ import { typography, useAppTheme } from "../../../../theme"
 import { GLOBAL_STYLE as GS } from "../../../../../assets/ts/styles"
 import { observer } from "mobx-react-lite"
 import { useTimer } from "../../../../services/hooks/useTimer"
+import WorkedOnTaskHours from "../../../../components/WorkedDayHours"
 interface IUserProfileTasks {
 	profile: IUserProfile
 	content: ITaskFilter
@@ -60,7 +61,7 @@ const UserProfileTasks: FC<IUserProfileTasks> = observer(({ profile, content }) 
 								borderBottomColor: colors.border,
 							}}
 						/>
-						<View style={{ flexDirection: "row" }}>
+						<View style={{ flexDirection: "row", alignItems: "center" }}>
 							<Text
 								style={{
 									color: colors.primary,
@@ -80,9 +81,12 @@ const UserProfileTasks: FC<IUserProfileTasks> = observer(({ profile, content }) 
 										fontSize: 12,
 									},
 								]}
-							>
-								03:31
-							</Text>
+							></Text>
+							<WorkedOnTaskHours
+								memberTask={profile.activeUserTeamTask}
+								containerStyle={{ alignItems: "center" }}
+								totalTimeText={{ color: colors.primary, fontSize: 12 }}
+							/>
 						</View>
 					</View>
 					<ListCardItem

--- a/apps/mobile/app/screens/Authenticated/ProfileScreen/components/UserProfileTasks.tsx
+++ b/apps/mobile/app/screens/Authenticated/ProfileScreen/components/UserProfileTasks.tsx
@@ -9,19 +9,21 @@ import { translate } from "../../../../i18n"
 import { typography, useAppTheme } from "../../../../theme"
 import { GLOBAL_STYLE as GS } from "../../../../../assets/ts/styles"
 import { observer } from "mobx-react-lite"
+import { useTimer } from "../../../../services/hooks/useTimer"
 interface IUserProfileTasks {
 	profile: IUserProfile
 	content: ITaskFilter
 }
 const UserProfileTasks: FC<IUserProfileTasks> = observer(({ profile, content }) => {
 	const { colors, dark } = useAppTheme()
+	const { timerStatus } = useTimer()
 	const tasks = useMemo(() => {
-		let tasks = content.tasksFiltered
-		if (content.tab === "worked" && profile.activeUserTeamTask) {
-			tasks = tasks.filter((ts) => {
-				return ts.id !== profile.activeUserTeamTask?.id
-			})
-		}
+		const tasks = content.tasksFiltered
+		// if (content.tab === "worked" && profile.activeUserTeamTask) {
+		// 	tasks = tasks.filter((ts) => {
+		// 		return ts.id !== profile.activeUserTeamTask?.id
+		// 	})
+		// }
 
 		return tasks
 	}, [content, profile])
@@ -35,7 +37,10 @@ const UserProfileTasks: FC<IUserProfileTasks> = observer(({ profile, content }) 
 			}}
 			bounces={false}
 		>
-			{profile.activeUserTeamTask && content.tab === "worked" ? (
+			{content.tab === "worked" &&
+			profile.activeUserTeamTask &&
+			(profile.member?.timerStatus === "running" ||
+				(profile.isAuthUser && timerStatus?.running)) ? (
 				<>
 					<View
 						style={{

--- a/apps/mobile/app/screens/Authenticated/ProfileScreen/components/UserProfileTasks.tsx
+++ b/apps/mobile/app/screens/Authenticated/ProfileScreen/components/UserProfileTasks.tsx
@@ -19,14 +19,7 @@ const UserProfileTasks: FC<IUserProfileTasks> = observer(({ profile, content }) 
 	const { colors, dark } = useAppTheme()
 	const { timerStatus } = useTimer()
 	const tasks = useMemo(() => {
-		const tasks = content.tasksFiltered
-		// if (content.tab === "worked" && profile.activeUserTeamTask) {
-		// 	tasks = tasks.filter((ts) => {
-		// 		return ts.id !== profile.activeUserTeamTask?.id
-		// 	})
-		// }
-
-		return tasks
+		return content.tasksFiltered
 	}, [content, profile])
 
 	return (


### PR DESCRIPTION
#1505
Fixed the "Now" and "Last 24 Hours" Logic. Now shows Now section only if timer is running, and the running task. The last 24 hours shows the task that user worked in last 24 hours, we get the data from DB

Timer running:
![File (2)](https://github.com/ever-co/ever-teams/assets/124465103/6fad4138-805d-4332-bc08-675636a3985a)

Timer stopped:
![File (1)](https://github.com/ever-co/ever-teams/assets/124465103/3d079e0e-03d8-49f5-a8b6-5d39c33a63bd)
