### PR TITLE
Feat/Next-Frontend APIs

### DIFF
--- a/apps/web/app/api/integration/github/metadata/route.ts
+++ b/apps/web/app/api/integration/github/metadata/route.ts
@@ -20,5 +20,5 @@ export async function GET(req: Request) {
 		access_token
 	);
 
-	return $res(response);
+	return $res(response.data);
 }

--- a/apps/web/app/api/integration/github/oauth/route.ts
+++ b/apps/web/app/api/integration/github/oauth/route.ts
@@ -20,5 +20,5 @@ export async function POST(req: Request) {
 		access_token
 	);
 
-	return $res(response);
+	return $res(response.data);
 }

--- a/apps/web/app/api/integration/github/repositories/route.ts
+++ b/apps/web/app/api/integration/github/repositories/route.ts
@@ -20,5 +20,5 @@ export async function GET(req: Request) {
 		access_token
 	);
 
-	return $res(response);
+	return $res(response.data);
 }

--- a/apps/web/app/api/integration/github/repository/sync/route.ts
+++ b/apps/web/app/api/integration/github/repository/sync/route.ts
@@ -18,5 +18,5 @@ export async function POST(req: Request) {
 		access_token
 	);
 
-	return $res(response);
+	return $res(response.data);
 }

--- a/apps/web/app/api/issue-types/route.ts
+++ b/apps/web/app/api/issue-types/route.ts
@@ -18,7 +18,9 @@ export async function GET(req: Request) {
 		organizationTeamId: (organizationTeamId as string) || null
 	};
 
-	return $res(await getIssueTypesListRequest(par, access_token));
+	const { data } = await getIssueTypesListRequest(par, access_token);
+
+	return $res(data);
 }
 
 export async function POST(req: Request) {

--- a/apps/web/app/api/languages/route.ts
+++ b/apps/web/app/api/languages/route.ts
@@ -13,5 +13,7 @@ export async function GET(req: Request) {
 		tenantId
 	};
 
-	return $res(await getLanguageListRequest(par, access_token));
+	const { data } = await getLanguageListRequest(par, access_token);
+
+	return $res(data);
 }

--- a/apps/web/app/api/tags/level/route.ts
+++ b/apps/web/app/api/tags/level/route.ts
@@ -18,5 +18,7 @@ export async function GET(req: Request) {
 		organizationTeamId: (organizationTeamId as string) || null
 	};
 
-	return $res(await getTaskLabelsListRequest(par, access_token));
+	const { data } = await getTaskLabelsListRequest(par, access_token);
+
+	return $res(data);
 }

--- a/apps/web/app/api/task-priorities/route.ts
+++ b/apps/web/app/api/task-priorities/route.ts
@@ -19,7 +19,9 @@ export async function GET(req: Request) {
 		organizationTeamId: (organizationTeamId as string) || null
 	};
 
