### PR TITLE
[Fix]: Daily Plan | Total estimated time on Outstanding UI

### DIFF
--- a/apps/web/lib/features/task/daily-plan/task-estimated-count.tsx
+++ b/apps/web/lib/features/task/daily-plan/task-estimated-count.tsx
@@ -13,15 +13,15 @@ export function TaskEstimatedCount({ outstandingPlans }: ITaskEstimatedCount) {
 	return (
 		<div className="flex space-x-10">
 			<div className="flex space-x-2">
-				<span className="text-slate-600">Estimated:</span>
-				<span className="text-slate-900 dark:text-slate-600 font-semibold text-[12px]">
+				<span className="text-slate-600 dark:text-slate-200">Estimated:</span>
+				<span className="text-slate-900 dark:text-slate-200 font-semibold text-[12px]">
 					{hour}h{minute}m
 				</span>
 			</div>
 			<VerticalSeparator className="border-slate-400" />
 			<div className="flex space-x-2">
-				<span className="text-slate-600">Total tasks:</span>
-				<span className="text-slate-900 dark:text-slate-600 font-semibold text-[12px]">{totalTasks}</span>
+				<span className="text-slate-600 dark:text-slate-200">Total tasks:</span>
+				<span className="text-slate-900 dark:text-slate-200 font-semibold text-[12px]">{totalTasks}</span>
 			</div>
 		</div>
 	);

--- a/apps/web/lib/features/task/daily-plan/task-estimated-count.tsx
+++ b/apps/web/lib/features/task/daily-plan/task-estimated-count.tsx
@@ -9,18 +9,19 @@ export function TaskEstimatedCount({ outstandingPlans }: ITaskEstimatedCount) {
 	const element = outstandingPlans?.map((plan: IDailyPlan) => plan.tasks?.map((task) => task));
 	const { timesEstimated, totalTasks } = estimatedTotalTime(element || []);
 	const { h: hour, m: minute } = secondsToTime(timesEstimated || 0);
+
 	return (
 		<div className="flex space-x-10">
 			<div className="flex space-x-2">
 				<span className="text-slate-600">Estimated:</span>
-				<span className="text-slate-900 font-semibold text-[12px]">
+				<span className="text-slate-900 dark:text-slate-600 font-semibold text-[12px]">
 					{hour}h{minute}m
 				</span>
 			</div>
 			<VerticalSeparator className="border-slate-400" />
 			<div className="flex space-x-2">
 				<span className="text-slate-600">Total tasks:</span>
-				<span className="text-slate-900 font-semibold text-[12px]">{totalTasks}</span>
+				<span className="text-slate-900 dark:text-slate-600 font-semibold text-[12px]">{totalTasks}</span>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
- Display total estimated time for all tasks in the 'Outstanding' tab (read-only)
- Show the total number of tasks in the 'Outstanding' tab (read-only)
<img width="1920" alt="Screenshot 2024-08-08 at 12 47 44 PM" src="https://github.com/user-attachments/assets/a2c4b374-a3bb-472d-ac1e-bcf82e53ea6a">

