### PR TITLE
fixed code filed for iOS devices, and reduced card options dropdown h…

### DIFF
--- a/apps/mobile/app/components/CodeField.tsx
+++ b/apps/mobile/app/components/CodeField.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-native/no-inline-styles */
 /* eslint-disable react-native/no-color-literals */
 import React, { FC, useEffect, useState } from 'react';
-import { View, StyleSheet, Text } from 'react-native';
+import { View, StyleSheet, Text, Dimensions, PixelRatio, Platform } from 'react-native';
 import { colors, typography, useAppTheme } from '../theme';
 import { CodeField, Cursor, useBlurOnFulfill, useClearByFocusCell } from 'react-native-confirmation-code-field';
 
@@ -11,6 +11,9 @@ interface ICodeField {
 	length?: number;
 	defaultValue?: string;
 }
+
+const { height: screeHeight } = Dimensions.get('screen');
+const screenDimension = PixelRatio.get();
 
 export const CodeInputField: FC<ICodeField> = (props) => {
 	const { onChange, editable, length = 6 } = props;
@@ -54,7 +57,8 @@ export const CodeInputField: FC<ICodeField> = (props) => {
 								flexDirection: 'column',
 								justifyContent: 'center',
 								alignItems: 'center',
-								lineHeight: 52
+								lineHeight:
+									Platform.OS === 'ios' ? screeHeight * 0.055 * (screenDimension / 3) : undefined
 							}
 						]}
 						onLayout={getCellOnLayoutHandler(index)}

--- a/apps/mobile/app/screens/Authenticated/TeamScreen/components/ListCardItem.tsx
+++ b/apps/mobile/app/screens/Authenticated/TeamScreen/components/ListCardItem.tsx
@@ -201,7 +201,7 @@ const ListCardItem: React.FC<Props> = observer((props) => {
 								...(props.index !== props.openMenuIndex ? { display: 'none' } : {})
 							}}
 						>
-							<View style={{ marginVertical: 10 }}>
+							<View style={{ marginVertical: 8 }}>
 								{(memberInfo.isAuthTeamManager || memberInfo.isAuthUser) && taskEdition.task && (
 									<ListItem
 										textStyle={[styles.dropdownTxt, { color: colors.primary }]}
@@ -348,7 +348,7 @@ const styles = StyleSheet.create({
 		color: '#282048',
 		fontFamily: typography.primary.semiBold,
 		fontSize: 14,
-		height: 38,
+		height: 36,
 		width: '100%'
 	},
 	estimate: {


### PR DESCRIPTION
…eight
#1831
The overlay issue wasn't present even in small devices as Pixel 3. Reduced height of the dropdown, so now should fit in Samsun S22 Ultra:
![image](https://github.com/ever-co/ever-teams/assets/124465103/cb7b66e3-ff88-4f2c-9348-242cbfe30c73)

#1865
iPhone 13 Pro Max:
![image](https://github.com/ever-co/ever-teams/assets/124465103/261d42a6-d96e-4577-a3e5-c6fdc3066cdc)

Samsung S8+:
![image](https://github.com/ever-co/ever-teams/assets/124465103/4526c53d-52a7-4b39-98e8-9e8c866edc54)

Pixel 3:
![image](https://github.com/ever-co/ever-teams/assets/124465103/88193a32-5736-41c6-b669-575d8e86b84d)
