### PR TITLE
Fix: Linting issues in settings-livekit and Daily-plan-compare-estima

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -187,6 +187,8 @@
 		"Kolkata",
 		"Kosrae",
 		"Koyeb",
+		"Krisp",
+		"krisp",
 		"labore",
 		"Lask",
 		"lastest",

--- a/apps/web/lib/features/daily-plan/daily-plan-compare-estimate-modal.tsx
+++ b/apps/web/lib/features/daily-plan/daily-plan-compare-estimate-modal.tsx
@@ -12,6 +12,7 @@ import { useDailyPlan, useTeamMemberCard, useTimer, useTMCardTaskEdit } from '@a
 import { dailyPlanCompareEstimated } from '@app/helpers/daily-plan-estimated';
 import { secondsToTime } from '@app/helpers';
 import { DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE } from '@app/constants';
+import { ScrollArea } from '@components/ui/scroll-bar';
 
 export interface IDailyPlanCompareEstimated {
 	difference?: boolean;

--- a/apps/web/lib/features/integrations/livekit/settings-livekit.tsx
+++ b/apps/web/lib/features/integrations/livekit/settings-livekit.tsx
@@ -15,7 +15,7 @@ import { shortenLink } from 'lib/utils';
 import { BiLoaderCircle } from "react-icons/bi";
 
 
-
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SettingsMenuProps extends React.HTMLAttributes<HTMLDivElement> { }
 
 export function SettingsMenu(props: SettingsMenuProps) {

--- a/apps/web/lib/features/integrations/livekit/settings-livekit.tsx
+++ b/apps/web/lib/features/integrations/livekit/settings-livekit.tsx
@@ -19,6 +19,8 @@ import { BiLoaderCircle } from "react-icons/bi";
 export interface SettingsMenuProps extends React.HTMLAttributes<HTMLDivElement> { }
 
 export function SettingsMenu(props: SettingsMenuProps) {
+    const TrackToggleComponent = TrackToggle as React.ElementType;
+
     const layoutContext = useMaybeLayoutContext();
     const [copied, setCopied] = React.useState<boolean>(false);
 
@@ -93,7 +95,7 @@ export function SettingsMenu(props: SettingsMenuProps) {
                             <>
                                 <h3>Camera</h3>
                                 <section className="lk-button-group">
-                                    <TrackToggle source={Track.Source.Camera}>Camera</TrackToggle>
+                                    <TrackToggleComponent source={Track.Source.Camera}>Camera</TrackToggleComponent>
                                     <div className="lk-button-group-menu">
                                         <MediaDeviceMenu kind="videoinput" />
                                     </div>
@@ -104,7 +106,7 @@ export function SettingsMenu(props: SettingsMenuProps) {
                             <>
                                 <h3>Microphone</h3>
                                 <section className="lk-button-group">
-                                    <TrackToggle source={Track.Source.Microphone}>Microphone</TrackToggle>
+                                    <TrackToggleComponent source={Track.Source.Microphone}>Microphone</TrackToggleComponent>
                                     <div className="lk-button-group-menu">
                                         <MediaDeviceMenu kind="audioinput" />
                                     </div>


### PR DESCRIPTION
- Resolved react/jsx-no-undef error in daily-plan-compare-estimate-modal.tsx by importing ScrollArea.
- Addressed @typescript-eslint/no-empty-interface error in settings-livekit.tsx by disabling the lint rule for the specific line to allow future extensibility.