-	return $res(await getTaskPrioritiesListRequest(par, access_token));
+	const { data } = await getTaskPrioritiesListRequest(par, access_token);
+
+	return $res(data);
 }
 
 export async function POST(req: Request) {

--- a/apps/web/app/api/task-related-issue-types/route.ts
+++ b/apps/web/app/api/task-related-issue-types/route.ts
@@ -22,7 +22,9 @@ export async function GET(req: Request) {
 		organizationTeamId: (organizationTeamId as string) || null
 	};
 
-	return $res(await getTaskRelatedIssueTypeListRequest(par, access_token));
+	const { data } = await getTaskRelatedIssueTypeListRequest(par, access_token);
+
+	return $res(data);
 }
 
 export async function POST(req: Request) {

--- a/apps/web/app/api/task-sizes/route.ts
+++ b/apps/web/app/api/task-sizes/route.ts
@@ -19,7 +19,9 @@ export async function GET(req: Request) {
 		organizationTeamId: (organizationTeamId as string) || null
 	};
 
-	return $res(await getTaskSizesListRequest(par, access_token));
+	const { data } = await getTaskSizesListRequest(par, access_token);
+
+	return $res(data);
 }
 
 export async function POST(req: Request) {

--- a/apps/web/app/api/task-statuses/route.ts
+++ b/apps/web/app/api/task-statuses/route.ts
@@ -19,7 +19,9 @@ export async function GET(req: Request) {
 		organizationTeamId: (organizationTeamId as string) || null
 	};
 
-	return $res(await getTaskStatusListRequest(par, access_token));
+	const { data } = await getTaskStatusListRequest(par, access_token);
+
+	return $res(data);
 }
 
 export async function POST(req: Request) {

--- a/apps/web/app/api/task-versions/route.ts
+++ b/apps/web/app/api/task-versions/route.ts
@@ -19,7 +19,9 @@ export async function GET(req: Request) {
 		organizationTeamId: (organizationTeamId as string) || null
 	};
 
-	return $res(await getTaskVersionListRequest(par, access_token));
+	const { data } = await getTaskVersionListRequest(par, access_token);
+
+	return $res(data);
 }
 
 export async function POST(req: Request) {

--- a/apps/web/app/api/user/[id]/route.ts
+++ b/apps/web/app/api/user/[id]/route.ts
@@ -11,12 +11,13 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 	if (!user) return $res('Unauthorized');
 
 	const { id: userId } = params;
-	return $res(
-		await getTaskCreator({
-			userId: userId as string,
-			bearer_token: access_token
-		})
-	);
+
+	const { data } = await getTaskCreator({
+		userId: userId as string,
+		bearer_token: access_token
+	});
+
+	return $res(data);
 }
 
 export async function PUT(req: Request) {

--- a/apps/web/app/hooks/features/useEmployee.ts
+++ b/apps/web/app/hooks/features/useEmployee.ts
@@ -18,9 +18,10 @@ export const useEmployee = () => {
 		if (!user?.tenantId) {
 			return;
 		}
-		getWorkingEmployeeQueryCall(user?.tenantId, user?.employee.organizationId).then((data) => {
-			if (data?.data?.items && data?.data?.items?.length) {
-				const items = data.data.items || [];
+		getWorkingEmployeeQueryCall(user?.tenantId, user?.employee.organizationId).then(({ data }) => {
+			if (data?.items && data?.items?.length) {
+				const items = data.items || [];
+
 				setWorkingEmployees(items);
 				setWorkingEmployeesEmail(items.map((item: any) => item.user?.email || ''));
 			}

--- a/apps/web/app/hooks/features/useIssueTypes.ts
+++ b/apps/web/app/hooks/features/useIssueTypes.ts
@@ -32,7 +32,7 @@ export function useIssueType() {
 
 		queryCall(user?.tenantId as string, user?.employee?.organizationId as string, activeTeamId || null).then(
 			(res) => {
-				setIssueTypes(res?.data?.data?.items || []);
+				setIssueTypes(res.data?.items || []);
 				return res;
 			}
 		);
@@ -49,7 +49,7 @@ export function useIssueType() {
 								user?.employee?.organizationId as string,
 								activeTeamId || null
 							).then((res) => {
-								setIssueTypes(res?.data?.data?.items || []);
+								setIssueTypes(res?.data?.items || []);
 								return res;
 							});
 						}
@@ -72,7 +72,7 @@ export function useIssueType() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setIssueTypes(res?.data?.data?.items || []);
+						setIssueTypes(res?.data?.items || []);
 						return res;
 					});
 					return res;
@@ -93,7 +93,7 @@ export function useIssueType() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setIssueTypes(res?.data?.data?.items || []);
+						setIssueTypes(res?.data?.items || []);
 						return res;
 					});
 					return res;

--- a/apps/web/app/hooks/features/useLanguageSettings.ts
+++ b/apps/web/app/hooks/features/useLanguageSettings.ts
@@ -40,7 +40,7 @@ export function useLanguageSettings() {
 	const loadLanguagesData = useCallback(() => {
 		setActiveLanguageId(getActiveLanguageIdCookie());
 		if (user) {
-			return queryCall(user.role.isSystem).then((res) => {				
+			return queryCall(user.role.isSystem).then((res) => {
 				setLanguages(
 					res?.data?.items.filter((item: any) => APPLICATION_LANGUAGES_CODE.includes(item.code)) || []
 				);

--- a/apps/web/app/hooks/features/useTaskLabels.ts
+++ b/apps/web/app/hooks/features/useTaskLabels.ts
@@ -45,8 +45,8 @@ export function useTaskLabels() {
 			user?.employee?.organizationId as string,
 			activeTeamId || teamId || null
 		).then((res) => {
-			if (!isEqual(res?.data?.data?.items || [], taskLabels)) {
-				setTaskLabels(res?.data?.data?.items || []);
+			if (!isEqual(res?.data?.items || [], taskLabels)) {
+				setTaskLabels(res?.data?.items || []);
 			}
 
 			return res;
@@ -75,7 +75,7 @@ export function useTaskLabels() {
 							user?.employee?.organizationId as string,
 							activeTeamId || null
 						).then((res) => {
-							setTaskLabels(res?.data?.data?.items || []);
+							setTaskLabels(res?.data?.items || []);
 							return res;
 						});
 					}
@@ -97,7 +97,7 @@ export function useTaskLabels() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskLabels(res?.data?.data?.items || []);
+						setTaskLabels(res?.data?.items || []);
 						return res;
 					});
 					return res;
@@ -116,7 +116,7 @@ export function useTaskLabels() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskLabels(res?.data?.data?.items || []);
+						setTaskLabels(res?.data?.items || []);
 						return res;
 					});
 					return res;

--- a/apps/web/app/hooks/features/useTaskPriorities.ts
+++ b/apps/web/app/hooks/features/useTaskPriorities.ts
@@ -46,8 +46,8 @@ export function useTaskPriorities() {
 			user?.employee?.organizationId as string,
 			activeTeamId || teamId || null
 		).then((res) => {
-			if (!isEqual(res?.data?.data?.items || [], taskPriorities)) {
-				setTaskPriorities(res?.data?.data?.items || []);
+			if (!isEqual(res?.data?.items || [], taskPriorities)) {
+				setTaskPriorities(res?.data?.items || []);
 			}
 
 			return res;
@@ -83,7 +83,7 @@ export function useTaskPriorities() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskPriorities(res?.data?.data?.items || []);
+						setTaskPriorities(res?.data?.items || []);
 						return res;
 					});
 					return res;
@@ -102,7 +102,7 @@ export function useTaskPriorities() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskPriorities(res?.data?.data?.items || []);
+						setTaskPriorities(res?.data?.items || []);
 						return res;
 					});
 					return res;

--- a/apps/web/app/hooks/features/useTaskRelatedIssueType.ts
+++ b/apps/web/app/hooks/features/useTaskRelatedIssueType.ts
@@ -51,8 +51,8 @@ export function useTaskRelatedIssueType() {
 			user?.employee?.organizationId as string,
 			activeTeamId || teamId || null
 		).then((res) => {
-			if (!isEqual(res?.data?.data?.items || [], taskRelatedIssueType)) {
-				setTaskRelatedIssueType(res?.data?.data?.items || []);
+			if (!isEqual(res?.data?.items || [], taskRelatedIssueType)) {
+				setTaskRelatedIssueType(res?.data?.items || []);
 			}
 			return res;
 		});
@@ -86,7 +86,7 @@ export function useTaskRelatedIssueType() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskRelatedIssueType(res?.data?.data?.items || []);
+						setTaskRelatedIssueType(res?.data?.items || []);
 						return res;
 					});
 					return res;
@@ -105,7 +105,7 @@ export function useTaskRelatedIssueType() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskRelatedIssueType(res?.data?.data?.items || []);
+						setTaskRelatedIssueType(res?.data?.items || []);
 						return res;
 					});
 					return res;

--- a/apps/web/app/hooks/features/useTaskSizes.ts
+++ b/apps/web/app/hooks/features/useTaskSizes.ts
@@ -43,8 +43,8 @@ export function useTaskSizes() {
 			user?.employee?.organizationId as string,
 			activeTeamId || teamId || null
 		).then((res) => {
-			if (!isEqual(res?.data?.data?.items || [], taskSizes)) {
-				setTaskSizes(res?.data?.data?.items || []);
+			if (!isEqual(res?.data?.items || [], taskSizes)) {
+				setTaskSizes(res?.data?.items || []);
 			}
 
 			return res;
@@ -80,7 +80,7 @@ export function useTaskSizes() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskSizes(res?.data?.data?.items || []);
+						setTaskSizes(res?.data?.items || []);
 						return res;
 					});
 					return res;
@@ -99,7 +99,7 @@ export function useTaskSizes() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskSizes(res?.data?.data?.items || []);
+						setTaskSizes(res?.data?.items || []);
 						return res;
 					});
 					return res;

--- a/apps/web/app/hooks/features/useTaskStatus.ts
+++ b/apps/web/app/hooks/features/useTaskStatus.ts
@@ -44,8 +44,8 @@ export function useTaskStatus() {
 			user?.employee?.organizationId as string,
 			activeTeamId || teamId || null
 		).then((res) => {
-			if (!isEqual(res?.data?.data?.items || [], taskStatus)) {
-				setTaskStatus(res?.data?.data?.items || []);
+			if (!isEqual(res.data?.items || [], taskStatus)) {
+				setTaskStatus(res.data?.items || []);
 			}
 			return res;
 		});
@@ -79,7 +79,7 @@ export function useTaskStatus() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskStatus(res?.data?.data?.items || []);
+						setTaskStatus(res.data?.items || []);
 						return res;
 					});
 					return res;
@@ -98,7 +98,7 @@ export function useTaskStatus() {
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskStatus(res?.data?.data?.items || []);
+						setTaskStatus(res.data?.items || []);
 						return res;
 					});
 					return res;

--- a/apps/web/app/hooks/features/useTaskVersion.ts
+++ b/apps/web/app/hooks/features/useTaskVersion.ts
@@ -45,8 +45,8 @@ export function useTaskVersion(onVersionCreated?: (version: ITaskVersionCreate) 
 			user?.employee?.organizationId as string,
 			activeTeamId || teamId || null
 		).then((res) => {
-			if (!isEqual(res?.data?.data?.items || [], taskVersion)) {
-				setTaskVersion(res?.data?.data?.items || []);
+			if (!isEqual(res.data?.items || [], taskVersion)) {
+				setTaskVersion(res.data?.items || []);
 			}
 			return res;
 		});
@@ -80,7 +80,7 @@ export function useTaskVersion(onVersionCreated?: (version: ITaskVersionCreate) 
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskVersion(res?.data?.data?.items || []);
+						setTaskVersion(res.data?.items || []);
 						return res;
 					});
 					return res;
@@ -101,7 +101,7 @@ export function useTaskVersion(onVersionCreated?: (version: ITaskVersionCreate) 
 						user?.employee?.organizationId as string,
 						activeTeamId || null
 					).then((res) => {
-						setTaskVersion(res?.data?.data?.items || []);
+						setTaskVersion(res.data?.items || []);
 						return res;
 					});
 					return res;

--- a/apps/web/app/hooks/features/useTeamInvitations.ts
+++ b/apps/web/app/hooks/features/useTeamInvitations.ts
@@ -65,7 +65,7 @@ export function useTeamInvitations() {
 				},
 				user?.tenantId as string
 			).then((res) => {
-				setTeamInvitations((prev) => [...prev, ...(res.data?.items || [])]);
+				// setTeamInvitations((prev) => [...prev, ...(res.data?.items || [])]);
 				return res;
 			});
 		},

--- a/apps/web/app/hooks/features/useTeamInvitations.ts
+++ b/apps/web/app/hooks/features/useTeamInvitations.ts
@@ -65,7 +65,7 @@ export function useTeamInvitations() {
 				},
 				user?.tenantId as string
 			).then((res) => {
-				// setTeamInvitations((prev) => [...prev, ...(res.data?.items || [])]);
+				setTeamInvitations((prev) => [...prev, ...(res.data?.items || [])]);
 				return res;
 			});
 		},

--- a/apps/web/app/hooks/features/useTimeDailyActivity.ts
+++ b/apps/web/app/hooks/features/useTimeDailyActivity.ts
@@ -29,7 +29,7 @@ export function useTimeDailyActivity(type: string) {
 			.then((response) => {
 				if (response.data) {
 					console.log(response.data);
-					setVisitedApps(response.data?.data);
+					setVisitedApps(response.data);
 				}
 			})
 			.catch((err) => console.log(err));

--- a/apps/web/app/hooks/features/useTimeSlot.ts
+++ b/apps/web/app/hooks/features/useTimeSlot.ts
@@ -26,23 +26,23 @@ export function useTimeSlots(ids?: string[]) {
 			todayStart
 		}).then((response) => {
 			if (response.data) {
-				setTimeSlots(response.data?.data[0]?.timeSlots);
+				setTimeSlots(response.data.timeSlots);
 			}
 		});
 	}, [queryCall, setTimeSlots, user]);
 
 	const deleteTimeSlots = useCallback(() => {
-		if(ids?.length){
+		if (ids?.length) {
 			queryDeleteCall({
-			tenantId: user?.tenantId ?? '',
-			organizationId: user?.employee.organizationId ?? '',
-			ids: ids
-		}).then(() => {
-			const updatedSlots = timeSlots.filter((el) => (!ids?.includes(el.id) ? el : null));
-			setTimeSlots(updatedSlots);
-		});
-	}
-	}, [queryDeleteCall, setTimeSlots,ids, timeSlots, user]);
+				tenantId: user?.tenantId ?? '',
+				organizationId: user?.employee.organizationId ?? '',
+				ids: ids
+			}).then(() => {
+				const updatedSlots = timeSlots.filter((el) => (!ids?.includes(el.id) ? el : null));
+				setTimeSlots(updatedSlots);
+			});
+		}
+	}, [queryDeleteCall, setTimeSlots, ids, timeSlots, user]);
 
 	useEffect(() => {
 		getTimeSlots();

--- a/apps/web/app/hooks/integrations/useGitHubIntegration.ts
+++ b/apps/web/app/hooks/integrations/useGitHubIntegration.ts
@@ -84,19 +84,19 @@ export function useGitHubIntegration() {
 				installationId,
 				repository
 			}).then((response) => {
-				if (response.data.data.id) {
+				if (response.data.id) {
 					editOrganizationProjectSettingAPI(
 						projectId,
 						{
 							tenantId,
 							organizationId,
-							repositoryId: response.data.data.id
+							repositoryId: response.data.id
 						},
 						tenantId
 					);
 				}
 
-				return response.data.data;
+				return response.data;
 			});
 		},
 		[syncGitHubRepositoryQueryCall]

--- a/apps/web/app/hooks/integrations/useGitHubIntegration.ts
+++ b/apps/web/app/hooks/integrations/useGitHubIntegration.ts
@@ -55,9 +55,9 @@ export function useGitHubIntegration() {
 	const metaData = useCallback(
 		(integrationId: string) => {
 			return metadataQueryCall(integrationId).then((response) => {
-				setIntegrationGithubMetadata(response.data.data);
+				setIntegrationGithubMetadata(response.data);
 
-				return response.data.data;
+				return response.data;
 			});
 		},
 		[metadataQueryCall, setIntegrationGithubMetadata]

--- a/apps/web/app/hooks/integrations/useGitHubIntegration.ts
+++ b/apps/web/app/hooks/integrations/useGitHubIntegration.ts
@@ -65,9 +65,9 @@ export function useGitHubIntegration() {
 	const getRepositories = useCallback(
 		(integrationId: string) => {
 			return repositoriesQueryCall(integrationId).then((response) => {
-				setIntegrationGithubRepositories(response.data.data);
+				setIntegrationGithubRepositories(response.data);
 
-				return response.data.data;
+				return response.data;
 			});
 		},
 		[repositoriesQueryCall, setIntegrationGithubRepositories]

--- a/apps/web/app/services/client/api/activity/activity.ts
+++ b/apps/web/app/services/client/api/activity/activity.ts
@@ -1,5 +1,6 @@
 import { get } from '@app/services/client/axios';
 import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
+import { ITimerApps } from '@app/interfaces/timer/ITimerApp';
 
 export async function getTimerDailyRequestAPI({
 	tenantId,
@@ -29,7 +30,5 @@ export async function getTimerDailyRequestAPI({
 		? `/timesheet/activity/daily?${query.toString()}`
 		: `/timer/daily?${query.toString()}`;
 
-	const data = await get(endpoint, true);
-
-	return data;
+	return get<ITimerApps[]>(endpoint);
 }

--- a/apps/web/app/services/client/api/activity/time-slots.ts
+++ b/apps/web/app/services/client/api/activity/time-slots.ts
@@ -1,5 +1,6 @@
 import { get } from '@app/services/client/axios';
 import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
+import { ITimerSlotDataRequest } from '@app/interfaces/timer/ITimerSlot';
 
 export async function getTimerLogsRequestAPI({
 	tenantId,
@@ -26,9 +27,7 @@ export async function getTimerLogsRequestAPI({
 		? `/timesheet/statistics/time-slots?${query.toString()}`
 		: `/timer/slots?${query.toString()}`;
 
-	const data = await get(endpoint, true);
-
-	return data;
+	return get<ITimerSlotDataRequest>(endpoint);
 }
 
 export async function deleteTimerLogsRequestAPI({
@@ -53,7 +52,5 @@ export async function deleteTimerLogsRequestAPI({
 		? `/timesheet/statistics/time-slots?${query.toString()}${idParams}`
 		: `/timer/slots?${query.toString()}${idParams}`;
 
-	const data = await get(endpoint, true);
-
-	return data;
+	return get(endpoint);
 }

--- a/apps/web/app/services/client/api/auth.ts
+++ b/apps/web/app/services/client/api/auth.ts
@@ -1,5 +1,5 @@
 import { getRefreshTokenCookie } from '@app/helpers/cookies';
-import { ISuccessResponse } from '@app/interfaces';
+import { ISuccessResponse, IUser } from '@app/interfaces';
 import { ILoginResponse, IRegisterDataAPI, ISigninEmailConfirmResponse } from '@app/interfaces/IAuthentication';
 import api, { get } from '../axios';
 import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
@@ -43,9 +43,9 @@ export const getAuthenticatedUserDataAPI = async () => {
 	const query = new URLSearchParams(params);
 
 	const endpoint = `/user/me?${query.toString()}`;
-	const data = await get(endpoint, true);
+	const data = await get<IUser>(endpoint);
 
-	return GAUZY_API_BASE_SERVER_URL.value ? data.data : data;
+	return GAUZY_API_BASE_SERVER_URL.value ? data : data;
 };
 
 export const verifyUserEmailByCodeAPI = (code: string) => {

--- a/apps/web/app/services/client/api/auth.ts
+++ b/apps/web/app/services/client/api/auth.ts
@@ -2,7 +2,6 @@ import { getRefreshTokenCookie } from '@app/helpers/cookies';
 import { ISuccessResponse, IUser } from '@app/interfaces';
 import { ILoginResponse, IRegisterDataAPI, ISigninEmailConfirmResponse } from '@app/interfaces/IAuthentication';
 import api, { get } from '../axios';
-import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
 
 export const signInWithEmailAndCodeAPI = (email: string, code: string) => {
 	return api.post<ILoginResponse>(`/auth/login`, {
@@ -26,13 +25,14 @@ export const sendAuthCodeAPI = (email: string) => {
 		email
 	});
 };
+
 export const signInEmailAPI = (email: string) => {
 	return api.post<{ status: number; message: string }>(`/auth/signin-email`, {
 		email
 	});
 };
 
-export const getAuthenticatedUserDataAPI = async () => {
+export const getAuthenticatedUserDataAPI = () => {
 	const params = {} as { [x: string]: string };
 	const relations = ['employee', 'role', 'tenant'];
 
@@ -42,10 +42,7 @@ export const getAuthenticatedUserDataAPI = async () => {
 
 	const query = new URLSearchParams(params);
 
-	const endpoint = `/user/me?${query.toString()}`;
-	const data = await get<IUser>(endpoint);
-
-	return GAUZY_API_BASE_SERVER_URL.value ? data : data;
+	return get<IUser>(`/user/me?${query.toString()}`);
 };
 
 export const verifyUserEmailByCodeAPI = (code: string) => {

--- a/apps/web/app/services/client/api/employee.ts
+++ b/apps/web/app/services/client/api/employee.ts
@@ -1,4 +1,5 @@
 import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
+import { IWorkingEmployee, PaginationResponse } from '@app/interfaces';
 import { get } from '../axios';
 
 export async function getWorkingEmployeesAPI(tenantId: string, organizationId: string) {
@@ -10,7 +11,6 @@ export async function getWorkingEmployeesAPI(tenantId: string, organizationId: s
 	const query = new URLSearchParams(params);
 
 	const endpoint = GAUZY_API_BASE_SERVER_URL.value ? `/employee/pagination?${query.toString()}` : '/employee/working';
-	const data = await get(endpoint, true, { tenantId });
 
-	return GAUZY_API_BASE_SERVER_URL.value ? data.data : data;
+	return get<PaginationResponse<IWorkingEmployee>>(endpoint, { tenantId });
 }

--- a/apps/web/app/services/client/api/integrations/github.ts
+++ b/apps/web/app/services/client/api/integrations/github.ts
@@ -1,7 +1,7 @@
 import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
 import { getOrganizationIdCookie, getTenantIdCookie } from '@app/helpers';
 import { IGithubMetadata, IGithubRepositories } from '@app/interfaces';
-import api, { get, post } from '../../axios';
+import { get, post } from '../../axios';
 
 // TODO
 export function installGitHubIntegrationAPI(body: any) {
@@ -40,5 +40,5 @@ export function getGithubIntegrationRepositoriesAPI(integrationId: string) {
 }
 
 export function syncGitHubRepositoryAPI(body: any) {
-	return api.post<any>('/integration/github/repository/sync', body);
+	return post<any>('/integration/github/repository/sync', body);
 }

--- a/apps/web/app/services/client/api/integrations/github.ts
+++ b/apps/web/app/services/client/api/integrations/github.ts
@@ -1,5 +1,7 @@
+import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
+import { getOrganizationIdCookie, getTenantIdCookie } from '@app/helpers';
 import { CreateResponse, IGithubMetadata, IGithubRepositories } from '@app/interfaces';
-import api, { post } from '../../axios';
+import api, { get, post } from '../../axios';
 
 // TODO
 export function installGitHubIntegrationAPI(body: any) {
@@ -8,12 +10,25 @@ export function installGitHubIntegrationAPI(body: any) {
 
 // TODO
 export function oAuthEndpointAuthorizationAPI(body: any) {
-	return api.post<any>('/integration/github/oauth', body);
+	return post<any>('/integration/github/oauth', body);
 }
 
 export function getGithubIntegrationMetadataAPI(integrationId: string) {
-	return api.get<CreateResponse<IGithubMetadata>>(`/integration/github/metadata?integrationId=${integrationId}`);
+	if (GAUZY_API_BASE_SERVER_URL.value) {
+		const tenantId = getTenantIdCookie();
+		const organizationId = getOrganizationIdCookie();
+
+		const query = new URLSearchParams({
+			tenantId,
+			organizationId
+		});
+
+		return get<IGithubMetadata>(`/integration/github/${integrationId}/metadata${query.toString()}`);
+	}
+
+	return api.get<IGithubMetadata>(`/integration/github/metadata?integrationId=${integrationId}`);
 }
+
 export function getGithubIntegrationRepositoriesAPI(integrationId: string) {
 	return api.get<CreateResponse<IGithubRepositories>>(
 		`/integration/github/repositories?integrationId=${integrationId}`

--- a/apps/web/app/services/client/api/integrations/github.ts
+++ b/apps/web/app/services/client/api/integrations/github.ts
@@ -1,6 +1,6 @@
 import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
 import { getOrganizationIdCookie, getTenantIdCookie } from '@app/helpers';
-import { CreateResponse, IGithubMetadata, IGithubRepositories } from '@app/interfaces';
+import { IGithubMetadata, IGithubRepositories } from '@app/interfaces';
 import api, { get, post } from '../../axios';
 
 // TODO
@@ -15,12 +15,9 @@ export function oAuthEndpointAuthorizationAPI(body: any) {
 
 export function getGithubIntegrationMetadataAPI(integrationId: string) {
 	if (GAUZY_API_BASE_SERVER_URL.value) {
-		const tenantId = getTenantIdCookie();
-		const organizationId = getOrganizationIdCookie();
-
 		const query = new URLSearchParams({
-			tenantId,
-			organizationId
+			tenantId: getTenantIdCookie(),
+			organizationId: getOrganizationIdCookie()
 		});
 
 		return get<IGithubMetadata>(`/integration/github/${integrationId}/metadata${query.toString()}`);
@@ -30,9 +27,16 @@ export function getGithubIntegrationMetadataAPI(integrationId: string) {
 }
 
 export function getGithubIntegrationRepositoriesAPI(integrationId: string) {
-	return api.get<CreateResponse<IGithubRepositories>>(
-		`/integration/github/repositories?integrationId=${integrationId}`
-	);
+	if (GAUZY_API_BASE_SERVER_URL.value) {
+		const query = new URLSearchParams({
+			tenantId: getTenantIdCookie(),
+			organizationId: getOrganizationIdCookie()
+		});
+
+		return get<IGithubRepositories>(`/integration/github/${integrationId}/repositories${query.toString()}`);
+	}
+
+	return api.get<IGithubRepositories>(`/integration/github/repositories?integrationId=${integrationId}`);
 }
 
 export function syncGitHubRepositoryAPI(body: any) {

--- a/apps/web/app/services/client/api/integrations/github.ts
+++ b/apps/web/app/services/client/api/integrations/github.ts
@@ -14,29 +14,29 @@ export function oAuthEndpointAuthorizationAPI(body: any) {
 }
 
 export function getGithubIntegrationMetadataAPI(integrationId: string) {
-	if (GAUZY_API_BASE_SERVER_URL.value) {
-		const query = new URLSearchParams({
-			tenantId: getTenantIdCookie(),
-			organizationId: getOrganizationIdCookie()
-		});
+	const query = new URLSearchParams({
+		tenantId: getTenantIdCookie(),
+		organizationId: getOrganizationIdCookie()
+	});
 
-		return get<IGithubMetadata>(`/integration/github/${integrationId}/metadata${query.toString()}`);
-	}
+	const endpoint = GAUZY_API_BASE_SERVER_URL.value
+		? `/integration/github/${integrationId}/metadata${query.toString()}`
+		: `/integration/github/metadata?integrationId=${integrationId}`;
 
-	return api.get<IGithubMetadata>(`/integration/github/metadata?integrationId=${integrationId}`);
+	return get<IGithubMetadata>(endpoint);
 }
 
 export function getGithubIntegrationRepositoriesAPI(integrationId: string) {
-	if (GAUZY_API_BASE_SERVER_URL.value) {
-		const query = new URLSearchParams({
-			tenantId: getTenantIdCookie(),
-			organizationId: getOrganizationIdCookie()
-		});
+	const query = new URLSearchParams({
+		tenantId: getTenantIdCookie(),
+		organizationId: getOrganizationIdCookie()
+	});
 
-		return get<IGithubRepositories>(`/integration/github/${integrationId}/repositories${query.toString()}`);
-	}
+	const endpoint = GAUZY_API_BASE_SERVER_URL.value
+		? `/integration/github/${integrationId}/repositories${query.toString()}`
+		: `/integration/github/repositories?integrationId=${integrationId}`;
 
-	return api.get<IGithubRepositories>(`/integration/github/repositories?integrationId=${integrationId}`);
+	return get<IGithubRepositories>(endpoint);
 }
 
 export function syncGitHubRepositoryAPI(body: any) {

--- a/apps/web/app/services/client/api/invite.ts
+++ b/apps/web/app/services/client/api/invite.ts
@@ -1,8 +1,8 @@
 import { PaginationResponse } from '@app/interfaces/IDataResponse';
-import { IInvitation, MyInvitationActionEnum, CreateResponse, IInviteCreate, IRole } from '@app/interfaces';
-import { GAUZY_API_BASE_SERVER_URL, INVITE_CALLBACK_URL } from '@app/constants';
+import { IInvitation, MyInvitationActionEnum, CreateResponse, IInviteCreate, IMyInvitations } from '@app/interfaces';
+import { INVITE_CALLBACK_URL } from '@app/constants';
 import api, { get, post } from '../axios';
-import { AxiosResponse } from 'axios';
+import { ITimerSlotDataRequest } from '@app/interfaces/timer/ITimerSlot';
 
 interface IIInviteRequest {
 	email: string;
@@ -19,7 +19,7 @@ export async function inviteByEmailsAPI(data: IIInviteRequest, tenantId: string)
 
 	const getRoleEndpoint = '/roles/options?name=EMPLOYEE';
 
-	const employeeRole: AxiosResponse<IRole, any> = (await get(getRoleEndpoint, true, { tenantId })).data;
+	const employeeRole = await get<any>(getRoleEndpoint, { tenantId });
 
 	const dataToInviteUser: IInviteCreate & { tenantId: string } = {
 		emailIds: [data.email],
@@ -39,9 +39,8 @@ export async function inviteByEmailsAPI(data: IIInviteRequest, tenantId: string)
 	};
 
 	// for not direct call we need to adjust data to include name and email only
-	const fetchData = await post<any>(endpoint, dataToInviteUser, { tenantId });
 
-	return GAUZY_API_BASE_SERVER_URL.value ? fetchData.data : fetchData;
+	return post<ITimerSlotDataRequest>(endpoint, dataToInviteUser, { tenantId });
 }
 
 export async function getTeamInvitationsAPI(tenantId: string, organizationId: string, role: string, teamId: string) {
@@ -54,9 +53,8 @@ export async function getTeamInvitationsAPI(tenantId: string, organizationId: st
 	});
 
 	const endpoint = `/invite?${query.toString()}`;
-	const data = await get(endpoint, true, { tenantId });
 
-	return GAUZY_API_BASE_SERVER_URL.value ? data.data : data;
+	return get<PaginationResponse<IInvitation>>(endpoint, { tenantId });
 }
 
 export function removeTeamInvitationsAPI(invitationId: string) {
@@ -71,9 +69,8 @@ export function resendTeamInvitationsAPI(inviteId: string) {
 
 export async function getMyInvitationsAPI(tenantId: string) {
 	const endpoint = '/invite/me';
-	const data = await get(endpoint, true, { tenantId });
 
-	return GAUZY_API_BASE_SERVER_URL.value ? data.data : data;
+	return get<PaginationResponse<IMyInvitations>>(endpoint, { tenantId });
 }
 
 export function acceptRejectMyInvitationsAPI(invitationId: string, action: MyInvitationActionEnum) {

--- a/apps/web/app/services/client/api/invite.ts
+++ b/apps/web/app/services/client/api/invite.ts
@@ -2,7 +2,6 @@ import { PaginationResponse } from '@app/interfaces/IDataResponse';
 import { IInvitation, MyInvitationActionEnum, CreateResponse, IInviteCreate, IMyInvitations } from '@app/interfaces';
 import { INVITE_CALLBACK_URL } from '@app/constants';
 import api, { get, post } from '../axios';
-import { ITimerSlotDataRequest } from '@app/interfaces/timer/ITimerSlot';
 
 interface IIInviteRequest {
 	email: string;
@@ -40,7 +39,7 @@ export async function inviteByEmailsAPI(data: IIInviteRequest, tenantId: string)
 
 	// for not direct call we need to adjust data to include name and email only
 
-	return post<ITimerSlotDataRequest>(endpoint, dataToInviteUser, { tenantId });
+	return post<PaginationResponse<IInvitation>>(endpoint, dataToInviteUser, { tenantId });
 }
 
 export async function getTeamInvitationsAPI(tenantId: string, organizationId: string, role: string, teamId: string) {

--- a/apps/web/app/services/client/api/issue-type.ts
+++ b/apps/web/app/services/client/api/issue-type.ts
@@ -1,4 +1,10 @@
-import { CreateResponse, DeleteResponse, IIssueTypesCreate } from '@app/interfaces';
+import {
+	CreateResponse,
+	DeleteResponse,
+	IIssueTypesCreate,
+	IIssueTypesItemList,
+	PaginationResponse
+} from '@app/interfaces';
 import api, { get } from '../axios';
 
 export function createIssueTypeAPI(data: IIssueTypesCreate, tenantId?: string) {
@@ -23,7 +29,6 @@ export function deleteIssueTypeAPI(id: string) {
 
 export async function getIssueTypeList(tenantId: string, organizationId: string, activeTeamId: string | null) {
 	const endpoint = `/issue-types?tenantId=${tenantId}&organizationId=${organizationId}&organizationTeamId=${activeTeamId}`;
-	const data = await get(endpoint, true, { tenantId });
 
-	return data;
+	return get<PaginationResponse<IIssueTypesItemList>>(endpoint, { tenantId });
 }

--- a/apps/web/app/services/client/api/languages.ts
+++ b/apps/web/app/services/client/api/languages.ts
@@ -1,9 +1,8 @@
-import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
+import { ILanguageItemList, PaginationResponse } from '@app/interfaces';
 import { get } from '../axios';
 
 export async function getLanguageListAPI(is_system: boolean) {
 	const endpoint = `/languages?is_system=${is_system}`;
-	const data = await get(endpoint, true);
 
-	return GAUZY_API_BASE_SERVER_URL.value ? data.data : data;
+	return get<PaginationResponse<ILanguageItemList>>(endpoint);
 }

--- a/apps/web/app/services/client/api/organization-team.ts
+++ b/apps/web/app/services/client/api/organization-team.ts
@@ -10,7 +10,6 @@ import {
 } from '@app/interfaces';
 import moment from 'moment';
 import api, { get } from '../axios';
-import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
 
 export async function getOrganizationTeamsAPI(organizationId: string, tenantId: string) {
 	const relations = [
@@ -37,8 +36,7 @@ export async function getOrganizationTeamsAPI(organizationId: string, tenantId: 
 	const query = new URLSearchParams(params);
 	const endpoint = `/organization-team?${query.toString()}`;
 
-	const data = await get(endpoint, true, { tenantId });
-	return GAUZY_API_BASE_SERVER_URL.value ? data.data : data;
+	return get<PaginationResponse<IOrganizationTeamList>>(endpoint, { tenantId });
 }
 
 export function createOrganizationTeamAPI(name: string) {
@@ -74,9 +72,8 @@ export async function getOrganizationTeamAPI(teamId: string, organizationId: str
 	const queries = new URLSearchParams(params || {});
 
 	const endpoint = `/organization-team/${teamId}?${queries.toString()}`;
-	const data = await get(endpoint, true);
 
-	return GAUZY_API_BASE_SERVER_URL.value ? data.data : data;
+	return get<IOrganizationTeamList>(endpoint);
 }
 
 export function editOrganizationTeamAPI(data: IOrganizationTeamUpdate) {

--- a/apps/web/app/services/client/api/task-labels.ts
+++ b/apps/web/app/services/client/api/task-labels.ts
@@ -1,4 +1,10 @@
-import { CreateResponse, DeleteResponse, ITaskLabelsCreate } from '@app/interfaces';
+import {
+	CreateResponse,
+	DeleteResponse,
+	ITaskLabelsCreate,
+	ITaskLabelsItemList,
+	PaginationResponse
+} from '@app/interfaces';
 import api, { get } from '../axios';
 
 export function createTaskLabelsAPI(data: ITaskLabelsCreate, tenantId?: string) {
@@ -23,7 +29,6 @@ export function deleteTaskLabelsAPI(id: string) {
 
 export async function getTaskLabelsList(tenantId: string, organizationId: string, organizationTeamId: string | null) {
 	const endpoint = `/tags/level?tenantId=${tenantId}&organizationId=${organizationId}&organizationTeamId=${organizationTeamId}`;
-	const data = await get(endpoint, true, { tenantId });
 
-	return data;
+	return get<PaginationResponse<ITaskLabelsItemList>>(endpoint, { tenantId });
 }

--- a/apps/web/app/services/client/api/task-priorities.ts
+++ b/apps/web/app/services/client/api/task-priorities.ts
@@ -1,4 +1,10 @@
-import { CreateResponse, DeleteResponse, ITaskPrioritiesCreate } from '@app/interfaces';
+import {
+	CreateResponse,
+	DeleteResponse,
+	ITaskPrioritiesCreate,
+	ITaskPrioritiesItemList,
+	PaginationResponse
+} from '@app/interfaces';
 import api, { get } from '../axios';
 
 export function createTaskPrioritiesAPI(data: ITaskPrioritiesCreate, tenantId?: string) {
@@ -28,7 +34,5 @@ export async function getTaskPrioritiesList(
 ) {
 	const endpoint = `/task-priorities?tenantId=${tenantId}&organizationId=${organizationId}&organizationTeamId=${organizationTeamId}`;
 
-	const data = await get(endpoint, true, { tenantId });
-
-	return data;
+	return get<PaginationResponse<ITaskPrioritiesItemList>>(endpoint, { tenantId });
 }

--- a/apps/web/app/services/client/api/task-related-issue-type.ts
+++ b/apps/web/app/services/client/api/task-related-issue-type.ts
@@ -1,4 +1,10 @@
-import { CreateResponse, DeleteResponse, ITaskRelatedIssueTypeCreate } from '@app/interfaces';
+import {
+	CreateResponse,
+	DeleteResponse,
+	ITaskRelatedIssueTypeCreate,
+	ITaskRelatedIssueTypeItemList,
+	PaginationResponse
+} from '@app/interfaces';
 import api, { get } from '../axios';
 
 export function createTaskRelatedIssueTypeAPI(data: ITaskRelatedIssueTypeCreate, tenantId?: string) {
@@ -28,7 +34,5 @@ export async function getTaskRelatedIssueTypeList(
 ) {
 	const endpoint = `/task-related-issue-types?tenantId=${tenantId}&organizationId=${organizationId}&organizationTeamId=${organizationTeamId}`;
 
-	const data = await get(endpoint, true, { tenantId });
-
-	return data;	
+	return get<PaginationResponse<ITaskRelatedIssueTypeItemList>>(endpoint, { tenantId });
 }

--- a/apps/web/app/services/client/api/task-sizes.ts
+++ b/apps/web/app/services/client/api/task-sizes.ts
@@ -1,4 +1,10 @@
-import { CreateResponse, DeleteResponse, ITaskSizesCreate } from '@app/interfaces';
+import {
+	CreateResponse,
+	DeleteResponse,
+	ITaskSizesCreate,
+	ITaskSizesItemList,
+	PaginationResponse
+} from '@app/interfaces';
 import api, { get } from '../axios';
 
 export function createTaskSizesAPI(data: ITaskSizesCreate, tenantId?: string) {
@@ -23,5 +29,5 @@ export function deleteTaskSizesAPI(id: string) {
 
 export async function getTaskSizesList(tenantId: string, organizationId: string, activeTeamId: string | null) {
 	const endpoint = `/task-sizes?tenantId=${tenantId}&organizationId=${organizationId}&organizationTeamId=${activeTeamId}`;
-	return get(endpoint, true);
+	return get<PaginationResponse<ITaskSizesItemList>>(endpoint);
 }

--- a/apps/web/app/services/client/api/task-status.ts
+++ b/apps/web/app/services/client/api/task-status.ts
@@ -1,4 +1,10 @@
-import { CreateResponse, DeleteResponse, ITaskStatusCreate } from '@app/interfaces';
+import {
+	CreateResponse,
+	DeleteResponse,
+	ITaskStatusCreate,
+	ITaskStatusItemList,
+	PaginationResponse
+} from '@app/interfaces';
 import api, { get } from '../axios';
 
 export function createTaskStatusAPI(data: ITaskStatusCreate, tenantId?: string) {
@@ -24,7 +30,5 @@ export function deleteTaskStatusAPI(id: string) {
 export async function getTaskStatusList(tenantId: string, organizationId: string, organizationTeamId: string | null) {
 	const endpoint = `/task-statuses?tenantId=${tenantId}&organizationId=${organizationId}&organizationTeamId=${organizationTeamId}`;
 
-	const data = await get(endpoint, true, { tenantId });
-
-	return data;
+	return get<PaginationResponse<ITaskStatusItemList>>(endpoint, { tenantId });
 }

--- a/apps/web/app/services/client/api/task-version.ts
+++ b/apps/web/app/services/client/api/task-version.ts
@@ -1,4 +1,10 @@
-import { CreateResponse, DeleteResponse, ITaskVersionCreate } from '@app/interfaces';
+import {
+	CreateResponse,
+	DeleteResponse,
+	ITaskVersionCreate,
+	ITaskVersionItemList,
+	PaginationResponse
+} from '@app/interfaces';
 import api, { get } from '../axios';
 
 export function createTaskVersionAPI(data: ITaskVersionCreate, tenantId?: string) {
@@ -24,7 +30,5 @@ export function deleteTaskVersionAPI(id: string) {
 export async function getTaskVersionList(tenantId: string, organizationId: string, organizationTeamId: string | null) {
 	const endpoint = `/task-versions?tenantId=${tenantId}&organizationId=${organizationId}&organizationTeamId=${organizationTeamId}`;
 
-	const data = await get(endpoint, true, { tenantId });
-
-	return data;
+	return get<PaginationResponse<ITaskVersionItemList>>(endpoint, { tenantId });
 }

--- a/apps/web/app/services/client/api/tasks.ts
+++ b/apps/web/app/services/client/api/tasks.ts
@@ -79,15 +79,16 @@ export async function tasksTimesheetStatisticsAPI(
 			defaultRange: 'false'
 		});
 
-		const globalData = await get(`/timesheet/statistics/tasks?${globalQueries.toString()}`, {
+		const globalData = await get<ITasksTimesheet[]>(`/timesheet/statistics/tasks?${globalQueries.toString()}`, {
 			tenantId
 		});
 
 		const todayQueries = new URLSearchParams({
+			...commonParams,
 			defaultRange: 'true',
 			unitOfTime: 'day'
 		});
-		const todayData = await get(`/timesheet/statistics/tasks?${todayQueries.toString()}`, {
+		const todayData = await get<ITasksTimesheet[]>(`/timesheet/statistics/tasks?${todayQueries.toString()}`, {
 			tenantId
 		});
 
@@ -127,12 +128,12 @@ export async function activeTaskTimesheetStatisticsAPI(
 			...commonParams,
 			defaultRange: 'false'
 		});
-		const globalData = await get(`/timesheet/statistics/tasks?${globalQueries.toString()}`, {
+		const globalData = await get<ITasksTimesheet[]>(`/timesheet/statistics/tasks?${globalQueries.toString()}`, {
 			tenantId
 		});
 
 		const todayQueries = new URLSearchParams({ ...commonParams, defaultRange: 'true', unitOfTime: 'day' });
-		const todayData = await get(`/timesheet/statistics/tasks?${todayQueries.toString()}`, {
+		const todayData = await get<ITasksTimesheet[]>(`/timesheet/statistics/tasks?${todayQueries.toString()}`, {
 			tenantId
 		});
 

--- a/apps/web/app/services/client/api/tasks.ts
+++ b/apps/web/app/services/client/api/tasks.ts
@@ -39,9 +39,8 @@ export async function getTeamTasksAPI(organizationId: string, tenantId: string, 
 
 	const query = new URLSearchParams(obj);
 	const endpoint = `/tasks/team?${query.toString()}`;
-	const data = await get(endpoint, true, { tenantId });
 
-	return GAUZY_API_BASE_SERVER_URL.value ? data.data : data;
+	return get<PaginationResponse<ITeamTask>>(endpoint, { tenantId });
 }
 
 export function deleteTaskAPI(taskId: string) {
@@ -79,7 +78,8 @@ export async function tasksTimesheetStatisticsAPI(
 			...commonParams,
 			defaultRange: 'false'
 		});
-		const globalData = await get(`/timesheet/statistics/tasks?${globalQueries.toString()}`, true, {
+
+		const globalData = await get(`/timesheet/statistics/tasks?${globalQueries.toString()}`, {
 			tenantId
 		});
 
@@ -87,7 +87,7 @@ export async function tasksTimesheetStatisticsAPI(
 			defaultRange: 'true',
 			unitOfTime: 'day'
 		});
-		const todayData = await get(`/timesheet/statistics/tasks?${todayQueries.toString()}`, true, {
+		const todayData = await get(`/timesheet/statistics/tasks?${todayQueries.toString()}`, {
 			tenantId
 		});
 
@@ -127,12 +127,12 @@ export async function activeTaskTimesheetStatisticsAPI(
 			...commonParams,
 			defaultRange: 'false'
 		});
-		const globalData = await get(`/timesheet/statistics/tasks?${globalQueries.toString()}`, true, {
+		const globalData = await get(`/timesheet/statistics/tasks?${globalQueries.toString()}`, {
 			tenantId
 		});
 
 		const todayQueries = new URLSearchParams({ ...commonParams, defaultRange: 'true', unitOfTime: 'day' });
-		const todayData = await get(`/timesheet/statistics/tasks?${todayQueries.toString()}`, true, {
+		const todayData = await get(`/timesheet/statistics/tasks?${todayQueries.toString()}`, {
 			tenantId
 		});
 

--- a/apps/web/app/services/client/api/timer.ts
+++ b/apps/web/app/services/client/api/timer.ts
@@ -5,9 +5,8 @@ import { GAUZY_API_BASE_SERVER_URL } from '@app/constants';
 export async function getTimerStatusAPI(tenantId: string, organizationId: string) {
 	const params = new URLSearchParams({ tenantId, organizationId });
 	const endpoint = GAUZY_API_BASE_SERVER_URL.value ? `/timesheet/timer/status?${params.toString()}` : '/timer/status';
-	const data = await get(endpoint, true);
 
-	return GAUZY_API_BASE_SERVER_URL.value ? data.data : data;
+	return get<ITimerStatus>(endpoint);
 }
 
 export function toggleTimerAPI(body: Pick<IToggleTimerParams, 'taskId'>) {

--- a/apps/web/app/services/client/api/timer/timer-log.ts
+++ b/apps/web/app/services/client/api/timer/timer-log.ts
@@ -1,3 +1,4 @@
+import { ITimerStatus } from '@app/interfaces';
 import { get } from '../../axios';
 
 export async function getTimerLogs(
@@ -8,9 +9,7 @@ export async function getTimerLogs(
 ) {
 	const endpoint = `/timer/status?tenantId=${tenantId}&organizationId=${organizationId}&organizationTeamId=${organizationTeamId}&employeeIds[0]=${employeeId}`;
 
-	const data = await get(endpoint, true, { tenantId });
-
-	return data;
+	return get<ITimerStatus>(endpoint, { tenantId });
 }
 
 // todayStart, todayEnd;

--- a/apps/web/app/services/client/api/timer/timer-status.ts
+++ b/apps/web/app/services/client/api/timer/timer-status.ts
@@ -1,3 +1,4 @@
+import { ITimerStatus } from '@app/interfaces';
 import { get } from '../../axios';
 
 export async function getTaskStatusList(
@@ -8,9 +9,7 @@ export async function getTaskStatusList(
 ) {
 	const endpoint = `/timer/status?tenantId=${tenantId}&organizationId=${organizationId}&organizationTeamId=${organizationTeamId}&employeeId=${employeeId}`;
 
-	const data = await get(endpoint, true, { tenantId });
-
-	return data;
+	return get<ITimerStatus>(endpoint, { tenantId });
 }
 
 // todayStart, todayEnd;

--- a/apps/web/app/services/client/axios.ts
+++ b/apps/web/app/services/client/axios.ts
@@ -46,10 +46,15 @@ const apiDirect = axios.create({
 
 apiDirect.interceptors.request.use(
 	async (config: any) => {
+		const tenantId = getTenantIdCookie();
 		const cookie = getAccessTokenCookie();
 
 		if (cookie) {
 			config.headers['Authorization'] = `Bearer ${cookie}`;
+		}
+
+		if (tenantId) {
+			config.headers['tenant-id'] = tenantId;
 		}
 
 		return config;
@@ -60,12 +65,7 @@ apiDirect.interceptors.request.use(
 );
 
 apiDirect.interceptors.response.use(
-	(response: AxiosResponse) => {
-		return {
-			...response,
-			data: response
-		};
-	},
+	(response: AxiosResponse) => response,
 	async (error: { response: AxiosResponse }) => {
 		const statusCode = error.response?.status;
 
@@ -80,7 +80,6 @@ apiDirect.interceptors.response.use(
 type APIConfig = AxiosRequestConfig<any> & { tenantId?: string; directAPI?: boolean };
 
 function apiConfig(config?: APIConfig) {
-	const bearer_token = getAccessTokenCookie();
 	const tenantId = getTenantIdCookie();
 	const organizationId = getOrganizationIdCookie();
 
@@ -89,28 +88,13 @@ function apiConfig(config?: APIConfig) {
 
 	apiDirect.defaults.baseURL = baseURL;
 
-	if (bearer_token) {
-		apiDirect.defaults.headers.common = {
-			...apiDirect.defaults.headers.common,
-			Authorization: `Bearer ${bearer_token}`
-		};
-	}
-
-	if (tenantId) {
-		apiDirect.defaults.headers.common = {
-			...apiDirect.defaults.headers.common,
-			'tenant-id': tenantId
-		};
-	}
-
 	const headers = {
-		...(config?.tenantId ? { 'tenant-id': config?.tenantId } : { 'tenant-id': tenantId }),
+		...(config?.tenantId ? { 'tenant-id': config?.tenantId } : {}),
 		...config?.headers
 	};
 
 	return {
 		baseURL,
-		bearer_token,
 		tenantId,
 		organizationId,
 		headers

--- a/apps/web/app/services/server/requests/employee.ts
+++ b/apps/web/app/services/server/requests/employee.ts
@@ -1,4 +1,5 @@
-import { ICreateEmployee, IEmployee } from '@app/interfaces/IEmployee';
+import { PaginationResponse } from '@app/interfaces';
+import { ICreateEmployee, IEmployee, IWorkingEmployee } from '@app/interfaces/IEmployee';
 import { serverFetch } from '../fetch';
 
 export function createEmployeeFromUser(data: ICreateEmployee, bearer_token: string) {
@@ -18,7 +19,7 @@ export function getOrganizationEmployees(bearer_token: string, tenantId: string,
 		'relations[0]': 'user'
 	};
 	const query = new URLSearchParams(params);
-	return serverFetch<IEmployee>({
+	return serverFetch<PaginationResponse<IWorkingEmployee>>({
 		path: `/employee/pagination?${query.toString()}`,
 		method: 'GET',
 		bearer_token,

--- a/apps/web/app/services/server/requests/issue-type.ts
+++ b/apps/web/app/services/server/requests/issue-type.ts
@@ -1,4 +1,4 @@
-import { IIssueTypesCreate, IIssueTypesItemList } from '@app/interfaces';
+import { IIssueTypesCreate, IIssueTypesItemList, PaginationResponse } from '@app/interfaces';
 import { serverFetch } from '../fetch';
 
 export function createIssueTypeRequest(datas: IIssueTypesCreate, bearer_token: string, tenantId?: any) {
@@ -56,7 +56,7 @@ export function getIssueTypesListRequest(
 	}: { tenantId: string; organizationId: string; organizationTeamId: string | null },
 	bearer_token: string
 ) {
-	return serverFetch({
+	return serverFetch<PaginationResponse<IIssueTypesItemList>>({
 		path: `/issue-types?tenantId=${tenantId}&organizationId=${organizationId}&organizationTeamId=${organizationTeamId}`,
 		method: 'GET',
 		bearer_token

--- a/apps/web/app/services/server/requests/languages.ts
+++ b/apps/web/app/services/server/requests/languages.ts
@@ -1,3 +1,4 @@
+import { ILanguageItemList, PaginationResponse } from '@app/interfaces';
 import { serverFetch } from '../fetch';
 
 export function getLanguageListRequest(
@@ -5,7 +6,7 @@ export function getLanguageListRequest(
 	bearer_token: string
 ) {
 	// const init = {};
-	return serverFetch({
+	return serverFetch<PaginationResponse<ILanguageItemList>>({
 		path: `/languages?is_system=${is_system}`,
 		method: 'GET',
 		bearer_token,

--- a/apps/web/components/shared/skeleton/Skeleton.tsx
+++ b/apps/web/components/shared/skeleton/Skeleton.tsx
@@ -11,7 +11,6 @@ const Skeleton = ({
 	borderRadius: number;
 	className: string;
 }) => {
-	console.log({ borderRadius });
 	return (
 		<div
 			className={clsxm(

--- a/apps/web/lib/app/authenticator.tsx
+++ b/apps/web/lib/app/authenticator.tsx
@@ -43,9 +43,7 @@ export function withAuthentication(Component: NextPage<any, any>, params: Params
 
 		useEffect(() => {
 			if (!user) {
-				queryCall().then((res) => {
-					setUser(res.data);
-				});
+				queryCall().then((res) => setUser(res.data));
 			}
 		}, [queryCall, setUser, user]);
 


### PR DESCRIPTION
- Tiny improvement on Axios direct api

- Implement integration github oauth on frontend

- Implement integration github repositories api on frontend

- Improve direct api (github and timer activities)

- Add typescript type to endpoints

- Axios returns two responses objects


- POST /integration/github/oauth
- GET /integration/github/metadata
- GET /integration/github/repositories
- POST /integration/github/repository/syn