### PR TITLE
[Improvement]: Fix Label Tag Size in Kanban Board

### DIFF
--- a/apps/web/lib/features/task/task-input-kanban.tsx
+++ b/apps/web/lib/features/task/task-input-kanban.tsx
@@ -395,7 +395,7 @@ function TaskCard({
 									<TaskLabels
 										className="lg:min-w-[170px] text-xs"
 										forDetails={false}
-										taskStatusClassName="dark:bg-[#1B1D22] dark:border dark:border-[#FFFFFF33] h-7 text-xs"
+										taskStatusClassName="dark:bg-[#1B1D22] dark:border dark:border-[#FFFFFF33] h-11 text-xs"
 										onValueChange={(_: any, values: string[] | undefined) => {
 											taskLabelsData.filter((tag) =>
 												tag.name ? values?.includes(tag.name) : false


### PR DESCRIPTION
Issue No. #3566 

## Description
The Label Tag Button on the Kanban Board page has been corrected, and its size is now consistent with the other tags in the "Create New Task" popup.

### Steps to Reproduce:
1. Navigate to the Dashboard.  
2. Click on the Kanban page.  
3. Pick any card and click on "Create New Task."  
4. Type anything in the search box, and the tags will appear.  

### Expected Behavior:
- The Label Tag size should be the same as other tags present.

## Type of Change

-   [x] Bug fix  
-   [ ] New feature  
-   [ ] Breaking change  
-   [ ] Documentation update  

## Checklist

-   [ ] My code follows the style guidelines of this project  
-   [ ] I have performed a self-review of my code  
-   [ ] I have commented on my code, particularly in hard-to-understand areas  
-   [ ] I have made corresponding changes to the documentation  
-   [ ] My changes generate no new warnings  

## Previous Screenshots

<img width="1431" alt="Screenshot 2025-01-31 at 11 41 48 PM" src="https://github.com/user-attachments/assets/b9963ecd-c1db-4cf8-b183-8b1af0612d18" />

## Current Screenshots

<img width="1434" alt="Screenshot 2025-01-31 at 11 44 20 PM" src="https://github.com/user-attachments/assets/63ee5988-2967-4263-a551-9a18b06069bd" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the height of task labels in the Kanban view to improve visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->