### PR TITLE
Planned tasks popup |  add unplan action menu

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
 	"caseSensitive": false,
 	"$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
 	"words": [
+		"Unplan",
 		"nivo",
 		"accepte",
 		"Accordian",

--- a/apps/web/lib/features/daily-plan/add-task-estimation-hours-modal.tsx
+++ b/apps/web/lib/features/daily-plan/add-task-estimation-hours-modal.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { TASKS_ESTIMATE_HOURS_MODAL_DATE } from '@app/constants';
 import { useMemo, useCallback, useState, useEffect } from 'react';
 import { PiWarningCircleFill } from 'react-icons/pi';
@@ -10,6 +11,9 @@ import { TaskEstimate } from '../task/task-estimate';
 import { IDailyPlan, ITeamTask } from '@app/interfaces';
 import clsx from 'clsx';
 import { AddIcon, ThreeCircleOutlineVerticalIcon } from 'assets/svg';
+import { Popover, Transition } from '@headlessui/react';
+import { clsxm } from '@app/utils';
+import Link from 'next/link';
 
 interface IAddTasksEstimationHoursModalProps {
 	closeModal: () => void;
@@ -107,7 +111,7 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 								</span>
 								<div className="flex flex-col gap-1">
 									{sortedTasks.map((task, index) => (
-										<TaskCard key={index} task={task} />
+										<TaskCard plan={plan} key={index} task={task} />
 									))}
 								</div>
 							</div>
@@ -143,9 +147,10 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 
 interface ITaskCardProps {
 	task: ITeamTask;
+	plan: IDailyPlan;
 }
 
-function TaskCard({ task }: ITaskCardProps) {
+function TaskCard({ task, plan }: ITaskCardProps) {
 	const { setActiveTask, activeTeamTask } = useTeamTasks();
 
 	return (
@@ -155,9 +160,8 @@ function TaskCard({ task }: ITaskCardProps) {
 				'lg:flex  items-center justify-between py-3  md:px-4 hidden min-h-[4.5rem] w-[30rem] h-[4.5rem] dark:bg-[#1E2025] border-[0.05rem] dark:border-[#FFFFFF0D] relative !text-xs cursor-pointer',
 				task.id === activeTeamTask?.id && 'border-primary-light border-[0.15rem]'
 			)}
-			onClick={() => setActiveTask(task)}
 		>
-			<div className="min-w-[48%] flex items-center h-full max-w-[50%]">
+			<div onClick={() => setActiveTask(task)} className="min-w-[48%] flex items-center h-full max-w-[50%]">
 				<TaskNameInfoDisplay task={task} />
 			</div>
 			<VerticalSeparator />
@@ -166,9 +170,190 @@ function TaskCard({ task }: ITaskCardProps) {
 					<span>Estimation :</span> <TaskEstimate _task={task} />
 				</div>
 				<span className="w-4 h-full flex items-center justify-center">
-					<ThreeCircleOutlineVerticalIcon className="  dark:text-[#B1AEBC]" />
+					<TaskCardActions selectedPlan={plan} task={task} />
 				</span>
 			</div>
 		</Card>
+	);
+}
+
+interface ITaskCardActionsProps {
+	task: ITeamTask;
+	selectedPlan: IDailyPlan;
+}
+
+/**
+ * A Popover that contents task actions (view, edit, unplan)
+ *
+ * @param {object} props - The props
+ * @param {ITeamTask} props.task - The task actions will be performed
+ * @param {IDailyPlan} props.selectedPlan - The currently selected plan
+ *
+ * @returns {JSX.Element} The Popover component.
+ */
+
+function TaskCardActions(props: ITaskCardActionsProps) {
+	const { task, selectedPlan } = props;
+
+	const { futurePlans, todayPlan } = useDailyPlan();
+
+	const otherPlanIds = useMemo(
+		() =>
+			[...futurePlans, ...todayPlan]
+				// Remove selected plan
+				.filter((plan) => plan.id! !== selectedPlan.id)
+				.filter((plan) => plan.tasks && plan.tasks.find((_task) => _task.id == task.id))
+				.map((plan) => plan.id!),
+		[futurePlans, selectedPlan.id, task.id, todayPlan]
+	);
+
+	/**
+	 * A function that removes task from one or more plans
+	 *
+	 * @param {string} [taskId] - The task ID
+	 * @param {string[]} [planIds] - The list of plan IDs
+	 *
+	 * @returns {void}
+	 *
+	 */
+	const handleUplanTask = useCallback(
+		(taskId: string, planIds: string[]) => {
+			console.log(task.id, selectedPlan, otherPlanIds);
+		},
+		[otherPlanIds, selectedPlan, task.id]
+	);
+
+	return (
+		<Popover>
+			<Popover.Button className="w-4 h-full flex items-center justify-center border-none outline-none">
+				<ThreeCircleOutlineVerticalIcon className="  dark:text-[#B1AEBC]" />
+			</Popover.Button>
+
+			<Transition
+				enter="transition duration-100 ease-out"
+				enterFrom="transform scale-95 opacity-0"
+				enterTo="transform scale-100 opacity-100"
+				leave="transition duration-75 ease-out"
+				leaveFrom="transform scale-100 opacity-100"
+				leaveTo="transform scale-95 opacity-0"
+				className="absolute z-10 right-0 min-w-[110px]"
+			>
+				<Popover.Panel>
+					{() => {
+						return (
+							<Card shadow="custom" className=" shadow-xlcard  !p-3 !rounded-lg !border-2">
+								<ul className=" flex flex-col justify-end gap-3">
+									<li className="">
+										<Link
+											href={`/task/${task.id}`}
+											className={clsxm('hover:font-semibold hover:transition-all')}
+										>
+											View
+										</Link>
+									</li>
+									<li className={clsxm('hover:font-semibold hover:transition-all')}>Edit</li>
+
+									{selectedPlan && selectedPlan.id && (
+										<li>
+											{otherPlanIds.length ? (
+												<UplanTask
+													taskId={task.id}
+													selectedPlanId={selectedPlan.id}
+													planIds={otherPlanIds}
+													unplanHandler={handleUplanTask}
+												/>
+											) : (
+												<span
+													onClick={() => handleUplanTask(task.id, [selectedPlan.id!])}
+													className={clsxm(
+														' text-red-600 hover:font-semibold hover:transition-all'
+													)}
+												>
+													Unplan
+												</span>
+											)}
+										</li>
+									)}
+								</ul>
+							</Card>
+						);
+					}}
+				</Popover.Panel>
+			</Transition>
+		</Popover>
+	);
+}
+
+interface IUnplanTaskProps {
+	taskId: string;
+	selectedPlanId: string;
+	planIds: string[];
+	unplanHandler: (taskId: string, planIds: string[]) => void;
+}
+
+/**
+ * A Popover that contents unplan options (view, edit, unplan)
+ *
+ * @param {object} props - The props
+ * @param {string} props.taskId - The task ID with which actions will be performed
+ * @param {string} props.selectedPlanId - The currently selected plan id
+ * @param {string[]} [props.planIds] - The plans's ids
+ * @param {(taskId : string, planIds : string[]) => void} props.unplanHandler - The function to perform the action (unplan)
+ *
+ * @returns {JSX.Element} The Popover component.
+ */
+
+function UplanTask(props: IUnplanTaskProps) {
+	const { taskId, selectedPlanId, planIds, unplanHandler } = props;
+	return (
+		<Popover>
+			<Popover.Button>
+				<span className={clsxm(' text-red-600 hover:font-semibold hover:transition-all')}>Unplan</span>
+			</Popover.Button>
+
+			<Transition
+				enter="transition duration-100 ease-out"
+				enterFrom="transform scale-95 opacity-0"
+				enterTo="transform scale-100 opacity-100"
+				leave="transition duration-75 ease-out"
+				leaveFrom="transform scale-100 opacity-100"
+				leaveTo="transform scale-95 opacity-0"
+				className="absolute z-10 right-0 min-w-[110px]"
+			>
+				<Popover.Panel>
+					{({ close }) => {
+						return (
+							<Card
+								shadow="custom"
+								className=" shadow-xlcard  min-w-max w-40 flex flex-col justify-end !p-0 !rounded-lg !border-2"
+							>
+								<ul className="p-3 w-full flex flex-col border justify-end gap-3">
+									<li
+										onClick={() => unplanHandler(taskId, [selectedPlanId])}
+										className={clsxm('hover:font-semibold hover:transition-all shrink-0')}
+									>
+										Uplan selected date
+									</li>
+									<li
+										onClick={() => unplanHandler(taskId, planIds)}
+										className={clsxm('hover:font-semibold hover:transition-all')}
+									>
+										Unplan all
+									</li>
+								</ul>
+								<button
+									onClick={() => {
+										close();
+									}}
+									className={clsxm('w-full bg-primary/5 px-3 py-2')}
+								>
+									<span>Cancel</span>
+								</button>
+							</Card>
+						);
+					}}
+				</Popover.Panel>
+			</Transition>
+		</Popover>
 	);
 }


### PR DESCRIPTION
## Description

This PR fixes #2961 

What I did:
- User can now remove a task from the today's plan (or all plans) on the 'Planned tasks' popup

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings


## Current screenshots

[Loom](https://www.loom.com/share/801ce079cc924b32b7a91fe92ef6d58d?sid=bcf31cde-e6a1-4562-acd3-ff4c359410e8)