### PR TITLE
refactor: the timer should not start when the user ignores the 'Todayplan' popup

### DIFF
--- a/apps/web/app/hooks/features/useStartStopTimerHandler.ts
+++ b/apps/web/app/hooks/features/useStartStopTimerHandler.ts
@@ -162,7 +162,7 @@ export function useStartStopTimerHandler() {
 		if (timerStatusFetching || !canRunTimer) return;
 		if (timerStatus?.running) {
 			stopTimer();
-		} else if (requirePlan && !isActiveTaskPlaned) {
+		} else if (requirePlan && hasPlan && !isActiveTaskPlaned) {
 			openEnforcePlannedTaskModal();
 		} else {
 			if (

--- a/apps/web/app/hooks/features/useTimer.ts
+++ b/apps/web/app/hooks/features/useTimer.ts
@@ -265,9 +265,7 @@ export function useTimer() {
     user?.isEmailVerified &&
     ((!!activeTeamTask && activeTeamTask.status !== 'closed') ||
       // If timer is running at some other source and user may or may not have selected the task
-      timerStatusRef.current?.lastLog?.source !== TimerSource.TEAMS) &&
-    // If team settings require to have a plan to be able track
-    canTrack;
+      timerStatusRef.current?.lastLog?.source !== TimerSource.TEAMS)
 
   // Local time status
   const {

--- a/apps/web/lib/components/modal.tsx
+++ b/apps/web/lib/components/modal.tsx
@@ -15,6 +15,7 @@ type Props = {
 	className?: string;
 	alignCloseIcon?: boolean;
 	showCloseIcon?: boolean;
+	closeOnOutsideClick?: boolean;
 } & PropsWithChildren;
 
 export function Modal({
@@ -27,7 +28,8 @@ export function Modal({
 	description,
 	className,
 	alignCloseIcon,
-	showCloseIcon = true
+	showCloseIcon = true,
+	closeOnOutsideClick = false
 }: Props) {
 	const refDiv = useRef(null);
 
@@ -44,7 +46,7 @@ export function Modal({
 		>
 			<Dialog
 				initialFocus={refDiv}
-				onClose={closeModal}
+				onClose={closeOnOutsideClick ? closeModal : () => null}
 				as="div"
 				className="fixed inset-0 backdrop-brightness-90 backdrop-blur-sm z-[9999] w-full h-full"
 			>
@@ -52,28 +54,32 @@ export function Modal({
 					<Dialog.Overlay
 						className={clsxm('flex justify-center items-center flex-col space-y-1 relative', className)}
 					>
-						{title && <Dialog.Title className={clsxm(titleClass)}>{title}</Dialog.Title>}
-						{description && <Dialog.Description>{description}</Dialog.Description>}
-						{showCloseIcon && (
-							<div
-								onClick={() => {
-									closeModal();
-									customCloseModal?.();
-								}}
-								className={`absolute ${
-									alignCloseIcon ? 'right-2 top-3' : 'right-3 top-3'
-								}  md:right-2 md:top-3 cursor-pointer z-50`}
-							>
-								<Image
-									src={'/assets/svg/close.svg'}
-									alt="close"
-									width={28}
-									height={28}
-									className="w-6 md:w-7"
-								/>
-							</div>
-						)}
-						{children}
+						<Dialog.Panel
+							className={clsxm('flex justify-center items-center flex-col space-y-1 relative', className)}
+						>
+							{title && <Dialog.Title className={clsxm(titleClass)}>{title}</Dialog.Title>}
+							{description && <Dialog.Description>{description}</Dialog.Description>}
+							{showCloseIcon && (
+								<div
+									onClick={() => {
+										closeModal();
+										customCloseModal?.();
+									}}
+									className={`absolute ${
+										alignCloseIcon ? 'right-2 top-3' : 'right-3 top-3'
+									}  md:right-2 md:top-3 cursor-pointer z-50`}
+								>
+									<Image
+										src={'/assets/svg/close.svg'}
+										alt="close"
+										width={28}
+										height={28}
+										className="w-6 md:w-7"
+									/>
+								</div>
+							)}
+							{children}
+						</Dialog.Panel>
 					</Dialog.Overlay>
 				</div>
 			</Dialog>

--- a/apps/web/lib/components/switch.tsx
+++ b/apps/web/lib/components/switch.tsx
@@ -5,6 +5,7 @@ import { Switch } from '@headlessui/react';
 import { useCallback, useEffect, useState } from 'react';
 import { Text } from './typography';
 import { useTranslations } from 'next-intl';
+import { DAILY_PLAN_SUGGESTION_MODAL_DATE } from '@app/constants';
 
 export default function TimeTrackingToggle({ activeManager }: { activeManager: OT_Member | undefined }) {
 	const t = useTranslations();
@@ -129,6 +130,9 @@ export function RequireDailyPlanToTrack() {
 					.filter((value, index, array) => array.indexOf(value) === index)
 			});
 			setEnabled(!enabled);
+			if (!enabled) {
+				localStorage.removeItem(DAILY_PLAN_SUGGESTION_MODAL_DATE);
+			}
 		}
 	}, [activeTeam, editOrganizationTeam, enabled]);
 

--- a/apps/web/lib/features/daily-plan/add-daily-plan-work-hours-modal.tsx
+++ b/apps/web/lib/features/daily-plan/add-daily-plan-work-hours-modal.tsx
@@ -87,7 +87,7 @@ export function AddDailyPlanWorkHourModal(props: IAddDailyPlanWorkHoursModalProp
 						<Button
 							variant="default"
 							type="submit"
-							disabled={requirePlan ? (hasWorkHours ? false : true) : false}
+							disabled={loading || (requirePlan ? (hasWorkHours ? false : true) : false)}
 							className="py-3 px-5 min-w-[10rem] rounded-md font-light text-md dark:text-white"
 							onClick={handleSubmit}
 						>

--- a/apps/web/lib/features/daily-plan/add-daily-plan-work-hours-modal.tsx
+++ b/apps/web/lib/features/daily-plan/add-daily-plan-work-hours-modal.tsx
@@ -50,7 +50,7 @@ export function AddDailyPlanWorkHourModal(props: IAddDailyPlanWorkHoursModalProp
 	}, [handleCloseModal, plan, startTimer, updateDailyPlan, workTimePlanned]);
 
 	return (
-		<Modal isOpen={isOpen} closeModal={handleCloseModal} showCloseIcon={requirePlan ? false : true}>
+		<Modal isOpen={isOpen} closeModal={handleCloseModal} showCloseIcon>
 			<Card className="w-full" shadow="custom">
 				<div className="flex flex-col justify-between">
 					<div className="mb-7">

--- a/apps/web/lib/features/daily-plan/add-daily-plan-work-hours-modal.tsx
+++ b/apps/web/lib/features/daily-plan/add-daily-plan-work-hours-modal.tsx
@@ -35,9 +35,9 @@ export function AddDailyPlanWorkHourModal(props: IAddDailyPlanWorkHoursModalProp
 			setLoading(true);
 
 			// Update the plan work time only if the user changed it
-			plan &&
-				plan.workTimePlanned !== workTimePlanned &&
-				(await updateDailyPlan({ workTimePlanned }, plan.id ?? ''));
+			if (plan && plan.workTimePlanned !== workTimePlanned) {
+				await updateDailyPlan({ workTimePlanned }, plan.id ?? '');
+			}
 
 			startTimer();
 
@@ -87,7 +87,7 @@ export function AddDailyPlanWorkHourModal(props: IAddDailyPlanWorkHoursModalProp
 						<Button
 							variant="default"
 							type="submit"
-							disabled={loading || (requirePlan ? (hasWorkHours ? false : true) : false)}
+							disabled={loading || (requirePlan && !hasWorkHours)}
 							className="py-3 px-5 min-w-[10rem] rounded-md font-light text-md dark:text-white"
 							onClick={handleSubmit}
 						>

--- a/apps/web/lib/features/daily-plan/add-task-estimation-hours-modal.tsx
+++ b/apps/web/lib/features/daily-plan/add-task-estimation-hours-modal.tsx
@@ -57,11 +57,10 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 	const t = useTranslations();
 	const { updateDailyPlan, myDailyPlans } = useDailyPlan();
 	const { startTimer, timerStatus } = useTimerView();
-	const { activeTeam, activeTeamTask, setActiveTask } = useTeamTasks();
+	const { activeTeamTask, setActiveTask } = useTeamTasks();
 	const [showSearchInput, setShowSearchInput] = useState(false);
 	const [workTimePlanned, setWorkTimePlanned] = useState<number>(plan?.workTimePlanned ?? 0);
 	const currentDate = useMemo(() => new Date().toISOString().split('T')[0], []);
-	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 	const tasksEstimationTimes = useMemo(
 		() => (plan && plan.tasks ? estimatedTotalTime(plan.tasks).timesEstimated / 3600 : 0),
 		[plan]
@@ -466,15 +465,7 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 						</div>
 						<div className=" flex justify-between items-center">
 							<Button
-								disabled={
-									loading || isRenderedInSoftFlow
-										? canStartWorking && requirePlan
-										: timerStatus?.running
-											? canStartWorking && requirePlan && (planEditState.draft || warning)
-												? true
-												: false
-											: canStartWorking && requirePlan && Boolean(warning)
-								}
+								disabled={loading}
 								variant="outline"
 								type="submit"
 								className="py-3 px-5 w-40 rounded-md font-light text-md dark:text-white dark:bg-slate-700 dark:border-slate-600"
@@ -501,7 +492,7 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 	return (
 		<>
 			{isRenderedInSoftFlow ? (
-				<Modal isOpen={isOpen} closeModal={closeModalAndSubmit} showCloseIcon={requirePlan ? false : true}>
+				<Modal isOpen={isOpen} closeModal={closeModalAndSubmit} showCloseIcon>
 					<Card className="w-[36rem]" shadow="custom">
 						{content}
 					</Card>

--- a/apps/web/lib/features/daily-plan/add-task-estimation-hours-modal.tsx
+++ b/apps/web/lib/features/daily-plan/add-task-estimation-hours-modal.tsx
@@ -108,12 +108,24 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 	/**
 	 * The function that close the Planned tasks modal when the user ignores the modal (Today's plan)
 	 */
-	const closeModalAndStartTimer = useCallback(() => {
-		handleCloseModal();
-		if (canStartWorking) {
-			startTimer();
+	const closeModalAndSubmit = useCallback(async () => {
+		try {
+			setLoading(true);
+
+			// Update the plan work time only if the user changed it
+			plan &&
+				plan.workTimePlanned !== workTimePlanned &&
+				(await updateDailyPlan({ workTimePlanned }, plan.id ?? ''));
+
+			setPlanEditState({ draft: false, saved: true });
+
+			handleCloseModal();
+		} catch (error) {
+			console.log(error);
+		} finally {
+			setLoading(false);
 		}
-	}, [canStartWorking, handleCloseModal, startTimer]);
+	}, [handleCloseModal, plan, updateDailyPlan, workTimePlanned]);
 
 	/**
 	 * The function that opens the Change task modal if conditions are met (or start the timer)
@@ -466,7 +478,7 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 								variant="outline"
 								type="submit"
 								className="py-3 px-5 w-40 rounded-md font-light text-md dark:text-white dark:bg-slate-700 dark:border-slate-600"
-								onClick={isRenderedInSoftFlow ? closeModalAndStartTimer : handleCloseModal}
+								onClick={isRenderedInSoftFlow ? closeModalAndSubmit : handleCloseModal}
 							>
 								{isRenderedInSoftFlow ? t('common.SKIP_ADD_LATER') : t('common.CANCEL')}
 							</Button>
@@ -489,7 +501,7 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 	return (
 		<>
 			{isRenderedInSoftFlow ? (
-				<Modal isOpen={isOpen} closeModal={closeModalAndStartTimer} showCloseIcon={requirePlan ? false : true}>
+				<Modal isOpen={isOpen} closeModal={closeModalAndSubmit} showCloseIcon={requirePlan ? false : true}>
 					<Card className="w-[36rem]" shadow="custom">
 						{content}
 					</Card>

--- a/apps/web/lib/features/daily-plan/suggest-daily-plan-modal.tsx
+++ b/apps/web/lib/features/daily-plan/suggest-daily-plan-modal.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react';
 import { DAILY_PLAN_SUGGESTION_MODAL_DATE, HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL } from '@app/constants';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { useAuthenticateUser } from '@app/hooks';
+import { useAuthenticateUser, useTeamTasks, useTimer } from '@app/hooks';
 import { usePathname } from 'next/navigation';
 
 interface ISuggestDailyPlanModalProps {
@@ -14,27 +14,38 @@ interface ISuggestDailyPlanModalProps {
 
 export function SuggestDailyPlanModal(props: ISuggestDailyPlanModalProps) {
 	const { isOpen, closeModal } = props;
-
+	const { hasPlan } = useTimer();
+	const { activeTeam } = useTeamTasks();
 	const { user } = useAuthenticateUser();
 	const name = useMemo(
 		() => user?.name || user?.firstName || user?.lastName || user?.username || '',
 		[user?.firstName, user?.lastName, user?.name, user?.username]
 	);
+	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 	const path = usePathname();
 	const t = useTranslations();
 
 	const currentDate = useMemo(() => new Date().toISOString().split('T')[0], []);
 
 	const handleCloseModal = useCallback(() => {
-		localStorage.setItem(HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL, currentDate);
+		if (!requirePlan || (requirePlan && hasPlan)) {
+			localStorage.setItem(HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL, currentDate);
+		}
 		if (path.split('/')[1] == 'profile') {
-			localStorage.setItem(DAILY_PLAN_SUGGESTION_MODAL_DATE, currentDate);
+			if (!requirePlan || (requirePlan && hasPlan)) {
+				localStorage.setItem(DAILY_PLAN_SUGGESTION_MODAL_DATE, currentDate);
+			}
 		}
 		closeModal();
-	}, [closeModal, currentDate, path]);
+	}, [closeModal, currentDate, hasPlan, path, requirePlan]);
 
 	return (
-		<Modal isOpen={isOpen} closeModal={handleCloseModal} showCloseIcon={false}>
+		<Modal
+			closeOnOutsideClick={requirePlan}
+			isOpen={isOpen}
+			closeModal={handleCloseModal}
+			showCloseIcon={requirePlan}
+		>
 			<Card className="w-full" shadow="custom">
 				<div className="flex flex-col items-center justify-between">
 					<div className="mb-7">

--- a/apps/web/locales/ar.json
+++ b/apps/web/locales/ar.json
@@ -217,7 +217,8 @@
 			"EDIT_PLAN": "تعديل الخطة",
 			"TRACKED_TIME": "الوقت المتعقب",
 			"SEE_PLANS": "عرض الخطط",
-			"ADD_PLAN": "إضافة خطة"
+			"ADD_PLAN": "إضافة خطة",
+			"DELETE_THIS_PLAN": "احذف هذه الخطة"
 		},
 		"timesheets": {
 			"SINGULAR": "ورقة الحضور",

--- a/apps/web/locales/bg.json
+++ b/apps/web/locales/bg.json
@@ -217,7 +217,8 @@
 			"EDIT_PLAN": "Редактиране на план",
 			"TRACKED_TIME": "Проследено време",
 			"SEE_PLANS": "Виж планове",
-			"ADD_PLAN": "Добави план"
+			"ADD_PLAN": "Добави план",
+			"DELETE_THIS_PLAN": "Изтрийте този план"
 		},
 		"timesheets": {
 			"SINGULAR": "Работен лист",

--- a/apps/web/locales/de.json
+++ b/apps/web/locales/de.json
@@ -217,7 +217,8 @@
 			"EDIT_PLAN": "Plan bearbeiten",
 			"TRACKED_TIME": "Verfolgte Zeit",
 			"SEE_PLANS": "Pläne anzeigen",
-			"ADD_PLAN": "Plan hinzufügen"
+			"ADD_PLAN": "Plan hinzufügen",
+			"DELETE_THIS_PLAN": "Diesen Plan löschen"
 		},
 		"timesheets": {
 			"SINGULAR": "Stundenzettel",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -217,7 +217,8 @@
 			"EDIT_PLAN": "Edit Plan",
 			"TRACKED_TIME": "Tracked time",
 			"SEE_PLANS": "See plans",
-			"ADD_PLAN": "Add Plan"
+			"ADD_PLAN": "Add Plan",
+			"DELETE_THIS_PLAN": "Delete this plan"
 		},
 		"timesheets": {
 			"SINGULAR": "Timesheet",

--- a/apps/web/locales/es.json
+++ b/apps/web/locales/es.json
@@ -217,7 +217,8 @@
 			"ADD_PLAN": "Agregar Plan",
 			"TRACKED_TIME": "Tiempo registrado",
 			"SEE_PLANS": "Ver planes",
-			"FOR_TOMORROW": "Plan de mañana"
+			"FOR_TOMORROW": "Plan de mañana",
+			"DELETE_THIS_PLAN": "Eliminar este plan"
 		},
 		"timesheets": {
 			"SINGULAR": "Hoja de horas",

--- a/apps/web/locales/fr.json
+++ b/apps/web/locales/fr.json
@@ -217,7 +217,8 @@
 			"EDIT_PLAN": "Modifier le plan",
 			"TRACKED_TIME": "Temps suivi",
 			"SEE_PLANS": "Voir les plans",
-			"ADD_PLAN": "Ajouter un plan"
+			"ADD_PLAN": "Ajouter un plan",
+			"DELETE_THIS_PLAN": "Supprimer ce plan"
 		},
 		"timesheets": {
 			"SINGULAR": "Feuille de temps",

--- a/apps/web/locales/he.json
+++ b/apps/web/locales/he.json
@@ -217,7 +217,8 @@
 			"EDIT_PLAN": "ערוך תוכנית",
 			"TRACKED_TIME": "זמן מעקב",
 			"SEE_PLANS": "ראה תוכניות",
-			"ADD_PLAN": "הוסף תוכנית"
+			"ADD_PLAN": "הוסף תוכנית",
+			"DELETE_THIS_PLAN": "מחק את התוכנית הזו"
 		},
 		"timesheets": {
 			"SINGULAR": "דוח שעות",

--- a/apps/web/locales/it.json
+++ b/apps/web/locales/it.json
@@ -221,7 +221,8 @@
 			"EDIT_PLAN": "Modifica Piano",
 			"TRACKED_TIME": "Tempo tracciato",
 			"SEE_PLANS": "Vedi piani",
-			"ADD_PLAN": "Aggiungi Piano"
+			"ADD_PLAN": "Aggiungi Piano",
+			"DELETE_THIS_PLAN": "Elimina questo piano"
 		},
 		"COPY_ISSUE_LINK": "Copia collegamento problema",
 		"MAKE_A_COPY": "Fai una copia",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -221,7 +221,8 @@
 			"EDIT_PLAN": "Plan bewerken",
 			"TRACKED_TIME": "Gegeneraliseerde tijd",
 			"SEE_PLANS": "Plannen bekijken",
-			"ADD_PLAN": "Plan toevoegen"
+			"ADD_PLAN": "Plan toevoegen",
+			"DELETE_THIS_PLAN": "Verwijder dit plan"
 		},
 		"COPY_ISSUE_LINK": "Probleemlink kopiëren",
 		"MAKE_A_COPY": "Maak een kopie",

--- a/apps/web/locales/pl.json
+++ b/apps/web/locales/pl.json
@@ -221,7 +221,8 @@
 			"EDIT_PLAN": "Edytuj plan",
 			"TRACKED_TIME": "Śledzony czas",
 			"SEE_PLANS": "Zobacz plany",
-			"ADD_PLAN": "Dodaj plan"
+			"ADD_PLAN": "Dodaj plan",
+			"DELETE_THIS_PLAN": "Usuń ten plan"
 		},
 		"COPY_ISSUE_LINK": "Skopiuj link do zgłoszenia",
 		"MAKE_A_COPY": "Zrób kopię",

--- a/apps/web/locales/pt.json
+++ b/apps/web/locales/pt.json
@@ -221,7 +221,8 @@
 			"EDIT_PLAN": "Editar Plano",
 			"TRACKED_TIME": "Tempo rastreado",
 			"SEE_PLANS": "Ver planos",
-			"ADD_PLAN": "Adicionar Plano"
+			"ADD_PLAN": "Adicionar Plano",
+			"DELETE_THIS_PLAN": "Excluir este plano"
 		},
 		"COPY_ISSUE_LINK": "Copiar link do problema",
 		"MAKE_A_COPY": "Fazer uma cópia",

--- a/apps/web/locales/ru.json
+++ b/apps/web/locales/ru.json
@@ -221,7 +221,8 @@
 			"EDIT_PLAN": "Редактировать план",
 			"TRACKED_TIME": "Отслеживаемое время",
 			"SEE_PLANS": "Посмотреть планы",
-			"ADD_PLAN": "Agregar Plan"
+			"ADD_PLAN": "Agregar Plan",
+			"DELETE_THIS_PLAN": "Удалить этот план"
 		},
 		"COPY_ISSUE_LINK": "Скопировать ссылку на проблему",
 		"MAKE_A_COPY": "Сделать копию",

--- a/apps/web/locales/zh.json
+++ b/apps/web/locales/zh.json
@@ -221,7 +221,8 @@
 			"EDIT_PLAN": "编辑计划",
 			"TRACKED_TIME": "跟踪时间",
 			"SEE_PLANS": "查看计划",
-			"ADD_PLAN": "添加计划"
+			"ADD_PLAN": "添加计划",
+			"DELETE_THIS_PLAN": "删除此计划"
 		},
 		"COPY_ISSUE_LINK": "复制问题链接",
 		"MAKE_A_COPY": "制作副本",


### PR DESCRIPTION
## Description

This PR fixes #3156 

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Previous screenshots

[Loom](https://www.loom.com/share/6feaed8e21914ba4971d26d7074c32de?sid=0b268d6e-193f-474f-a57f-065aa5f57ef6)

## Current screenshots

[Loom](https://www.loom.com/share/2dee856380c746dea2a8cb0c4b4a6fbe?sid=81a33f92-4c03-4839-abc0-9d2ffa8845bf)
[Loom](https://www.loom.com/share/1fca46ad703c479a94e6b5f69facdc50?sid=98f804d1-3467-4d96-a595-9d8db4a7ed6e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced loading indication with a spinner during submission in the daily plan modals.
	- Updated functionality for submitting planned work time in the task estimation modal.
	- Added new property to control modal behavior on outside clicks.
	- Introduced new localization strings for deleting plans across multiple languages.

- **Bug Fixes**
	- Improved error handling during submission processes.

- **Refactor**
	- Renamed and modified functions for better clarity and functionality in managing modal submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->