### PR TITLE
[Fix] Dark colors | 'groupBy' report limits dropdown

### DIFF
--- a/apps/web/app/[locale]/reports/weekly-limit/components/group-by-select.tsx
+++ b/apps/web/app/[locale]/reports/weekly-limit/components/group-by-select.tsx
@@ -59,7 +59,7 @@ export function GroupBySelect({ defaultValues, onChange }: IProps) {
 	return (
 		<Listbox multiple value={selected} onChange={handleChange}>
 			<div className="relative h-[2.2rem] w-[12rem]">
-				<Listbox.Button className="relative w-full h-full cursor-default rounded-lg bg-white py-2 pl-1 pr-6 text-left border focus:outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-white/75 focus-visible:ring-offset-2 focus-visible:ring-offset-primary sm:text-sm">
+				<Listbox.Button className="relative w-full h-full cursor-default rounded-lg bg-white dark:border-gray-700 dark:bg-dark--theme-light py-2 pl-1 pr-6 text-left border focus:outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-white/75 focus-visible:ring-offset-2 focus-visible:ring-offset-primary sm:text-sm">
 					<div className=" items-center w-full h-full flex gap-1">
 						{selected.map((option) => (
 							<Badge
@@ -83,7 +83,7 @@ export function GroupBySelect({ defaultValues, onChange }: IProps) {
 					leaveFrom="opacity-100"
 					leaveTo="opacity-0"
 				>
-					<Listbox.Options className="absolute mt-1 max-h-60 w-full z-[999] overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
+					<Listbox.Options className="absolute mt-1 max-h-60 w-full z-[999] overflow-auto rounded-md bg-white dark:bg-dark--theme-light  py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
 						{options.map((option, index) => (
 							<Listbox.Option
 								disabled={
@@ -91,10 +91,12 @@ export function GroupBySelect({ defaultValues, onChange }: IProps) {
 									selected.includes(option) && selected.length == 1
 								}
 								key={index}
-								className={({ active }) =>
+								className={({ active, selected }) =>
 									`relative cursor-default select-none py-2 pl-10 pr-4 ${
-										active ? 'bg-primary/10 text-primary' : 'text-gray-900'
-									}`
+										active
+											? 'bg-primary/10 text-primary dark:text-white dark:bg-primary/10'
+											: 'text-gray-900 dark:text-white'
+									} ${selected && 'dark:bg-primary/10'}`
 								}
 								value={option}
 							>


### PR DESCRIPTION
## Description

Fixes #3466 

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Previous screenshots

![Screenshot from 2024-12-23 18-05-14](https://github.com/user-attachments/assets/41cbe3b0-2f46-4fb9-b49e-45d604b8b810)


## Current screenshots

![Screenshot from 2024-12-23 17-58-54](https://github.com/user-attachments/assets/cc61f254-639e-47b9-ae88-f14db8b60b17)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dark mode support for the GroupBySelect component, enhancing visual representation for better user experience.
	- Updated styling for selection states in dark mode.

- **Bug Fixes**
	- Improved adaptability of text and background colors based on selection and active states in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->