### PR TITLE
2439 update search components not found

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,15 +27,12 @@
     "**/.git": true,
     "**/.DS_Store": true,
     "**/node_modules": false,
-    "**/public/**/*.png": true,
-    "**/public/**/*.jpg": true,
+    "**/public/**/*.png": false,
+    "**/public/**/*.jpg": false,
     "**/public/**/*.pdf": true
   },
   "search.exclude": {
     "**/node_modules": true,
-    "**/bower_components": true,
-    "**/*.code-search": true,
-    "**/web/components/**": true
   },
   "docwriter.style": "Auto-detect"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,4 +41,3 @@
   },
   "docwriter.style": "Auto-detect"
 }
-// exclude search for specific folder with all files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,12 @@
   },
   "search.exclude": {
     "**/node_modules": true,
+    "**/.idea": true,
+    "**/.idea/**/*.{xml,iml}": true,
+    "**/.iml": true,
+    "**/.yarn": true,
+    "**/yarn.lock": true
   },
   "docwriter.style": "Auto-detect"
 }
+// exclude search for specific folder with all files


### PR DESCRIPTION
If users try to search some components in the project they will not find any component due to this change but now it is fixed so that new users will be able to search components
 
Previously someone copied the code from this URL and pasted in the vscode JSON and not verified folder which is not used in our project.

![image](https://github.com/ever-co/ever-teams/assets/105014311/9e3bdb55-d213-451b-b9d1-4ff1ee80c472)
