### PR TITLE
[Fix]: Correct Alignment of "Kanban Board Not Found" Card

### DIFF
--- a/apps/web/lib/components/Kanban.tsx
+++ b/apps/web/lib/components/Kanban.tsx
@@ -99,7 +99,7 @@ function InnerItemList({ items, title }: { title: string; items: ITeamTask[]; dr
 					))}
 				{Array.isArray(items) && items?.length == 0 && (
 					<div className="bg-[#f2f2f2] dark:bg-[#191a20] absolute w-full">
-						<div className="h-[180px] bg-transparent bg-white dark:bg-[#1e2025] w-[340px] mt-3 flex justify-center items-center my-2 rounded-xl">
+						<div className="h-[180px] bg-transparent bg-white dark:bg-[#1e2025] mt-3 flex justify-center items-center my-2 rounded-xl">
 							{t('common.NOT_FOUND')}!
 						</div>
 						<div

--- a/apps/web/lib/features/team-members-kanban-view.tsx
+++ b/apps/web/lib/features/team-members-kanban-view.tsx
@@ -208,7 +208,7 @@ export const KanbanView = ({ kanbanBoardTasks, isLoading }: { kanbanBoardTasks: 
 							{(provided: DroppableProvided, snapshot: DroppableStateSnapshot) => (
 								<div
 									className={cn(
-										'flex flex-1 flex-row gap-2 min-h-fit px-8 lg:px-0 w-full h-full',
+										'flex flex-1 flex-row gap-4 min-h-fit px-8 lg:px-0 w-full h-full',
 										snapshot.isDraggingOver ? 'bg-slate-200 dark:bg-slate-800' : '',
 									)}
 									ref={provided.innerRef}


### PR DESCRIPTION
Related Issue
Closes #3564 

## Description
This PR fixes the alignment issue of the "Kanban Board Not Found" card. The card was misaligned, affecting the overall UI consistency. 

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots
<img width="1440" alt="Before" src="https://github.com/user-attachments/assets/2d09a092-1095-4e0b-812b-ecd2fd58137b" />

## Current screenshots
<img width="1435" alt="Screenshot 2025-01-31 at 11 13 40 PM" src="https://github.com/user-attachments/assets/d21868e7-b671-474a-883d-b3afe4c87612" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated Kanban component's empty state display layout
	- Adjusted column spacing in Kanban board from `gap-2` to `gap-4`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->