### PR TITLE
Fix task time tracking issues

### DIFF
--- a/apps/web/app/hooks/features/useTimer.ts
+++ b/apps/web/app/hooks/features/useTimer.ts
@@ -364,8 +364,13 @@ export function useTimer() {
 	}, [timerStatus, setTimerStatus, stopTimerQueryCall, taskId, updateLocalTimerStatus]);
 
 	useEffect(() => {
-		console.log(timerStatus);
-	}, [timerStatus]);
+		if (timerStatus?.running) {
+			const syncTimerInterval = setInterval(() => {
+				syncTimer();
+			}, 60000);
+			return () => clearInterval(syncTimerInterval);
+		}
+	}, [syncTimer, timerStatus]);
 
 	// If active team changes then stop the timer
 	useEffect(() => {

--- a/apps/web/app/hooks/features/useTimer.ts
+++ b/apps/web/app/hooks/features/useTimer.ts
@@ -84,27 +84,27 @@ function useLocalTimeCounter(timerStatus: ITimerStatus | null, activeTeamTask: I
 
 	// Update local time status (storage and store) only when global timerStatus changes
 	useEffect(() => {
-		if (firstLoad) {
-			const localStatus = getLocalCounterStatus();
-			localStatus && setLocalTimerStatus(localStatus);
+		// if (firstLoad) {
+		const localStatus = getLocalCounterStatus();
+		localStatus && setLocalTimerStatus(localStatus);
 
-			const timerStatusDate = timerStatus?.lastLog?.createdAt
-				? moment(timerStatus?.lastLog?.createdAt).unix() * 1000 - timerStatus?.lastLog?.duration
-				: 0;
+		const timerStatusDate = timerStatus?.lastLog?.createdAt
+			? moment(timerStatus?.lastLog?.createdAt).unix() * 1000 - timerStatus?.lastLog?.duration
+			: 0;
 
-			timerStatus &&
-				updateLocalTimerStatus({
-					runnedDateTime:
-						(timerStatus.running ? timerStatusDate || Date.now() : 0) || localStatus?.runnedDateTime || 0,
-					running: timerStatus.running,
-					lastTaskId: timerStatus.lastLog?.taskId || null
-				});
-		}
+		timerStatus &&
+			updateLocalTimerStatus({
+				runnedDateTime:
+					(timerStatus.running ? timerStatusDate || Date.now() : 0) || localStatus?.runnedDateTime || 0,
+				running: timerStatus.running,
+				lastTaskId: timerStatus.lastLog?.taskId || null
+			});
+		// }
 	}, [firstLoad, timerStatus, getLocalCounterStatus, setLocalTimerStatus, updateLocalTimerStatus]);
 
 	// THis is form constant update of the progress line
 	timerSecondsRef.current = useMemo(() => {
-		if (!firstLoad) return 0;
+		// if (!firstLoad) return 0;
 		if (seconds > timerSecondsRef.current) {
 			return seconds;
 		}
@@ -115,16 +115,16 @@ function useLocalTimeCounter(timerStatus: ITimerStatus | null, activeTeamTask: I
 	}, [seconds, firstLoad, timerStatusRef]);
 
 	useEffect(() => {
-		if (firstLoad) {
-			timerSecondsRef.current = 0;
-			setTimerSeconds(0);
-		}
+		// if (firstLoad) {
+		timerSecondsRef.current = 0;
+		setTimerSeconds(0);
+		// }
 	}, [activeTeamTask?.id, setTimerSeconds, firstLoad, timerSecondsRef]);
 
 	useEffect(() => {
-		if (firstLoad) {
-			setTimerSeconds(timerSecondsRef.current);
-		}
+		// if (firstLoad) {
+		setTimerSeconds(timerSecondsRef.current);
+		// }
 	}, [setTimerSeconds, firstLoad]);
 
 	// Time Counter
@@ -271,9 +271,9 @@ export function useTimer() {
 
 	// Loading states
 	useEffect(() => {
-		if (firstLoad) {
-			setTimerStatusFetching(loading);
-		}
+		// if (firstLoad) {
+		setTimerStatusFetching(loading);
+		// }
 	}, [loading, firstLoad, setTimerStatusFetching]);
 
 	useEffect(() => {
@@ -355,10 +355,17 @@ export function useTimer() {
 			running: false
 		});
 
+		syncTimer();
+
 		return stopTimerQueryCall(timerStatus?.lastLog?.source || TimerSource.TEAMS).then((res) => {
 			res.data && !isEqual(timerStatus, res.data) && setTimerStatus(res.data);
 		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [timerStatus, setTimerStatus, stopTimerQueryCall, taskId, updateLocalTimerStatus]);
+
+	useEffect(() => {
+		console.log(timerStatus);
+	}, [timerStatus]);
 
 	// If active team changes then stop the timer
 	useEffect(() => {


### PR DESCRIPTION
Fixing update statistics for task time tricking : 
[x] Timer running : When user clicks on Stop timer, the Today/Total worked time are set to new values
[x] Total daily worked hours for user are updated
[x] During running, After each 1 minute, those values are also updated
[x] All tasks that the user worked home appear on Tab "Worked" on the user profile page

:warning: :warning: :warning: Note : WARNING !!! Before merge this PR, please test other parts of code as I commented some critical first loading conditions. Those tests were the main reason of not updating values after pause timer. It took me some time to detect that.

[screencast-localhost_3030-2024_07_04-17_47_41.webm](https://github.com/ever-co/ever-teams/assets/86450367/b5283b0e-e4eb-407e-a1b6-454018ec5992)
