### PR TITLE
feat: redirect to 'unassigned' if no oustanding / assigned tasks (SOFT FLOW)

### DIFF
--- a/apps/web/lib/features/task/task-filters.tsx
+++ b/apps/web/lib/features/task/task-filters.tsx
@@ -121,7 +121,7 @@ export function useTaskFilter(profile: I_UserProfilePage) {
 	if (activeTeam?.shareProfileView || canSeeActivity) {
 		tabs.push({
 			tab: 'dailyplan',
-			name: t('common.DAILYPLAN'as DottedLanguageObjectStringPaths) ,
+			name: t('common.DAILYPLAN' as DottedLanguageObjectStringPaths),
 			description: t('task.tabFilter.DAILYPLAN_DESCRIPTION' as DottedLanguageObjectStringPaths),
 			count: profile.tasksGrouped.planned
 		});
@@ -174,8 +174,10 @@ export function useTaskFilter(profile: I_UserProfilePage) {
 			if (!getTotalTasks(todayPlan)) {
 				if (estimatedTotalTime(outstandingPlans).totalTasks) {
 					setTab('dailyplan');
-				} else {
+				} else if (profile.tasksGrouped.assignedTasks.length) {
 					setTab('assigned');
+				} else {
+					setTab('unassigned');
 				}
 			}
 		}
@@ -377,11 +379,7 @@ function InputFilters({ hook, profile }: Props) {
 					</Button>
 				</Tooltip>
 			</TaskUnOrAssignPopover>
-			<AddManualTimeModal
-				closeModal={closeManualTimeModal}
-				isOpen={isManualTimeModalOpen}
-				params='AddTime'
-			/>
+			<AddManualTimeModal closeModal={closeManualTimeModal} isOpen={isManualTimeModalOpen} params="AddTime" />
 		</div>
 	);
 }


### PR DESCRIPTION
## Description

Redirect the user to "Unassigned" tab if there is no outstanding and assigned tasks in SOFT FLOW if s/he does not have today plan after clicking on "OK" of the Daily plan popup

## Type of Change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings