### PR TITLE
fix: remove planned task from 'Outstanding' tab

### DIFF
--- a/apps/web/app/hooks/features/useDailyPlan.ts
+++ b/apps/web/app/hooks/features/useDailyPlan.ts
@@ -271,6 +271,26 @@ export function useDailyPlan() {
 		return planDate.getTime() < today.getTime();
 	});
 
+	const todayPlan =
+		profileDailyPlans.items &&
+		[...profileDailyPlans.items].filter((plan) =>
+			plan.date?.toString()?.startsWith(new Date()?.toISOString().split('T')[0])
+		);
+
+	const todayTasks = todayPlan
+		.map((plan) => {
+			return plan.tasks ? plan.tasks : [];
+		})
+		.flat();
+
+	const futureTasks =
+		futurePlans &&
+		futurePlans
+			.map((plan) => {
+				return plan.tasks ? plan.tasks : [];
+			})
+			.flat();
+
 	const outstandingPlans =
 		profileDailyPlans.items &&
 		[...profileDailyPlans.items]
@@ -290,13 +310,14 @@ export function useDailyPlan() {
 				// Include only no completed tasks
 				tasks: plan.tasks?.filter((task) => task.status !== 'completed')
 			}))
+			.map((plan) => ({
+				...plan,
+				// Include only tasks that are not added yet to the today plan or future plans
+				tasks: plan.tasks?.filter(
+					(_task) => ![...todayTasks, ...futureTasks].find((task) => task.id === _task.id)
+				)
+			}))
 			.filter((plan) => plan.tasks?.length && plan.tasks.length > 0);
-
-	const todayPlan =
-		profileDailyPlans.items &&
-		[...profileDailyPlans.items].filter((plan) =>
-			plan.date?.toString()?.startsWith(new Date()?.toISOString().split('T')[0])
-		);
 
 	const sortedPlans =
 		profileDailyPlans.items &&

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -72,8 +72,6 @@ export function checkPastDate(dateToBeChecked?: Date): boolean {
 		date.setHours(0, 0, 0, 0);
 		todayDate.setHours(0, 0, 0, 0);
 
-		console.log(todayDate, date);
-
 		return todayDate > date;
 	} else {
 		return false; // Return false if dateToBeChecked is not provided or is null or undefined.


### PR DESCRIPTION
## Description

After adding a task to a plan from the outstanding tab, we should remove that task to 'Outstanding' tab

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Previous screenshots

[Loom](https://www.loom.com/share/b7cf8a93d2394f69859b62ccf4ba5e37?sid=7e1f3964-0ace-4f6f-9a5b-694da2f162dc)

## Current screenshots

[Loom](https://www.loom.com/share/dc373fdd9afd4027843580a69026eedb?sid=6b80d020-8927-4290-81dd-5490558e6ec1)
