### PR TITLE
Fix: Correct Text for Collapsed and Expanded Card States

### DIFF
--- a/apps/web/lib/components/Kanban.tsx
+++ b/apps/web/lib/components/Kanban.tsx
@@ -299,7 +299,7 @@ export const EmptyKanbanDroppable = ({
 														className="hover:font-medium p-1.5 text-sm cursor-pointer"
 														onClick={() => toggleColumn(title, false)}
 													>
-														{t('common.COLLAPSE_COLUMN')}
+														{t('common.EXPAND_COLUMN')}
 													</div>
 													<div
 														className="hover:font-medium p-1.5 text-sm cursor-pointer"

--- a/apps/web/locales/ar.json
+++ b/apps/web/locales/ar.json
@@ -7,6 +7,7 @@
 		"MEN_HOURS": "ساعات العمل",
 		"MEMBERS_WORKED": "الأعضاء الذين عملوا",
 		"COLLAPSE_COLUMN": "طي العمود",
+		"EXPAND_COLUMN": "توسيع العمود",
 		"EDIT_STATUS": "تعديل الحالة",
 		"ADD_TIME_ENTRY": "إضافة إدخال وقت",
 		"OPT_IN_UPDATES": "اشترك لتلقي التحديثات والأخبار حول Ever Teams.",

--- a/apps/web/locales/bg.json
+++ b/apps/web/locales/bg.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "Човеко-часове",
 		"MEMBERS_WORKED": "Работили членове",
 		"COLLAPSE_COLUMN": "Свий колона",
+		"EXPAND_COLUMN": "Разгъни колона",
 		"EDIT_STATUS": "Редактирай статус",
 		"ADD_TIME_ENTRY": "Добавяне на запис на време",
 		"OPT_IN_UPDATES": "Абонирайте се за актуализации и новини за Ever Teams.",

--- a/apps/web/locales/de.json
+++ b/apps/web/locales/de.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "Mannstunden",
 		"MEMBERS_WORKED": "Mitglieder gearbeitet",
 		"COLLAPSE_COLUMN": "Spalte einklappen",
+		"EXPAND_COLUMN": "Spalte ausklappen",
 		"EDIT_STATUS": "Status bearbeiten",
 		"ADD_TIME_ENTRY": "Zeiteintrag hinzufügen",
 		"OPT_IN_UPDATES": "Abonnieren Sie Updates und Nachrichten zu Ever Teams.",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -34,6 +34,7 @@
 		"TO_DO": "To-do",
 
 		"COLLAPSE_COLUMN": "Collapse Column",
+		"EXPAND_COLUMN": "Expand Column",
 		"EDIT_STATUS": "Edit Status",
 		"ADD_TIME_ENTRY": "Add Time Entry",
 		"OPT_IN_UPDATES": "Opt-in to receive updates and news about Ever Teams.",

--- a/apps/web/locales/es.json
+++ b/apps/web/locales/es.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "Horas Hombre",
 		"MEMBERS_WORKED": "Miembros que trabajaron",
 		"COLLAPSE_COLUMN": "Colapsar columna",
+		"EXPAND_COLUMN": "Expandir columna",
 		"EDIT_STATUS": "Editar estado",
 		"ADD_TIME_ENTRY": "Agregar entrada de tiempo",
 		"OPT_IN_UPDATES": "Opta por recibir actualizaciones y noticias sobre Ever Teams.",

--- a/apps/web/locales/fr.json
+++ b/apps/web/locales/fr.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "Heures Homme",
 		"MEMBERS_WORKED": "Membres ayant travaillé",
 		"COLLAPSE_COLUMN": "Réduire la colonne",
+		"EXPAND_COLUMN": "Développer la colonne",
 		"EDIT_STATUS": "Modifier le statut",
 		"ADD_TIME_ENTRY": "Ajouter une entrée de temps",
 		"OPT_IN_UPDATES": "Acceptez de recevoir des mises à jour et des nouvelles sur Ever Teams.",

--- a/apps/web/locales/he.json
+++ b/apps/web/locales/he.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "שעות עבודה",
 		"MEMBERS_WORKED": "חברים שעבדו",
 		"COLLAPSE_COLUMN": "כווץ עמודה",
+		"EXPAND_COLUMN": "הרחב עמודה",
 		"EDIT_STATUS": "ערוך סטטוס",
 		"ADD_TIME_ENTRY": "הוסף כניסת זמן",
 		"OPT_IN_UPDATES": "בחר לקבל עדכונים וחדשות על Ever Teams.",

--- a/apps/web/locales/it.json
+++ b/apps/web/locales/it.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "Ore Uomo",
 		"MEMBERS_WORKED": "Membri che hanno lavorato",
 		"COLLAPSE_COLUMN": "Comprimi colonna",
+		"EXPAND_COLUMN": "Espandi colonna",
 		"EDIT_STATUS": "Modifica stato",
 		"ADD_TIME_ENTRY": "Aggiungi voce di tempo",
 		"OPT_IN_UPDATES": "Acconsenti a ricevere aggiornamenti e notizie su Ever Teams.",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "Manuren",
 		"MEMBERS_WORKED": "Leden gewerkt",
 		"COLLAPSE_COLUMN": "Kolom samenvouwen",
+		"EXPAND_COLUMN": "Kolom uitvouwen",
 		"EDIT_STATUS": "Status bewerken",
 		"ADD_TIME_ENTRY": "Tijdinvoer toevoegen",
 		"OPT_IN_UPDATES": "Kies ervoor om updates en nieuws over Ever Teams te ontvangen.",

--- a/apps/web/locales/pl.json
+++ b/apps/web/locales/pl.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "Roboczogodziny",
 		"MEMBERS_WORKED": "Członkowie pracowali",
 		"COLLAPSE_COLUMN": "Zwiń kolumnę",
+		"EXPAND_COLUMN": "Rozwiń kolumnę",
 		"EDIT_STATUS": "Edytuj status",
 		"ADD_TIME_ENTRY": "Dodaj wpis czasu",
 		"OPT_IN_UPDATES": "Zgódź się na otrzymywanie aktualizacji i wiadomości o Ever Teams.",

--- a/apps/web/locales/pt.json
+++ b/apps/web/locales/pt.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "Horas Homem",
 		"MEMBERS_WORKED": "Membros Trabalharam",
 		"COLLAPSE_COLUMN": "Colapsar Coluna",
+		"EXPAND_COLUMN": "Expandir Coluna",
 		"EDIT_STATUS": "Editar Status",
 		"ADD_TIME_ENTRY": "Adicionar Entrada de Tempo",
 		"OPT_IN_UPDATES": "Concorde em receber atualizações e notícias sobre Ever Teams.",

--- a/apps/web/locales/ru.json
+++ b/apps/web/locales/ru.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "Часы работы",
 		"MEMBERS_WORKED": "Члены, которые работали",
 		"COLLAPSE_COLUMN": "Свернуть столбец",
+		"EXPAND_COLUMN": "Развернуть столбец",
 		"EDIT_STATUS": "Редактировать статус",
 		"ADD_TIME_ENTRY": "Добавить запись времени",
 		"OPT_IN_UPDATES": "Согласитесь получать обновления и новости о Ever Teams.",

--- a/apps/web/locales/zh.json
+++ b/apps/web/locales/zh.json
@@ -25,6 +25,7 @@
 		"MEN_HOURS": "工时",
 		"MEMBERS_WORKED": "参与成员",
 		"COLLAPSE_COLUMN": "折叠列",
+		"EXPAND_COLUMN": "展开列",
 		"EDIT_STATUS": "编辑状态",
 		"ADD_TIME_ENTRY": "添加时间条目",
 		"OPT_IN_UPDATES": "选择接收关于 Ever Teams 的更新和新闻。",


### PR DESCRIPTION
## Related Issue
Closes #3562 

## Description
This PR addresses the issue where the text displayed when a card is collapsed or expanded is incorrect. Currently, the text does not change as expected between "Expand" and "Collapse" states. This fix ensures that the correct text is shown based on the card's state for all the languages used in ever teams website.


## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots
<img width="1435" alt="Screenshot 2025-01-31 at 8 34 54 PM" src="https://github.com/user-attachments/assets/c921dad3-92e2-4978-80ed-f21c4526d8dd" />

## Current screenshots
<img width="1439" alt="Screenshot 2025-01-31 at 9 11 34 PM" src="https://github.com/user-attachments/assets/391d18b9-eb4b-4944-9bbd-81ae8308c335" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to expand Kanban columns
	- Updated user interface text to reflect column expansion action

- **Localization**
	- Added "Expand Column" translations for multiple languages, including Arabic, Bulgarian, German, English, Spanish, French, Hebrew, Italian, Dutch, Polish, Portuguese, Russian, and Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->