### PR TITLE
improvement: focus should be on the first input which has a digit when user click on edit | estimate task

### DIFF
--- a/apps/web/lib/features/task/task-estimate.tsx
+++ b/apps/web/lib/features/task/task-estimate.tsx
@@ -5,7 +5,7 @@ import { ITeamTask, Nullable } from '@app/interfaces';
 import { clsxm } from '@app/utils';
 import { EditPenBoxIcon, CheckCircleTickIcon as TickSaveIcon, LoadingIcon } from 'assets/svg';
 import { TimeInputField } from 'lib/components';
-import { MutableRefObject, useEffect } from 'react';
+import { MutableRefObject, useEffect, useRef } from 'react';
 
 type Props = {
 	_task?: Nullable<ITeamTask>;
@@ -42,9 +42,22 @@ export function TaskEstimate({
 	} = useTaskEstimation(_task);
 	const onCloseEditionRef = useCallbackRef(onCloseEdition);
 	const closeable_fcRef = useCallbackRef(closeable_fc);
+	const hourRef = useRef<HTMLInputElement | null>(null);
+	const minRef = useRef<HTMLInputElement | null>(null);
 
 	useEffect(() => {
 		!editableMode && onCloseEditionRef.current && onCloseEditionRef.current();
+
+		if (editableMode) {
+			if (value['hours']) {
+				hourRef.current?.focus();
+			} else if (value['minutes']) {
+				minRef.current?.focus();
+			} else {
+				hourRef.current?.focus();
+			}
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [editableMode, onCloseEditionRef]);
 
 	useEffect(() => {
@@ -60,6 +73,7 @@ export function TaskEstimate({
 	return (
 		<div className={clsxm('flex items-center space-x-1', className)} ref={targetEl}>
 			<TimeInputField
+				ref={hourRef}
 				value={value['hours']}
 				onChange={onChange('hours')}
 				onKeyUp={(e) => {
@@ -91,6 +105,7 @@ export function TaskEstimate({
 				) : null
 			) : null}
 			<TimeInputField
+				ref={minRef}
 				value={value['minutes']}
 				onChange={onChange('minutes')}
 				onKeyUp={(e) => {


### PR DESCRIPTION

## Description

When the user click on the edit button of the Task estimate component, the focus should be on the first input which has a digit

## Type of Change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Previous screenshots

[Loom](https://www.loom.com/share/27bc7935586c4671acf8225cf7b82ad6?sid=7bfcf2dd-6542-41ca-9ae1-c2387913a1d0)

## Current screenshots

[Loom](https://www.loom.com/share/a96ceb6ab39445eea66c28e06d93ed39?sid=8ec69390-270e-467f-923f-8580c81daa37)
