### PR TITLE
refactor: improve the workspaces list on login/workspace screen

### DIFF
--- a/apps/web/app/[locale]/auth/passcode/component.tsx
+++ b/apps/web/app/[locale]/auth/passcode/component.tsx
@@ -27,6 +27,8 @@ import { ScrollArea, ScrollBar } from '@components/ui/scroll-bar';
 import SocialLogins from '../social-logins-buttons';
 import { useSession } from 'next-auth/react';
 import { LAST_WORSPACE_AND_TEAM, USER_SAW_OUTSTANDING_NOTIFICATION } from '@app/constants';
+import { MdOutlineKeyboardArrowDown } from 'react-icons/md';
+import { cn } from 'lib/utils';
 
 function AuthPasscode() {
 	const form = useAuthenticationPasscode();
@@ -78,7 +80,8 @@ function AuthPasscode() {
 					{form.authScreen.screen === 'workspace' && (
 						<WorkSpaceScreen form={form} className={clsxm('w-full')} />
 					)}
-				</div>				
+				</div>
+				{/* Social logins */}
 				<SocialLogins />
 			</div>
 		</AuthLayout>
@@ -412,6 +415,12 @@ type IWorkSpace = {
 export function WorkSpaceComponent(props: IWorkSpace) {
 	const t = useTranslations();
 
+	const [uncollapsedWorkspace, setUncollapsedWorkspace] = useState(props.selectedWorkspace);
+
+	useEffect(() => {
+		setUncollapsedWorkspace(props.selectedWorkspace);
+	}, [props.selectedWorkspace]);
+
 	return (
 		<form
 			className={clsxm(props.className, 'flex justify-center w-full')}
@@ -428,13 +437,28 @@ export function WorkSpaceComponent(props: IWorkSpace) {
 							{props.workspaces?.map((worksace, index) => (
 								<div
 									key={index}
-									className={`w-full flex flex-col border border-[#0000001A] dark:border-[#34353D] ${
-										props.selectedWorkspace === index ? 'bg-[#FCFCFC] dark:bg-[#1F2024]' : ''
-									} hover:bg-[#FCFCFC] dark:hover:bg-[#1F2024] rounded-xl`}
+									className={`w-full overflow-hidden h-16 ${uncollapsedWorkspace === index && 'h-auto'}   flex flex-col border border-[#0000001A] dark:border-[#34353D] ${
+										props.selectedWorkspace === index
+											? 'bg-[#FCFCFC] -order-1 dark:bg-[#1F2024]'
+											: ''
+									} hover:bg-[#FCFCFC]  dark:hover:bg-[#1F2024] rounded-xl`}
 								>
 									<div className="text-base font-medium py-[1.25rem] px-4 flex flex-col gap-[1.0625rem]">
 										<div className="flex justify-between">
-											<span>{worksace.user.tenant.name}</span>
+											<div
+												onClick={() => setUncollapsedWorkspace(index)}
+												className="flex cursor-pointer items-center justify-center gap-1"
+											>
+												<span>{worksace.user.tenant.name}</span>
+												<span
+													className={cn(
+														'h-6 w-6 flex items-center justify-center transition-transform',
+														uncollapsedWorkspace === index && 'rotate-180'
+													)}
+												>
+													<MdOutlineKeyboardArrowDown />
+												</span>
+											</div>
 											<span
 												className="hover:cursor-pointer"
 												onClick={() => {
@@ -456,7 +480,9 @@ export function WorkSpaceComponent(props: IWorkSpace) {
 												)}
 											</span>
 										</div>
-										<span className="bg-[#E5E5E5] w-full h-[1px]"></span>
+										<span
+											className={`bg-[#E5E5E5] w-full h-[1px] hidden ${uncollapsedWorkspace === index && 'block'}`}
+										></span>
 										{/* <div className="w-full h-[1px] bg-[#E5E5E5] dark:bg-[#34353D]"></div> */}
 										<div className="flex flex-col gap-4 px-5 py-1.5">
 											{worksace.current_teams?.map((team) => (

--- a/apps/web/app/[locale]/auth/passcode/component.tsx
+++ b/apps/web/app/[locale]/auth/passcode/component.tsx
@@ -415,10 +415,10 @@ type IWorkSpace = {
 export function WorkSpaceComponent(props: IWorkSpace) {
 	const t = useTranslations();
 
-	const [uncollapsedWorkspace, setUncollapsedWorkspace] = useState(props.selectedWorkspace);
+	const [expandedWorkspace, setExpandedWorkspace] = useState(props.selectedWorkspace);
 
 	useEffect(() => {
-		setUncollapsedWorkspace(props.selectedWorkspace);
+		setExpandedWorkspace(props.selectedWorkspace);
 	}, [props.selectedWorkspace]);
 
 	return (
@@ -437,7 +437,7 @@ export function WorkSpaceComponent(props: IWorkSpace) {
 							{props.workspaces?.map((worksace, index) => (
 								<div
 									key={index}
-									className={`w-full overflow-hidden h-16 ${uncollapsedWorkspace === index && 'h-auto'}   flex flex-col border border-[#0000001A] dark:border-[#34353D] ${
+									className={`w-full overflow-hidden h-16 ${expandedWorkspace === index && 'h-auto'}   flex flex-col border border-[#0000001A] dark:border-[#34353D] ${
 										props.selectedWorkspace === index
 											? 'bg-[#FCFCFC] -order-1 dark:bg-[#1F2024]'
 											: ''
@@ -446,14 +446,14 @@ export function WorkSpaceComponent(props: IWorkSpace) {
 									<div className="text-base font-medium py-[1.25rem] px-4 flex flex-col gap-[1.0625rem]">
 										<div className="flex justify-between">
 											<div
-												onClick={() => setUncollapsedWorkspace(index)}
+												onClick={() => setExpandedWorkspace(index)}
 												className="flex cursor-pointer items-center justify-center gap-1"
 											>
 												<span>{worksace.user.tenant.name}</span>
 												<span
 													className={cn(
 														'h-6 w-6 flex items-center justify-center transition-transform',
-														uncollapsedWorkspace === index && 'rotate-180'
+														expandedWorkspace === index && 'rotate-180'
 													)}
 												>
 													<MdOutlineKeyboardArrowDown />
@@ -481,7 +481,7 @@ export function WorkSpaceComponent(props: IWorkSpace) {
 											</span>
 										</div>
 										<span
-											className={`bg-[#E5E5E5] w-full h-[1px] hidden ${uncollapsedWorkspace === index && 'block'}`}
+											className={`bg-[#E5E5E5] w-full h-[1px] hidden ${expandedWorkspace === index && 'block'}`}
 										></span>
 										{/* <div className="w-full h-[1px] bg-[#E5E5E5] dark:bg-[#34353D]"></div> */}
 										<div className="flex flex-col gap-4 px-5 py-1.5">


### PR DESCRIPTION
## Description

This PR fixes #2896 

Changes made:
- Put the latest selected Workspace on top of the list, in expended mode with the latest team selected
- Collapse other workspaces and let user (expended / collapse) them if needed

## Type of Change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Previous screenshots

[Loom](https://www.loom.com/share/c1e776b55caf41c1a30927e4d8ad7fbe?sid=1ba01446-5d3b-40c8-afc0-0daab54648fa)

## Current screenshots

[Loom](https://www.loom.com/share/ce0db78d1542417ea2cbb8a5fb0b117c?sid=a5ea46e0-25b8-4548-bb3c-1603e08e82de)
