### PR TITLE
fix: show number of tasks instead of plans for different tabs

### DIFF
--- a/apps/web/lib/features/task/daily-plan/outstanding-all.tsx
+++ b/apps/web/lib/features/task/daily-plan/outstanding-all.tsx
@@ -77,7 +77,7 @@ export function OutstandingAll({ profile }: OutstandingAll) {
 															taskBadgeClassName={`rounded-sm`}
 															taskTitleClassName="mt-[0.0625rem]"
 															planMode="Outstanding"
-															className='shadow-[0px_0px_15px_0px_#e2e8f0]'
+															className="shadow-[0px_0px_15px_0px_#e2e8f0]"
 														/>
 													</div>
 												)}

--- a/apps/web/lib/features/task/daily-plan/task-estimated-count.tsx
+++ b/apps/web/lib/features/task/daily-plan/task-estimated-count.tsx
@@ -42,3 +42,16 @@ export function estimatedTotalTime(data: any) {
 
 	return { timesEstimated, totalTasks };
 }
+
+export const getTotalTasks = (plan: IDailyPlan[]) => {
+	if (!plan) {
+		return 0;
+	}
+	const tasksPerPlan = plan.map((plan) => plan.tasks?.length);
+
+	if (tasksPerPlan.length <= 0) {
+		return 0;
+	}
+
+	return tasksPerPlan.reduce((a, b) => (a ?? 0) + (b ?? 0)) ?? 0;
+};

--- a/apps/web/lib/features/task/task-filters.tsx
+++ b/apps/web/lib/features/task/task-filters.tsx
@@ -108,7 +108,7 @@ export function useTaskFilter(profile: I_UserProfilePage) {
 			tab: 'dailyplan',
 			name: 'Daily Plan',
 			description: 'This tab shows all yours tasks planned',
-			count: profile.tasksGrouped.dailyplan?.length
+			count: profile.tasksGrouped.planned
 		});
 		tabs.unshift({
 			tab: 'worked',


### PR DESCRIPTION
### This PR is focused on showing number of tasks instead of number of plan for different tabs:
 (Daily plan, today tasks, past tasks, future tasks, outstanding)
![Screenshot from 2024-08-07 14-12-25](https://github.com/user-attachments/assets/801f9493-64b6-465c-ad2f-69fd51cac991)
