### PR TITLE
fixbug: duplicate action icons for estimation hours input

### DIFF
--- a/apps/web/lib/features/task/task-estimate.tsx
+++ b/apps/web/lib/features/task/task-estimate.tsx
@@ -14,9 +14,18 @@ type Props = {
 	loadingRef?: MutableRefObject<boolean>;
 	closeable_fc?: () => void;
 	wrapperClassName?: string;
+	showEditAndSaveButton?: boolean;
 };
 
-export function TaskEstimate({ _task, onCloseEdition, className, loadingRef, closeable_fc, wrapperClassName }: Props) {
+export function TaskEstimate({
+	_task,
+	onCloseEdition,
+	className,
+	loadingRef,
+	closeable_fc,
+	wrapperClassName,
+	showEditAndSaveButton = true
+}: Props) {
 	const {
 		targetEl,
 		value,
@@ -101,26 +110,28 @@ export function TaskEstimate({ _task, onCloseEdition, className, loadingRef, clo
 					`${editableMode ? 'block' : parseInt(value['minutes']) > 0 ? 'block' : parseInt(value['hours']) > 0 ? 'hidden' : 'block'}`
 				)}
 			/>
-			<div className="h-full flex items-center justify-center">
-				{!updateLoading ? (
-					editableMode ? (
-						<button
-							onClick={() => {
-								handleSubmit();
-								setEditableMode(false);
-							}}
-						>
-							<TickSaveIcon className={clsxm('lg:h-4 lg:w-4 w-2 h-2 mx-2')} />
-						</button>
+			{showEditAndSaveButton && (
+				<div className="h-full flex items-center justify-center">
+					{!updateLoading ? (
+						editableMode ? (
+							<button
+								onClick={() => {
+									handleSubmit();
+									setEditableMode(false);
+								}}
+							>
+								<TickSaveIcon className={clsxm('lg:h-4 lg:w-4 w-2 h-2 mx-2')} />
+							</button>
+						) : (
+							<button onClick={() => setEditableMode(true)}>
+								<EditPenBoxIcon className={clsxm('lg:h-4 lg:w-4 w-2 h-2 mx-2')} />
+							</button>
+						)
 					) : (
-						<button onClick={() => setEditableMode(true)}>
-							<EditPenBoxIcon className={clsxm('lg:h-4 lg:w-4 w-2 h-2 mx-2')} />
-						</button>
-					)
-				) : (
-					<LoadingIcon className={clsxm('lg:h-4 lg:w-4 w-2 h-2 mx-2 animate-spin')} />
-				)}
-			</div>
+						<LoadingIcon className={clsxm('lg:h-4 lg:w-4 w-2 h-2 mx-2 animate-spin')} />
+					)}
+				</div>
+			)}
 		</div>
 	);
 }

--- a/apps/web/lib/features/team/user-team-card/task-estimate.tsx
+++ b/apps/web/lib/features/team/user-team-card/task-estimate.tsx
@@ -60,7 +60,12 @@ export function TaskEstimateInput({ memberInfo, edition }: Omit<Props, 'classNam
 			>
 				{task && (
 					<>
-						<TaskEstimate _task={task} loadingRef={loadingRef} closeable_fc={closeFn} />
+						<TaskEstimate
+							_task={task}
+							loadingRef={loadingRef}
+							closeable_fc={closeFn}
+							showEditAndSaveButton={false}
+						/>
 						<button
 							className={`ml-2 ${loadingRef.current && 'hidden'}`}
 							onClick={() => task && edition.setEstimateEditMode(false)}


### PR DESCRIPTION
### This PR fixes #2819 

[Loom](https://www.loom.com/share/6ed644fed3ee49ff981e344ed7cc29a6?sid=7ac493ad-d323-420b-ad54-6500a691a7b7)