### PR TITLE
Bug/timer screen teams dropdown and estimate task

### DIFF
--- a/apps/mobile/app/components/TeamDropdown/DropDownSection.tsx
+++ b/apps/mobile/app/components/TeamDropdown/DropDownSection.tsx
@@ -41,10 +41,18 @@ const DropDownSection: FC<Props> = observer(function DropDownSection({
 
 	const others = teams.filter((t) => t.id !== activeTeamId);
 
-	const { colors } = useAppTheme();
+	const { colors, dark } = useAppTheme();
 	return (
 		<View
-			style={[styles.mainContainer, { backgroundColor: colors.background, shadowColor: 'rgba(0, 0, 0, 0.12)' }]}
+			style={[
+				styles.mainContainer,
+				{
+					backgroundColor: colors.background,
+					shadowColor: 'rgba(0, 0, 0, 0.12)',
+					borderWidth: dark ? 1 : 0,
+					borderColor: colors.border
+				}
+			]}
 		>
 			{/* <View style={styles.indDropDown}>
 				<View style={{ flexDirection: "row", alignItems: "center" }}>

--- a/apps/mobile/app/screens/Authenticated/TeamScreen/components/ListCardItem.tsx
+++ b/apps/mobile/app/screens/Authenticated/TeamScreen/components/ListCardItem.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react-native/no-color-literals */
 /* eslint-disable react-native/no-inline-styles */
 import React, { useState } from 'react';
-import { View, ViewStyle, TouchableOpacity, StyleSheet, TouchableWithoutFeedback, Platform } from 'react-native';
+import { View, ViewStyle, TouchableOpacity, StyleSheet, TouchableWithoutFeedback } from 'react-native';
 import { Ionicons, Entypo } from '@expo/vector-icons';
 
 // COMPONENTS
@@ -87,14 +87,7 @@ export const ListItemContent: React.FC<IcontentProps> = observer(({ memberInfo, 
 					</View>
 				</View>
 				<View style={[styles.times, { borderTopColor: colors.divider }]}>
-					<TouchableWithoutFeedback
-						onPress={(event) => {
-							if (Platform.OS === 'android' && taskEdition.estimateEditMode) {
-								event.stopPropagation();
-								taskEdition.setEstimateEditMode(false);
-							}
-						}}
-					>
+					<TouchableWithoutFeedback>
 						<View
 							style={{
 								flexDirection: 'row',
@@ -114,7 +107,11 @@ export const ListItemContent: React.FC<IcontentProps> = observer(({ memberInfo, 
 							</View>
 
 							{memberInfo.memberTask && taskEdition.estimateEditMode ? (
-								<View style={styles.estimate} ref={clickOutsideTaskEstimationInputRef}>
+								<View
+									style={styles.estimate}
+									collapsable={false}
+									ref={clickOutsideTaskEstimationInputRef}
+								>
 									<EstimateTime
 										setEditEstimate={taskEdition.setEstimateEditMode}
 										currentTask={memberInfo.memberTask}

--- a/apps/mobile/app/screens/Authenticated/TimerScreen/components/TimerTaskSection.tsx
+++ b/apps/mobile/app/screens/Authenticated/TimerScreen/components/TimerTaskSection.tsx
@@ -160,7 +160,8 @@ const TimerTaskSection = observer(
 									>
 										{translate('myWorkScreen.estimateLabel')} :{' '}
 									</Text>
-									<EstimateTime currentTask={activeTask} />
+
+									<EstimateTime timerScreen={true} currentTask={activeTask} />
 								</View>
 								<TaskSize
 									task={activeTask}


### PR DESCRIPTION
#1929

Added border to the dropdown in dark theme:
![image](https://github.com/ever-co/ever-teams/assets/124465103/674a4f00-4159-4a53-9571-20bb5c4dff80)

Fixed estimate time overlay when editing, and added functionality to cancel edit mode when pressed outside:

iPhone 13 Pro Max:
https://github.com/ever-co/ever-teams/assets/124465103/dc1b837e-dfb0-4ba3-9ad9-9796e18c0597

Samsung S8+:
https://github.com/ever-co/ever-teams/assets/124465103/1dda5dea-aeed-4cf7-9b98-6578b355aa4f

Before:
![image](https://github.com/ever-co/ever-teams/assets/124465103/e97ed70a-b963-41e6-9825-089a7e85e83d)
![image](https://github.com/ever-co/ever-teams/assets/124465103/c83a75db-4c12-4611-8f68-c1cc3dfe6fee)

