### PR TITLE
[Fix]: Buttons Displaying Two Borders on Kanban Page

### DIFF
--- a/apps/web/app/[locale]/kanban/page.tsx
+++ b/apps/web/app/[locale]/kanban/page.tsx
@@ -177,10 +177,10 @@ const Kanban = () => {
 									))}
 								</div>
 								<div className="flex gap-5 mt-4 lg:mt-0">
-									<div className="input-border rounded-xl h-11 bg-[#F2F2F2] dark:bg-dark--theme-light">
+									<div className="">
 										<EpicPropertiesDropdown
 											onValueChange={(_, values) => setEpics(values || [])}
-											className="lg:min-w-[140px] pt-[3px] mt-4 mb-2 lg:mt-0"
+											className="lg:min-w-[140px] pt-[3px] mb-2 lg:mt-0 input-border rounded-xl bg-[#F2F2F2] dark:bg-dark--theme-light max-h-11"
 											multiple={true}
 										/>
 									</div>
@@ -226,24 +226,24 @@ const Kanban = () => {
 											/>
 										</div>
 									</div>
-									<div className="input-border rounded-xl h-11 bg-[#F2F2F2] dark:bg-dark--theme-light">
+									<div className="">
 										<TaskLabelsDropdown
 											onValueChange={(_, values) => setLabels(values || [])}
-											className="lg:min-w-[140px] pt-[3px] mt-4 mb-2 lg:mt-0"
+											className="lg:min-w-[140px] pt-[3px] mb-2 lg:mt-0 input-border rounded-xl h-11 bg-[#F2F2F2] dark:bg-dark--theme-light"
 											multiple={true}
 										/>
 									</div>
-									<div className="input-border rounded-xl h-11 bg-[#F2F2F2] dark:bg-dark--theme-light">
+									<div className="">
 										<TaskPropertiesDropdown
 											onValueChange={(_, values) => setPriority(values || [])}
-											className="lg:min-w-[140px] pt-[3px] mt-4 mb-2 lg:mt-0"
+											className="lg:min-w-[140px] pt-[3px] mb-2 lg:mt-0 input-border rounded-xl h-11 bg-[#F2F2F2] dark:bg-dark--theme-light"
 											multiple={true}
 										/>
 									</div>
-									<div className="input-border rounded-xl h-11 bg-[#F2F2F2] dark:bg-dark--theme-light">
+									<div className="">
 										<TaskSizesDropdown
 											onValueChange={(_, values) => setSizes(values || [])}
-											className="lg:min-w-[140px] pt-[3px] mt-4 mb-2 lg:mt-0"
+											className="lg:min-w-[140px] pt-[3px] mb-2 lg:mt-0 input-border rounded-xl h-11 bg-[#F2F2F2] dark:bg-dark--theme-light"
 											multiple={true}
 										/>
 									</div>

--- a/apps/web/app/[locale]/kanban/page.tsx
+++ b/apps/web/app/[locale]/kanban/page.tsx
@@ -226,21 +226,21 @@ const Kanban = () => {
 											/>
 										</div>
 									</div>
-									<div className="">
+									<div>
 										<TaskLabelsDropdown
 											onValueChange={(_, values) => setLabels(values || [])}
 											className="lg:min-w-[140px] pt-[3px] mb-2 lg:mt-0 input-border rounded-xl h-11 bg-[#F2F2F2] dark:bg-dark--theme-light"
 											multiple={true}
 										/>
 									</div>
-									<div className="">
+									<div>
 										<TaskPropertiesDropdown
 											onValueChange={(_, values) => setPriority(values || [])}
 											className="lg:min-w-[140px] pt-[3px] mb-2 lg:mt-0 input-border rounded-xl h-11 bg-[#F2F2F2] dark:bg-dark--theme-light"
 											multiple={true}
 										/>
 									</div>
-									<div className="">
+									<div>
 										<TaskSizesDropdown
 											onValueChange={(_, values) => setSizes(values || [])}
 											className="lg:min-w-[140px] pt-[3px] mb-2 lg:mt-0 input-border rounded-xl h-11 bg-[#F2F2F2] dark:bg-dark--theme-light"

--- a/apps/web/lib/features/task/task-status.tsx
+++ b/apps/web/lib/features/task/task-status.tsx
@@ -1236,7 +1236,7 @@ export function MultipleStatusDropdown<T extends TStatusItem>({
 							className={clsxm(
 								'justify-between w-full capitalize',
 								sidebarUI && ['text-xs'],
-								' dark:text-white bg-white border dark:bg-dark--theme-light',
+								' dark:text-white dark:bg-dark--theme-light',
 								forDetails && 'bg-transparent border dark:border-[#FFFFFF33] dark:bg-[#1B1D22]',
 								taskStatusClassName
 							)}


### PR DESCRIPTION
Issue No: #3572 

## Description
The issue where the buttons on the Kanban page was displaying two borders has been resolved. Now, the buttons have a single, consistent border matching the overall design.  

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots
<img width="1437" alt="Screenshot 2025-02-03 at 11 27 47 AM" src="https://github.com/user-attachments/assets/3900375d-3750-42ae-8e74-01f27c54ded6" />

## Current screenshots
<img width="1437" alt="Screenshot 2025-02-03 at 11 32 41 AM" src="https://github.com/user-attachments/assets/0bccb150-f0ea-4b21-92db-406f5ade81dd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined the appearance and layout of dropdown menus for a more consistent user interface across themes.
- **New Features**
	- Enhanced dropdown behavior in task-status selections, ensuring updated tracking of selected options for a smoother interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->