### PR TITLE
feat: adapt sub-menus of 'Team' & 'Personal' menus UI

### DIFF
--- a/apps/web/lib/components/sidebar-accordian.tsx
+++ b/apps/web/lib/components/sidebar-accordian.tsx
@@ -19,7 +19,7 @@ export const SidebarAccordian = ({ children, title, className, wrapperClassName,
 					{({ open }) => (
 						<>
 							<Disclosure.Button
-								className={`flex w-full justify-between rounded-lg px-4 py-2 text-left font-medium items-center ${wrapperClassName} pt-[0.15rem] pb-0`}
+								className={`flex w-full justify-between rounded-lg px-4 py-2 text-left font-medium items-center ${wrapperClassName} pt-[0.15rem] pb-0 ${open ? 'text-[#3826a6] border-l-solid border-l-primary bg-[#E9E5F9] dark:bg-[#6755C9]' : 'border-l-transparent'}`}
 							>
 								<Text
 									className={`text-base dark:text-white  text-center sm:text-left flex items-center gap-2 ${textClassName}`}
@@ -34,7 +34,7 @@ export const SidebarAccordian = ({ children, title, className, wrapperClassName,
 								/>
 							</Disclosure.Button>
 							{children && (
-								<Disclosure.Panel className="px-4 pt-4 pb-2 text-sm text-gray-500 ">
+								<Disclosure.Panel className="px-4 pt-4 pb-2 text-sm text-gray-500 dark:bg-dark--theme shadow-[0px 14px 34px rgba(0, 0, 0, 0.05)] bg-light--theme-light dark:bg-dark--theme-light ">
 									{children}
 								</Disclosure.Panel>
 							)}

--- a/apps/web/lib/settings/left-side-setting-menu.tsx
+++ b/apps/web/lib/settings/left-side-setting-menu.tsx
@@ -99,14 +99,9 @@ export const LeftSideSettingMenu = ({ className }: { className?: string }) => {
 								: 'border-l-transparent font-normal dark:text-[#7E7991]'
 						}
 						`}
-						wrapperClassName={`w-full border-t-0 border-r-0 border-b-0 rounded-none
-                font-normal text-[#7e7991] justify-start  pt-[24px] pb-[24px] pl-[24px]
-				border-l-[5px] ${
-					activePage === '/settings/personal'
-						? 'text-[#3826a6] border-l-solid border-l-primary bg-[#E9E5F9] dark:bg-[#6755C9]'
-						: 'border-l-transparent'
-				}
-                `}
+						wrapperClassName={
+							'w-full border-t-0 border-r-0 border-b-0 rounded-none font-normal text-[#7e7991] justify-start  pt-[24px] pb-[24px] pl-[24px]	border-l-[5px]'
+						}
 					>
 						<div className="flex flex-col">
 							{PersonalAccordianData.map((ad, index) => {
@@ -117,7 +112,7 @@ export const LeftSideSettingMenu = ({ className }: { className?: string }) => {
 										key={index}
 									>
 										<Text
-											className={`text-[${ad.color}] text-lg font-normal flex items-center p-4 pr-1 pl-5`}
+											className={`text-[${ad.color}] text-lg font-normal flex items-center p-4 pr-1 pl-12`}
 											key={index}
 											style={{ color: ad.color }}
 										>
@@ -146,14 +141,9 @@ export const LeftSideSettingMenu = ({ className }: { className?: string }) => {
 								? ' text-[#3826a6] text-primary font-semibold'
 								: ' border-l-transparent font-normal dark:text-[#7E7991]'
 						}`}
-						wrapperClassName={`w-full border-t-0 border-r-0 border-b-0 rounded-none
-						font-normal text-[#7e7991] justify-start text-sm pt-[24px] pb-[24px] pl-[24px]
-	border-l-[5px] ${
-		activePage === '/settings/team'
-			? ' text-[#3826a6] border-l-solid border-l-primary bg-primary/5 text-primary dark:bg-[#6755C9]'
-			: ' border-l-transparent'
-	}
-						`}
+						wrapperClassName={
+							'w-full border-t-0 border-r-0 border-b-0 rounded-none	font-normal text-[#7e7991] justify-start text-sm pt-[24px] pb-[24px] pl-[24px] border-l-[5px]'
+						}
 					>
 						<div className="flex flex-col">
 							{TeamAccordianData.filter((ad) => (!isTeamManager && !ad.managerOnly) || isTeamManager).map(
@@ -165,7 +155,7 @@ export const LeftSideSettingMenu = ({ className }: { className?: string }) => {
 											key={index}
 										>
 											<Text
-												className={`text-[${ad.color}] text-lg font-normal flex items-center p-4 pr-1 pl-5 `}
+												className={`text-[${ad.color}] text-lg font-normal flex items-center p-4 pr-1 pl-12 `}
 												key={index}
 												style={{
 													color: ad.color,


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue.

I just adapted the sidebar menus of settings so that it is visible as requested in issue #3013 

## Type of Change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Breaking change
-   [ ] Documentation update

## Checklist

-   [X] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots

Please add here videos or images of previous status

On #3013 issue

## Current screenshots

Please add here videos or images of previous status

![Capture d’écran du 2024-09-12 16-19-39](https://github.com/user-attachments/assets/08901b98-5c02-42ba-8588-aacec7e629cb)
