### PR TITLE
[Remove]: remove the intersection observer for bug

### DIFF
--- a/apps/web/lib/features/user-profile-tasks.tsx
+++ b/apps/web/lib/features/user-profile-tasks.tsx
@@ -3,9 +3,6 @@ import { Divider, Text } from 'lib/components';
 import { TaskCard } from './task/task-card';
 import { I_TaskFilter } from './task/task-filters';
 import { useTranslations } from 'next-intl';
-import { ObserverComponent } from '@components/shared/Observer';
-import { useInfinityScrolling } from '@app/hooks/useInfinityFetch';
-
 type Props = {
 	tabFiltered: I_TaskFilter;
 	profile: I_UserProfilePage;
@@ -30,7 +27,6 @@ export function UserProfileTask({ profile, tabFiltered }: Props) {
 	const otherTasks = tasks.filter((t) =>
 		profile.member?.running == true ? t.id !== profile.activeUserTeamTask?.id : t
 	);
-	const { nextOffset, data } = useInfinityScrolling(otherTasks);
 	// const data = otherTasks.length < 10 ? otherTasks : data;
 
 	// const { total, onPageChange, itemsPerPage, itemOffset, endOffset, setItemsPerPage, currentItems } =
@@ -86,10 +82,9 @@ export function UserProfileTask({ profile, tabFiltered }: Props) {
 			)}
 
 			<ul className="flex flex-col gap-4">
-				{data.map((task, index) => {
+				{otherTasks.map((task) => {
 					return (
 						<li key={task.id}>
-							<ObserverComponent isLast={index === data.length - 1} getNextData={nextOffset} />
 							<TaskCard
 								task={task}
 								isAuthUser={profile.isAuthUser}


### PR DESCRIPTION
**Bug**
There is an intersection observer added in the profile page which renders application a lot of time that causes the re-rending issue which in the end slows the app.
The created function cannot deal with all the possible scenarios which is causing the problem.

**Fix**
I'm going to remove this function from this page to fix this issue.

**What's Next**
Using the Intersection Observer is useful when dealing with infinite scrolling and lazy loading, especially when data needs to be fetched from an API. However, the created function in our app doesn't address all potential issues that causes the problem. Therefore, using a dedicated library for this purpose is the best approach here. These libraries are designed to handle various complexities and edge cases seamlessly, ensuring smoother implementation and better performance.

I've recently deal with this issue using this library.
react-window // to show list that loads when user scroll but not work with API fetch
react-infinite-scroll-component // to show list that loads when user scroll with API calling

We need this functionality for whole app in future because there are a lot of lists in our app that needs optimization. But for now this is not the right time to use this.