### PR TITLE
[Fix] Settings | Icon direction when sections are collapsed / expended

### DIFF
--- a/apps/web/lib/components/accordian.tsx
+++ b/apps/web/lib/components/accordian.tsx
@@ -30,7 +30,7 @@ export const Accordian = ({ children, title, className, isDanger, id, defaultOpe
 
 								<ChevronUpIcon
 									className={`${
-										open ? 'rotate-180 transform' : ''
+										!open ? 'rotate-180 transform' : ''
 									} h-5 w-5 text-[#292D32] dark:text-white`}
 								/>
 							</Disclosure.Button>


### PR DESCRIPTION
## Description

- Reverse the condition that changes the icon 
- this PR fix the #3080 issue

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots

On #3080 issue

## Current screenshots

[Screencast from 2024-10-03 07-00-46.webm](https://github.com/user-attachments/assets/ddb499bb-bd8d-47a3-978a-cbef2d21ad71)

