### PR TITLE
limited the labels, sizes, priorities, statuses number of characters …

### DIFF
--- a/apps/mobile/app/components/LabelItem.tsx
+++ b/apps/mobile/app/components/LabelItem.tsx
@@ -3,6 +3,7 @@
 import React, { FC, ReactNode } from "react"
 import { View, StyleSheet, Text } from "react-native"
 import { typography } from "../theme"
+import { limitTextCharaters } from "../helpers/sub-text"
 
 interface Props {
 	label: string
@@ -15,7 +16,7 @@ const LabelItem: FC<Props> = ({ label, background, icon }) => {
 			<View style={{ flexDirection: "row" }}>
 				{icon}
 				<Text style={[styles.labelTitle, { color: "#282048" }]} numberOfLines={1}>
-					{label}
+					{limitTextCharaters({ text: label, numChars: 18 })}
 				</Text>
 			</View>
 		</View>
@@ -28,9 +29,10 @@ const styles = StyleSheet.create({
 		backgroundColor: "#D4EFDF",
 		borderRadius: 10,
 		flexDirection: "row",
+		maxWidth: 130,
+		minWidth: 70,
 		paddingHorizontal: 10,
 		paddingVertical: 6,
-		width: 97,
 	},
 	labelTitle: {
 		fontFamily: typography.secondary.semiBold,

--- a/apps/mobile/app/components/LabelItem.tsx
+++ b/apps/mobile/app/components/LabelItem.tsx
@@ -16,7 +16,7 @@ const LabelItem: FC<Props> = ({ label, background, icon }) => {
 			<View style={{ flexDirection: "row" }}>
 				{icon}
 				<Text style={[styles.labelTitle, { color: "#282048" }]} numberOfLines={1}>
-					{limitTextCharaters({ text: label, numChars: 18 })}
+					{label}
 				</Text>
 			</View>
 		</View>
@@ -29,7 +29,6 @@ const styles = StyleSheet.create({
 		backgroundColor: "#D4EFDF",
 		borderRadius: 10,
 		flexDirection: "row",
-		maxWidth: 130,
 		minWidth: 70,
 		paddingHorizontal: 10,
 		paddingVertical: 6,


### PR DESCRIPTION
…shown, and also made their container more flexible in width
#1543
https://github.com/ever-co/ever-teams/assets/124465103/599c7871-9ab7-4ceb-a1db-1b0fec31b751

Before:
![image](https://github.com/ever-co/ever-teams/assets/124465103/30d8f0d8-1c98-4f9c-8727-8d047411d086)


