### PR TITLE
feat: today's date in calenday should look differently

### DIFF
--- a/apps/web/lib/features/daily-plan/all-plans-modal.tsx
+++ b/apps/web/lib/features/daily-plan/all-plans-modal.tsx
@@ -353,7 +353,8 @@ const FuturePlansCalendar = memo(function FuturePlansCalendar(props: ICalendarPr
 
 				pastDay: clsxm(
 					'relative after:absolute after:bottom-0 after:left-1/2 after:-translate-x-1/2 after:w-1.5 after:h-1.5 after:bg-yellow-600 after:rounded-full'
-				)
+				),
+				today: clsxm('border-2 !border-yellow-700 rounded')
 			}}
 			fromYear={new Date(sortedPlans?.[0]?.date ?? Date.now())?.getFullYear()}
 			toYear={new Date(sortedPlans?.[sortedPlans?.length - 1]?.date ?? Date.now())?.getFullYear() + 5}

--- a/apps/web/lib/features/daily-plan/create-daily-plan-form-modal.tsx
+++ b/apps/web/lib/features/daily-plan/create-daily-plan-form-modal.tsx
@@ -242,7 +242,10 @@ const CustomCalendar = memo(function CustomCalendar({
 			modifiers={{
 				booked: existingPlanDates
 			}}
-			modifiersClassNames={{ booked: 'bg-primary text-white' }}
+			modifiersClassNames={{
+				booked: 'bg-primary text-white',
+				today: clsxm('border-2 !border-yellow-700 rounded')
+			}}
 			fromYear={new Date().getUTCFullYear()}
 			toYear={new Date().getUTCFullYear() + 5}
 		/>


### PR DESCRIPTION

## Description

Today's date should be a string in calendars

## Type of Change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Previous screenshots
![Screenshot from 2024-09-26 19-19-40](https://github.com/user-attachments/assets/6cbc0682-dea0-4cc0-b95b-6e6fc1297587)
![Screenshot from 2024-09-26 19-18-38](https://github.com/user-attachments/assets/b4857399-3d14-4f51-9a89-b6c01b7a4cd9)

## Current screenshots
![Screenshot from 2024-09-26 19-09-36](https://github.com/user-attachments/assets/1ebda1f1-54fd-4195-939b-841950023d7a)
![Screenshot from 2024-09-26 19-09-11](https://github.com/user-attachments/assets/0a29fdad-e925-4cf4-89bd-3669befd8036)

