### PR TITLE
fixbug: SOFT FLOW, popups logic when user added the today plan in the past

### DIFF
--- a/apps/web/app/hooks/features/useStartStopTimerHandler.ts
+++ b/apps/web/app/hooks/features/useStartStopTimerHandler.ts
@@ -88,7 +88,11 @@ export function useStartStopTimerHandler() {
 						startTimer();
 					}
 				} else {
-					openAddTasksEstimationHoursModal();
+					if (tasksEstimateHoursModalDate != currentDate) {
+						openAddTasksEstimationHoursModal();
+					} else {
+						startTimer();
+					}
 				}
 			} else {
 				startTimer();

--- a/apps/web/lib/features/daily-plan/add-daily-plan-work-hours-modal.tsx
+++ b/apps/web/lib/features/daily-plan/add-daily-plan-work-hours-modal.tsx
@@ -28,13 +28,13 @@ export function AddDailyPlanWorkHourModal(props: IAddDailyPlanWorkHoursModalProp
 	const handleCloseModal = useCallback(() => {
 		localStorage.setItem(DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE, currentDate);
 		closeModal();
-	}, [closeModal, currentDate]);
+		startTimer();
+	}, [closeModal, currentDate, startTimer]);
 
 	const handleSubmit = useCallback(() => {
 		updateDailyPlan({ workTimePlanned }, plan.id ?? '');
-		startTimer();
 		handleCloseModal();
-	}, [handleCloseModal, plan.id, startTimer, updateDailyPlan, workTimePlanned]);
+	}, [handleCloseModal, plan.id, updateDailyPlan, workTimePlanned]);
 
 	return (
 		<Modal isOpen={isOpen} closeModal={handleCloseModal} showCloseIcon={requirePlan ? false : true}>

--- a/apps/web/lib/features/daily-plan/add-task-estimation-hours-modal.tsx
+++ b/apps/web/lib/features/daily-plan/add-task-estimation-hours-modal.tsx
@@ -31,13 +31,14 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 	const handleCloseModal = useCallback(() => {
 		localStorage.setItem(TASKS_ESTIMATE_HOURS_MODAL_DATE, currentDate);
 		closeModal();
-	}, [closeModal, currentDate]);
+		startTimer();
+	}, [closeModal, currentDate, startTimer]);
 
 	const handleSubmit = useCallback(() => {
 		updateDailyPlan({ workTimePlanned }, plan.id ?? '');
-		startTimer();
+
 		handleCloseModal();
-	}, [handleCloseModal, plan.id, startTimer, updateDailyPlan, workTimePlanned]);
+	}, [handleCloseModal, plan.id, updateDailyPlan, workTimePlanned]);
 
 	return (
 		<Modal isOpen={isOpen} closeModal={handleCloseModal} showCloseIcon={requirePlan ? false : true}>


### PR DESCRIPTION

## Description

There was an issue with popups logic in the case where user starts a new day with a plan (could be defined in the past, i.e. yesterday or days before yesterday) 

What I did:
- I make sure to always test the last time a popup was opened (independently)

Additional changes (small):
- Start the timer if users ignore the popup (i.e. User clicks 'X' or cancel/Add later button)

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
