### PR TITLE
fixbug: fix suggest daily plan modal

### DIFF
--- a/apps/web/app/constants.ts
+++ b/apps/web/app/constants.ts
@@ -286,6 +286,7 @@ export const DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE = 'daily-plan-estimate-hours-m
 export const DEFAULT_PLANNED_TASK_ID = 'default-planned-task-id';
 export const LAST_OPTION__CREATE_DAILY_PLAN_MODAL = 'last-option--create-daily-plan-modal';
 export const HAS_VISITED_OUTSTANDING_TASKS = 'has-visited-outstanding-tasks';
+export const HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL = 'has-seen-daily-plan-suggestion-modal';
 
 // OAuth provider's keys
 

--- a/apps/web/app/hooks/features/useStartStopTimerHandler.ts
+++ b/apps/web/app/hooks/features/useStartStopTimerHandler.ts
@@ -88,13 +88,13 @@ export function useStartStopTimerHandler() {
 					if (tasksEstimateHoursModalDate != currentDate) {
 						openAddTasksEstimationHoursModal();
 					} else {
-						handleWarnings();
+						startTimerOrAskEstimate();
 					}
 				} else {
 					openEnforcePlannedTaskSoftModal();
 				}
 			} else {
-				handleWarnings();
+				startTimerOrAskEstimate();
 			}
 		};
 
@@ -106,10 +106,10 @@ export function useStartStopTimerHandler() {
 				if (!hasWorkedHours) {
 					openAddDailyPlanWorkHoursModal();
 				} else {
-					handleWarnings();
+					startTimerOrAskEstimate();
 				}
 			} else {
-				handleWarnings();
+				startTimerOrAskEstimate();
 			}
 		};
 
@@ -124,17 +124,17 @@ export function useStartStopTimerHandler() {
 					if (dailyPlanEstimateHoursModalDate != currentDate) {
 						handleMissingDailyPlanWorkHour();
 					} else {
-						handleWarnings();
+						startTimerOrAskEstimate();
 					}
 				} else {
 					if (tasksEstimateHoursModalDate != currentDate) {
 						openAddTasksEstimationHoursModal();
 					} else {
-						handleWarnings();
+						startTimerOrAskEstimate();
 					}
 				}
 			} else {
-				handleWarnings();
+				startTimerOrAskEstimate();
 			}
 		};
 
@@ -142,7 +142,7 @@ export function useStartStopTimerHandler() {
 		 * Check if there is warning for 'enforce' mode. If not,
 		 * start tracking
 		 */
-		const handleWarnings = () => {
+		const startTimerOrAskEstimate = () => {
 			if (
 				requirePlan &&
 				(!areAllTasksEstimated ||
@@ -170,7 +170,7 @@ export function useStartStopTimerHandler() {
 				tasksEstimateHoursModalDate == currentDate &&
 				dailyPlanEstimateHoursModalDate == currentDate
 			) {
-				handleWarnings();
+				startTimerOrAskEstimate();
 			} else {
 				if (dailyPlanSuggestionModalDate != currentDate) {
 					if (!hasPlan) {
@@ -185,13 +185,13 @@ export function useStartStopTimerHandler() {
 						if (areAllTasksEstimated) {
 							handleMissingDailyPlanWorkHour();
 						} else {
-							handleWarnings();
+							startTimerOrAskEstimate();
 						}
 					} else {
-						handleWarnings();
+						startTimerOrAskEstimate();
 					}
 				} else {
-					handleWarnings();
+					startTimerOrAskEstimate();
 				}
 			}
 		}

--- a/apps/web/lib/features/daily-plan/add-task-estimation-hours-modal.tsx
+++ b/apps/web/lib/features/daily-plan/add-task-estimation-hours-modal.tsx
@@ -461,7 +461,7 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 											? canStartWorking && requirePlan && (planEditState.draft || warning)
 												? true
 												: false
-											: canStartWorking && requirePlan
+											: canStartWorking && requirePlan && Boolean(warning)
 								}
 								variant="outline"
 								type="submit"

--- a/apps/web/lib/features/daily-plan/suggest-daily-plan-modal.tsx
+++ b/apps/web/lib/features/daily-plan/suggest-daily-plan-modal.tsx
@@ -1,10 +1,11 @@
 import { Modal, Card, Text } from 'lib/components';
 import { Button } from '@components/ui/button';
 import { useCallback, useMemo } from 'react';
-import { DAILY_PLAN_SUGGESTION_MODAL_DATE } from '@app/constants';
+import { DAILY_PLAN_SUGGESTION_MODAL_DATE, HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL } from '@app/constants';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useAuthenticateUser } from '@app/hooks';
+import { usePathname } from 'next/navigation';
 
 interface ISuggestDailyPlanModalProps {
 	closeModal: () => void;
@@ -19,15 +20,18 @@ export function SuggestDailyPlanModal(props: ISuggestDailyPlanModalProps) {
 		() => user?.name || user?.firstName || user?.lastName || user?.username || '',
 		[user?.firstName, user?.lastName, user?.name, user?.username]
 	);
-
+	const path = usePathname();
 	const t = useTranslations();
 
 	const currentDate = useMemo(() => new Date().toISOString().split('T')[0], []);
 
 	const handleCloseModal = useCallback(() => {
-		localStorage.setItem(DAILY_PLAN_SUGGESTION_MODAL_DATE, currentDate);
+		localStorage.setItem(HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL, currentDate);
+		if (path.split('/')[1] == 'profile') {
+			localStorage.setItem(DAILY_PLAN_SUGGESTION_MODAL_DATE, currentDate);
+		}
 		closeModal();
-	}, [closeModal, currentDate]);
+	}, [closeModal, currentDate, path]);
 
 	return (
 		<Modal isOpen={isOpen} closeModal={handleCloseModal} showCloseIcon={false}>

--- a/apps/web/lib/features/user-profile-plans.tsx
+++ b/apps/web/lib/features/user-profile-plans.tsx
@@ -14,7 +14,11 @@ import { useAuthenticateUser, useCanSeeActivityScreen, useDailyPlan, useUserProf
 import { useDateRange } from '@app/hooks/useDateRange';
 import { filterDailyPlan } from '@app/hooks/useFilterDateRange';
 import { useLocalStorageState } from '@app/hooks/useLocalStorageState';
-import { DAILY_PLAN_SUGGESTION_MODAL_DATE, HAS_VISITED_OUTSTANDING_TASKS } from '@app/constants';
+import {
+	DAILY_PLAN_SUGGESTION_MODAL_DATE,
+	HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL,
+	HAS_VISITED_OUTSTANDING_TASKS
+} from '@app/constants';
 import { IDailyPlan, ITeamTask } from '@app/interfaces';
 import { dataDailyPlanState } from '@app/stores';
 import { fullWidthState } from '@app/stores/fullWidth';
@@ -72,6 +76,7 @@ export function UserProfilePlans() {
 	const [filterAllPlanData, setFilterAllPlanData] = useState<IDailyPlan[]>(sortedPlans);
 	const dailyPlanSuggestionModalDate = window && window?.localStorage.getItem(DAILY_PLAN_SUGGESTION_MODAL_DATE);
 	const path = usePathname();
+	const haveSeenDailyPlanSuggestionModal = window?.localStorage.getItem(HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL);
 
 	// Set the tab plan tab to outstanding if user has no daily plan and there are outstanding tasks (on first load)
 	useEffect(() => {
@@ -79,7 +84,9 @@ export function UserProfilePlans() {
 			if (estimatedTotalTime(outstandingPlans).totalTasks) {
 				setCurrentTab('Outstanding');
 			}
-			window.localStorage.setItem(DAILY_PLAN_SUGGESTION_MODAL_DATE, new Date().toISOString().split('T')[0]);
+			if (haveSeenDailyPlanSuggestionModal == new Date().toISOString().split('T')[0]) {
+				window.localStorage.setItem(DAILY_PLAN_SUGGESTION_MODAL_DATE, new Date().toISOString().split('T')[0]);
+			}
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Description

This PR fixes the current issue in SOFT FLOW. 

The issue was, if you visit the profile page without a plan, if you start the timer, you should first see a popup that suggests creating a plan for today. (This was not working due to wrong local storage variable management)

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant to manage user interaction with the daily plan suggestion modal.
	- Enhanced modal functionality with conditional logic based on the user's current location within the application.
- **Improvements**
	- Streamlined logic for managing task estimation and warnings in the timer functionality.
	- Refined user experience with clearer feedback regarding task visibility and interaction with suggestion modals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->