### PR TITLE
3144 bug see plan  date without a plan should not be marked as now

### DIFF
--- a/apps/web/lib/features/daily-plan/all-plans-modal.tsx
+++ b/apps/web/lib/features/daily-plan/all-plans-modal.tsx
@@ -165,6 +165,27 @@ export const AllPlansModal = memo(function AllPlansModal(props: IAllPlansModal) 
 		[isSameDate, myDailyPlans.items, selectedPlan]
 	);
 
+	// A handler function to display the plan title
+	const displayPlanTitle = () => {
+		const isCalendarTab = selectedTab === 'Calendar';
+		const planDate = selectedPlan?.date ? new Date(selectedPlan.date).toLocaleDateString('en-GB') : '';
+		const hasTasks = selectedPlan?.tasks?.length;
+		const isTodayOrTomorrow =
+			selectedTab === 'Today'
+				? t('common.plan.FOR_TODAY')
+				: selectedTab === 'Tomorrow'
+					? t('common.plan.FOR_TOMORROW')
+					: '';
+
+		return isCalendarTab
+			? showCustomPlan && selectedPlan
+				? hasTasks
+					? t('common.plan.FOR_DATE', { date: planDate })
+					: planDate
+				: t('common.plan.PLURAL')
+			: isTodayOrTomorrow;
+	};
+
 	return (
 		<Modal
 			isOpen={isOpen}
@@ -193,13 +214,7 @@ export const AllPlansModal = memo(function AllPlansModal(props: IAllPlansModal) 
 						)}
 
 						<Text.Heading as="h3" className="uppercase text-center">
-							{selectedTab == 'Calendar'
-								? showCustomPlan && selectedPlan
-									? t('common.plan.FOR_DATE', {
-											date: new Date(selectedPlan.date).toLocaleDateString('en-GB')
-										})
-									: t('common.plan.PLURAL')
-								: `${selectedTab === 'Today' ? t('common.plan.FOR_TODAY') : selectedTab === 'Tomorrow' ? t('common.plan.FOR_TOMORROW') : ''}`}
+							{displayPlanTitle()}
 						</Text.Heading>
 					</div>
 					<div className="w-full h-12 flex items-center justify-between">


### PR DESCRIPTION
## Description

This PR fixes #3144 

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Current screenshots

[Loom](https://www.loom.com/share/178d928563384a749c2566843bcd5bde?sid=1346df63-d106-4ce2-b638-0a9d39fdd4b5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a centralized title display for the daily plan modal, enhancing clarity based on the selected tab and current plan.
	- Improved tab navigation and date handling within the daily plan modal.

- **Bug Fixes**
	- Optimized the calculation of the current user in the team members view for better performance.

- **Refactor**
	- Enhanced the efficiency of the `TeamMembers` and `TeamMembersView` components by utilizing memoization for member filtering and sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->