### PR TITLE
fix: user should not edit past plans

### DIFF
--- a/apps/web/lib/features/task/daily-plan/past-tasks.tsx
+++ b/apps/web/lib/features/task/daily-plan/past-tasks.tsx
@@ -88,6 +88,7 @@ export function PastTasks({ profile, currentTab = 'Past Tasks' }: { profile: any
 																		viewType={'dailyplan'}
 																		task={task}
 																		profile={profile}
+																		plan={plan}
 																		type="HORIZONTAL"
 																		taskBadgeClassName={`rounded-sm`}
 																		taskTitleClassName="mt-[0.0625rem]"

--- a/apps/web/lib/features/task/task-card.tsx
+++ b/apps/web/lib/features/task/task-card.tsx
@@ -190,7 +190,12 @@ export function TaskCard(props: Props) {
 					<>
 						{/* TaskEstimateInfo */}
 						<div className="flex items-center flex-col justify-center lg:flex-row w-[20%]">
-							<TaskEstimateInfo memberInfo={memberInfo} edition={taskEdition} activeAuthTask={true} />
+							<TaskEstimateInfo
+								plan={plan}
+								memberInfo={memberInfo}
+								edition={taskEdition}
+								activeAuthTask={true}
+							/>
 						</div>
 					</>
 				)}

--- a/apps/web/lib/features/user-profile-plans.tsx
+++ b/apps/web/lib/features/user-profile-plans.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { useCanSeeActivityScreen, useDailyPlan, useUserProfilePage } from '@app/hooks';
+import { useAuthenticateUser, useCanSeeActivityScreen, useDailyPlan, useUserProfilePage } from '@app/hooks';
 import { TaskCard } from './task/task-card';
 import { IDailyPlan, ITeamTask } from '@app/interfaces';
 import { AlertPopup, Container, HorizontalSeparator, NoData, ProgressBar, VerticalSeparator } from 'lib/components';
@@ -31,6 +31,7 @@ import { filterDailyPlan } from '@app/hooks/useFilterDateRange';
 import { handleDragAndDrop } from '@app/helpers/drag-and-drop';
 import { DragDropContext, Droppable, Draggable, DroppableProvided, DroppableStateSnapshot } from 'react-beautiful-dnd';
 import { useDateRange } from '@app/hooks/useDateRange';
+import { checkPastDate } from 'lib/utils';
 
 export type FilterTabs = 'Today Tasks' | 'Future Tasks' | 'Past Tasks' | 'All Tasks' | 'Outstanding';
 type FilterOutstanding = 'ALL' | 'DATE';
@@ -357,6 +358,7 @@ export function PlanHeader({ plan, planMode }: { plan: IDailyPlan; planMode: Fil
 	const [editTime, setEditTime] = useState<boolean>(false);
 	const [time, setTime] = useState<number>(0);
 	const { updateDailyPlan, updateDailyPlanLoading } = useDailyPlan();
+	const { isTeamManager } = useAuthenticateUser();
 	// Get all tasks's estimations time
 	// Helper function to sum times
 	const sumTimes = (tasks: ITeamTask[], key: any) =>
@@ -392,7 +394,7 @@ export function PlanHeader({ plan, planMode }: { plan: IDailyPlan; planMode: Fil
 							<span className="font-medium">Planned time: </span>
 							<span className="font-semibold">{formatIntegerToHour(plan.workTimePlanned)}</span>
 						</div>
-						{planMode !== 'Past Tasks' && (
+						{(!checkPastDate(plan.date) || isTeamManager) && (
 							<EditPenBoxIcon
 								className={clsxm('cursor-pointer lg:h-4 lg:w-4 w-2 h-2', 'dark:stroke-[#B1AEBC]')}
 								onClick={() => setEditTime(true)}

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -51,12 +51,31 @@ export const shortenLink = (value: any): string => {
 	return `${start}...${end}`;
 };
 
-
 export function formatWithSuffix(date: Date) {
 	const day = moment(date).date();
 	const suffix =
-		day === 1 || day === 21 || day === 31 ? 'st' :
-			day === 2 || day === 22 ? 'nd' :
-				day === 3 || day === 23 ? 'rd' : 'th';
+		day === 1 || day === 21 || day === 31
+			? 'st'
+			: day === 2 || day === 22
+				? 'nd'
+				: day === 3 || day === 23
+					? 'rd'
+					: 'th';
 	return moment(date).format(`D[${suffix}] MMMM YYYY`);
+}
+
+export function checkPastDate(dateToBeChecked?: Date): boolean {
+	if (dateToBeChecked) {
+		const todayDate = new Date(new Date().toUTCString());
+		const date = new Date(new Date(dateToBeChecked).toUTCString());
+
+		date.setHours(0, 0, 0, 0);
+		todayDate.setHours(0, 0, 0, 0);
+
+		console.log(todayDate, date);
+
+		return todayDate > date;
+	} else {
+		return false; // Return false if dateToBeChecked is not provided or is null or undefined.
+	}
 }


### PR DESCRIPTION
### This PR fixes #2847 , fixes #2622 
Now, users are not able to edit past plans
![Screenshot from 2024-08-07 20-57-51](https://github.com/user-attachments/assets/145270cf-f0bb-4f53-bfab-1ad282b42e9b)
