### PR TITLE
[Feat]: Customize month legend and theme styling 

### DIFF
--- a/apps/web/lib/features/integrations/activity-calendar/index.tsx
+++ b/apps/web/lib/features/integrations/activity-calendar/index.tsx
@@ -76,7 +76,20 @@ export function ActivityCalendar() {
                                 }
                             ]}
                             monthSpacing={20}
-                            monthLegend={(_, __, d) => d.toLocaleString('en-US', { month: 'short' })}
+                            monthLegend={(year, month) => {
+                                return new Date(year, month).toLocaleString('en-US', { month: 'short' });
+                            }}
+                            theme={{
+                                labels: {
+                                    text: {
+                                        fill: '#9ca3af',
+                                        fontSize: 16,
+                                        font: 'icon',
+                                        animation: 'ease',
+                                        border: '12',
+                                    }
+                                }
+                            }}
                         />
                     </div>
                 </div>

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -297,6 +297,11 @@ html.dark {
 	@apply ring-0 outline-gray-200 dark:outline-none dark:border-2 dark:border-[#464242];
 }
 
+.nivo-calendar .nivo-calendar-month-legend text {
+	@apply text-black font-bold text-sm;
+
+}
+
 @keyframes zoom-in-out {
 	0% {
 		transform: scale(1);


### PR DESCRIPTION
Implemented custom month legends using toLocaleString for short month names.
<img width="1920" alt="Screenshot 2024-08-09 at 11 09 02 PM" src="https://github.com/user-attachments/assets/03139a92-903e-41e8-a02e-9b5e95c92097">
<img width="1920" alt="Screenshot 2024-08-09 at 11 08 38 PM" src="https://github.com/user-attachments/assets/9d2438f8-bdfa-4518-92eb-e524ff24ce9a">