### PR TITLE
fixbug: Ability to add 'Code' to Code inputs

### DIFF
--- a/apps/web/lib/components/inputs/auth-code-input.tsx
+++ b/apps/web/lib/components/inputs/auth-code-input.tsx
@@ -188,26 +188,22 @@ export const AuthCodeInputField = forwardRef<AuthCodeRef, AuthCodeProps>(
 		};
 
 		const handleOnPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+			e.preventDefault();
 			const pastedValue = e.clipboardData.getData('Text');
 
 			let currentInput = 0;
 
 			for (let i = 0; i < pastedValue.length; i++) {
 				const pastedCharacter = pastedValue.charAt(i);
-				const currentValue = inputsRef.current[currentInput].value;
 				if (pastedCharacter.match(inputProps.pattern)) {
-					if (!currentValue) {
-						inputsRef.current[currentInput].value = pastedCharacter;
-						if (inputsRef.current[currentInput].nextElementSibling !== null) {
-							(inputsRef.current[currentInput].nextElementSibling as HTMLInputElement).focus();
-							currentInput++;
-						}
+					inputsRef.current[currentInput].value = pastedCharacter;
+					if (inputsRef.current[currentInput].nextElementSibling !== null) {
+						(inputsRef.current[currentInput].nextElementSibling as HTMLInputElement).focus();
+						currentInput++;
 					}
 				}
 			}
 			sendResult();
-
-			e.preventDefault();
 		};
 
 		const handleAutoComplete = (code: string) => {


### PR DESCRIPTION
### This PR fixes #2746 

- User should be able to paste a new value to the input code even if there is a current value. (ability to change the existing value)

[Loom](https://www.loom.com/share/38ae69d094d744a8a16400a5da3a00fc?sid=ee13e7f8-f732-4bee-acc5-3ef459bf3e00)