### PR TITLE
Daily plan requests | employeeId should be a string

### DIFF
--- a/apps/web/app/hooks/features/useDailyPlan.ts
+++ b/apps/web/app/hooks/features/useDailyPlan.ts
@@ -82,11 +82,13 @@ export function useDailyPlan() {
 
 	const getEmployeeDayPlans = useCallback(
 		(employeeId: string) => {
-			queryCall(employeeId).then((response) => {
-				const { items, total } = response.data;
-				setProfileDailyPlans({ items, total });
-				setEmployeePlans(items);
-			});
+			if (employeeId && typeof employeeId === 'string') {
+				queryCall(employeeId).then((response) => {
+					const { items, total } = response.data;
+					setProfileDailyPlans({ items, total });
+					setEmployeePlans(items);
+				});
+			}
 		},
 		[queryCall, setEmployeePlans, setProfileDailyPlans]
 	);


### PR DESCRIPTION
## Description

Make sure the employeeId is a string in dailyPlans requests

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings