### PR TITLE
Conditionally rendering options icon in team member cards

### DIFF
--- a/apps/mobile/app/screens/Authenticated/TeamScreen/components/ListCardItem.tsx
+++ b/apps/mobile/app/screens/Authenticated/TeamScreen/components/ListCardItem.tsx
@@ -298,7 +298,7 @@ const ListCardItem: React.FC<Props> = observer((props) => {
 							>
 								<Ionicons name="chevron-back" size={24} color={colors.primary} />
 							</TouchableOpacity>
-						) : (
+						) : memberInfo.isAuthTeamManager || memberInfo.isAuthUser ? (
 							<TouchableOpacity
 								onPress={() =>
 									props.setOpenMenuIndex(props.openMenuIndex === props.index ? null : props.index)
@@ -310,7 +310,7 @@ const ListCardItem: React.FC<Props> = observer((props) => {
 									<Entypo name="cross" size={24} color={colors.primary} />
 								)}
 							</TouchableOpacity>
-						)}
+						) : null}
 					</View>
 				</View>
 			}


### PR DESCRIPTION
Non Managers:
![image](https://github.com/ever-co/ever-teams/assets/124465103/2bb48f8d-5091-49bc-8337-8a4d977855db)

Managers:
![image](https://github.com/ever-co/ever-teams/assets/124465103/cfb4af9d-246e-4399-9c86-1fa8aa6fc9d1)
