### PR TITLE
fix: Action menu | remove blank space after adding a task to tomorrow plan

### DIFF
--- a/apps/web/lib/features/task/task-card.tsx
+++ b/apps/web/lib/features/task/task-card.tsx
@@ -620,15 +620,16 @@ function TaskCardMenu({
 														/>
 													</li>
 												)}
-
-												<li className="mb-2">
-													<PlanTask
-														planMode="tomorow"
-														taskId={task.id}
-														employeeId={profile?.member?.employeeId ?? ''}
-														taskPlannedForTomorrow={taskPlannedTomorrow}
-													/>
-												</li>
+												{!taskPlannedTomorrow && (
+													<li className="mb-2">
+														<PlanTask
+															planMode="tomorow"
+															taskId={task.id}
+															employeeId={profile?.member?.employeeId ?? ''}
+															taskPlannedForTomorrow={taskPlannedTomorrow}
+														/>
+													</li>
+												)}
 												<li className="mb-2">
 													<PlanTask
 														planMode="custom"
@@ -774,7 +775,7 @@ export function PlanTask({
 				)}
 				{planMode === 'tomorow' && !taskPlannedForTomorrow && (
 					<span>
-						{isPending ? (
+						{isPending || createDailyPlanLoading ? (
 							<ReloadIcon className="animate-spin mr-2 h-4 w-4" />
 						) : (
 							t('dailyPlan.PLAN_FOR_TOMORROW')


### PR DESCRIPTION
## Description

What I did:
- Add a loading icon when adding the task to tomorrow plan
- Remove the blank space on the Action menu after adding the plan to tomorrow plan

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Previous screenshots

[Loom](https://www.loom.com/share/be49ff7eec0b4afb87b32897a2112296?sid=f20c0f40-583a-4f2d-b3db-e1d631349133)

## Current screenshots

[Loom](https://www.loom.com/share/8f7f61edf36f4a2397711c28d5353a33?sid=418fa8ef-ee8a-4ace-b6c3-b792d2c5c29f)
