### PR TITLE
[FIX]: Buttons Moving Out of Container on Task Detail Page

### DIFF
--- a/apps/web/components/pages/task/details-section/blocks/task-secondary-info.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-secondary-info.tsx
@@ -92,7 +92,7 @@ const TaskSecondaryInfo = () => {
 			<TaskRow labelTitle={t('pages.taskDetails.VERSION')}>
 				<ActiveTaskVersionDropdown
 					task={task}
-					className="lg:min-w-[170px] text-black"
+					className="lg:min-w-fit text-black"
 					forDetails={true}
 					sidebarUI={true}
 					taskStatusClassName="text-[0.625rem] w-[7.6875rem] h-[2.35rem] max-w-[7.6875rem] rounded 3xl:text-xs"
@@ -131,7 +131,7 @@ const TaskSecondaryInfo = () => {
 			<TaskRow labelTitle={t('pages.taskDetails.STATUS')}>
 				<ActiveTaskStatusDropdown
 					task={task}
-					className="lg:min-w-[170px] text-black"
+					className="lg:w-auto text-black"
 					forDetails={true}
 					sidebarUI={true}
 					taskStatusClassName="text-[0.625rem] w-[7.6875rem] h-[2.35rem] max-w-[7.6875rem] rounded 3xl:text-xs"
@@ -150,7 +150,7 @@ const TaskSecondaryInfo = () => {
 			<TaskRow labelTitle={t('pages.taskDetails.LABELS')}>
 				<TaskLabels
 					task={task}
-					className="lg:min-w-[170px] text-black lg:mt-0"
+					className="lg:min-w-fit text-black lg:mt-0"
 					forDetails={true}
 					taskStatusClassName="text-[0.625rem] w-[7.6875rem] h-[2.35rem] max-w-[7.6875rem] rounded 3xl:text-xs"
 				/>
@@ -179,7 +179,7 @@ const TaskSecondaryInfo = () => {
 			<TaskRow labelTitle={t('pages.taskDetails.SIZE')} wrapperClassName="text-black">
 				<ActiveTaskSizesDropdown
 					task={task}
-					className="lg:min-w-[170px] text-black"
+					className="lg:min-w-fit text-black"
 					forDetails={true}
 					sidebarUI={true}
 					taskStatusClassName="text-[0.625rem] w-[7.6875rem] h-[2.35rem] max-w-[7.6875rem] rounded 3xl:text-xs"
@@ -198,7 +198,7 @@ const TaskSecondaryInfo = () => {
 			<TaskRow labelTitle={t('pages.taskDetails.PRIORITY')} wrapperClassName="text-black">
 				<ActiveTaskPropertiesDropdown
 					task={task}
-					className="lg:min-w-[170px] text-black rounded-xl"
+					className="lg:min-w-fit text-black"
 					forDetails={true}
 					sidebarUI={true}
 					taskStatusClassName="text-[0.625rem] w-[7.6875rem] h-[2.35rem] max-w-[7.6875rem] rounded 3xl:text-xs"

--- a/apps/web/components/pages/task/details-section/blocks/task-secondary-info.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-secondary-info.tsx
@@ -92,7 +92,7 @@ const TaskSecondaryInfo = () => {
 			<TaskRow labelTitle={t('pages.taskDetails.VERSION')}>
 				<ActiveTaskVersionDropdown
 					task={task}
-					className="lg:min-w-fit text-black"
+					className="lg:min-w-[130px] text-black"
 					forDetails={true}
 					sidebarUI={true}
 					taskStatusClassName="text-[0.625rem] w-[7.6875rem] h-[2.35rem] max-w-[7.6875rem] rounded 3xl:text-xs"
@@ -131,7 +131,7 @@ const TaskSecondaryInfo = () => {
 			<TaskRow labelTitle={t('pages.taskDetails.STATUS')}>
 				<ActiveTaskStatusDropdown
 					task={task}
-					className="lg:w-auto text-black"
+					className="lg:min-w-[130px] text-black"
 					forDetails={true}
 					sidebarUI={true}
 					taskStatusClassName="text-[0.625rem] w-[7.6875rem] h-[2.35rem] max-w-[7.6875rem] rounded 3xl:text-xs"
@@ -150,9 +150,9 @@ const TaskSecondaryInfo = () => {
 			<TaskRow labelTitle={t('pages.taskDetails.LABELS')}>
 				<TaskLabels
 					task={task}
-					className="lg:min-w-fit text-black lg:mt-0"
+					className="lg:min-w-[130px] text-black lg:mt-0"
 					forDetails={true}
-					taskStatusClassName="text-[0.625rem] w-[7.6875rem] h-[2.35rem] max-w-[7.6875rem] rounded 3xl:text-xs"
+					taskStatusClassName="text-[0.625rem] h-[2.35rem] min-w-[7.6875rem] rounded 3xl:text-xs"
 				/>
 			</TaskRow>
 			{tags.length > 0 && (
@@ -179,7 +179,7 @@ const TaskSecondaryInfo = () => {
 			<TaskRow labelTitle={t('pages.taskDetails.SIZE')} wrapperClassName="text-black">
 				<ActiveTaskSizesDropdown
 					task={task}
-					className="lg:min-w-fit text-black"
+					className="lg:min-w-[130px] text-black"
 					forDetails={true}
 					sidebarUI={true}
 					taskStatusClassName="text-[0.625rem] w-[7.6875rem] h-[2.35rem] max-w-[7.6875rem] rounded 3xl:text-xs"
@@ -198,7 +198,7 @@ const TaskSecondaryInfo = () => {
 			<TaskRow labelTitle={t('pages.taskDetails.PRIORITY')} wrapperClassName="text-black">
 				<ActiveTaskPropertiesDropdown
 					task={task}
-					className="lg:min-w-fit text-black"
+					className="lg:min-w-[130px] text-black"
 					forDetails={true}
 					sidebarUI={true}
 					taskStatusClassName="text-[0.625rem] w-[7.6875rem] h-[2.35rem] max-w-[7.6875rem] rounded 3xl:text-xs"
@@ -360,14 +360,14 @@ export function ProjectDropDown(props: ITaskProjectDropdownProps) {
 								<Listbox.Button
 									className={clsxm(
 										`cursor-pointer outline-none w-full flex dark:text-white
-									items-center justify-between px-4 h-full
+									items-center justify-between px-2 h-full
 									border-solid border-color-[#F2F2F2]
 									dark:bg-[#1B1D22] dark:border dark:border-[#FFFFFF33] rounded-lg`,
 										styles?.value
 									)}
 								>
 									{selected && (
-										<div className="">
+										<div className="mx-1">
 											<ProjectIcon />
 										</div>
 									)}


### PR DESCRIPTION
Issue No: #3575 

## Description

The issue where buttons were moving out of their container on the Task Detail page when the sidebar was expanded has been fixed. The buttons now remain properly aligned within their container.  

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots
<img width="1439" alt="Screenshot 2025-02-03 at 7 39 25 PM" src="https://github.com/user-attachments/assets/9f2fc631-3252-4b4e-931e-f70f333b9ca7" />

## Current screenshots
<img width="1435" alt="Screenshot 2025-02-03 at 7 44 37 PM" src="https://github.com/user-attachments/assets/c4c9cb95-64c2-449d-97cf-d2c164af93f1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted component widths to improve layout consistency on the task details page.
  - Refined spacing by updating padding on buttons and adding margin to icons for a more polished visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->