### PR TITLE
improvement: use the same Task Estimate component on all pages / popups/ Task card

### DIFF
--- a/apps/web/lib/features/task/task-estimate.tsx
+++ b/apps/web/lib/features/task/task-estimate.tsx
@@ -10,6 +10,7 @@ import { MutableRefObject, useEffect, useRef } from 'react';
 type Props = {
 	_task?: Nullable<ITeamTask>;
 	onCloseEdition?: () => void;
+	onOpenEdition?: () => void;
 	className?: string;
 	loadingRef?: MutableRefObject<boolean>;
 	closeable_fc?: () => void;
@@ -20,6 +21,7 @@ type Props = {
 export function TaskEstimate({
 	_task,
 	onCloseEdition,
+	onOpenEdition,
 	className,
 	loadingRef,
 	closeable_fc,
@@ -41,6 +43,7 @@ export function TaskEstimate({
 		setEditableMode
 	} = useTaskEstimation(_task);
 	const onCloseEditionRef = useCallbackRef(onCloseEdition);
+	const onOpenEditionRef = useCallbackRef(onOpenEdition);
 	const closeable_fcRef = useCallbackRef(closeable_fc);
 	const hourRef = useRef<HTMLInputElement | null>(null);
 	const minRef = useRef<HTMLInputElement | null>(null);
@@ -49,6 +52,7 @@ export function TaskEstimate({
 		!editableMode && onCloseEditionRef.current && onCloseEditionRef.current();
 
 		if (editableMode) {
+			onOpenEditionRef.current && onOpenEditionRef.current();
 			if (value['hours']) {
 				hourRef.current?.focus();
 			} else if (value['minutes']) {
@@ -138,7 +142,12 @@ export function TaskEstimate({
 								<TickSaveIcon className={clsxm('lg:h-4 lg:w-4 w-2 h-2 mx-2')} />
 							</button>
 						) : (
-							<button onClick={() => setEditableMode(true)}>
+							<button
+								onClick={(e) => {
+									e.stopPropagation();
+									setEditableMode(true);
+								}}
+							>
 								<EditPenBoxIcon className={clsxm('lg:h-4 lg:w-4 w-2 h-2 mx-2')} />
 							</button>
 						)

--- a/apps/web/lib/features/team/user-team-card/task-estimate.tsx
+++ b/apps/web/lib/features/team/user-team-card/task-estimate.tsx
@@ -21,10 +21,35 @@ type Props = IClassName & {
 };
 
 export function TaskEstimateInfo({ className, activeAuthTask, showTime = true, radial = false, ...rest }: Props) {
+	const { memberInfo, edition } = rest;
+	const t = useTranslations();
+	const loadingRef = useRef<boolean>(false);
+	const task = edition.task || memberInfo.memberTask;
+	const hasEditMode = edition.estimateEditMode && task;
+	const closeFn = () => {
+		setTimeout(() => {
+			!loadingRef.current && edition.setEstimateEditMode(false);
+		}, 1);
+	};
+
 	return (
 		<div className={className}>
 			<div className="flex items-center flex-col gap-y-[2rem] justify-center">
-				{showTime && <TaskEstimateInput {...rest} />}
+				{showTime && (
+					<div className="flex space-x-2 items-center font-normal lg:text-sm text-xs">
+						<span className={clsxm('text-gray-500', hasEditMode && ['hidden'])}>
+							{t('common.ESTIMATED')}:
+						</span>
+						<TaskEstimate
+							_task={task}
+							loadingRef={loadingRef}
+							closeable_fc={closeFn}
+							onOpenEdition={() => edition.setEstimateEditMode(true)}
+							onCloseEdition={() => edition.setEstimateEditMode(false)}
+							showEditAndSaveButton={memberInfo.isAuthUser || memberInfo.isAuthTeamManager}
+						/>
+					</div>
+				)}
 
 				<TaskProgressBar
 					task={rest.edition.task || rest.memberInfo.memberTask}


### PR DESCRIPTION

## Description

Reuse one component for all implementations of tasks estimation time (Add, Edit) 

## Type of Change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Previous screenshots

![before](https://github.com/user-attachments/assets/951f4c96-f088-4400-aa36-395151e416b4)


## Current screenshots
![now](https://github.com/user-attachments/assets/00808f66-a23b-4c20-8721-83ed16e9e535)
