### PR TITLE
Feat: add localized day names to all languages

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -111,6 +111,7 @@
 		"deserunt",
 		"digitaloceanspaces",
 		"dimesions",
+		"DAYOFWEEK",
 		"Ipredefine",
 		"discrepenancy",
 		"dolor",

--- a/apps/web/lib/settings/working-hours.tsx
+++ b/apps/web/lib/settings/working-hours.tsx
@@ -11,6 +11,7 @@ import { useForm } from 'react-hook-form';
 import { useAtom } from 'jotai';
 import { userState } from '@/app/stores';
 import { renderTrackingIcon } from './table-action-popover';
+import { useTranslations } from 'next-intl';
 
 interface WorkDay {
 	day: string;
@@ -23,26 +24,25 @@ interface WorkScheduleProps {
 	initialSchedule?: WorkDay[];
 }
 
-const defaultWorkDays: WorkDay[] = [
-	{ day: 'Monday', startTime: '09:00', endTime: '17:00', enabled: true },
-	{ day: 'Tuesday', startTime: '09:00', endTime: '17:00', enabled: true },
-	{ day: 'Wednesday', startTime: '09:00', endTime: '17:00', enabled: true },
-	{ day: 'Thursday', startTime: '09:00', endTime: '17:00', enabled: true },
-	{ day: 'Friday', startTime: '09:00', endTime: '17:00', enabled: true },
-	{ day: 'Saturday', startTime: '09:00', endTime: '17:00', enabled: false },
-	{ day: 'Sunday', startTime: '09:00', endTime: '17:00', enabled: false }
-];
-
 export const WorkingHours: React.FC<WorkScheduleProps> = ({ initialSchedule }) => {
 	const [currentTimezone, setCurrentTimezone] = React.useState('');
 	const [user] = useAtom(userState);
-
+	const t = useTranslations();
 	const { setValue } = useForm();
+
+	const defaultWorkDays: WorkDay[] = [
+		{ day: t('common.DAYOFWEEK.Monday'), startTime: '09:00', endTime: '17:00', enabled: true },
+		{ day: t('common.DAYOFWEEK.Tuesday'), startTime: '09:00', endTime: '17:00', enabled: true },
+		{ day: t('common.DAYOFWEEK.Wednesday'), startTime: '09:00', endTime: '17:00', enabled: true },
+		{ day: t('common.DAYOFWEEK.Thursday'), startTime: '09:00', endTime: '17:00', enabled: true },
+		{ day: t('common.DAYOFWEEK.Friday'), startTime: '09:00', endTime: '17:00', enabled: true },
+		{ day: t('common.DAYOFWEEK.Saturday'), startTime: '09:00', endTime: '17:00', enabled: false },
+		{ day: t('common.DAYOFWEEK.Sunday'), startTime: '09:00', endTime: '17:00', enabled: false }
+	];
 
 	const [schedule, setSchedule] = React.useState<WorkDay[]>(initialSchedule || defaultWorkDays);
 	const handleChangeTimezone = React.useCallback(
 		(newTimezone: string | undefined) => {
-			console.log(newTimezone);
 			setActiveTimezoneCookie(newTimezone || userTimezone());
 			setCurrentTimezone(newTimezone || userTimezone());
 			setValue('timeZone', newTimezone || userTimezone());
@@ -89,7 +89,7 @@ export const WorkingHours: React.FC<WorkScheduleProps> = ({ initialSchedule }) =
 		<div className="p-6">
 			<div className="space-y-4">
 				<div className="flex items-center">
-					<p className="text-2xl w-40">Timezone</p>
+					<p className="w-40 text-2xl">Timezone</p>
 					<div className="md:w-72">
 						<TimezoneDropDown
 							currentTimezone={currentTimezone}

--- a/apps/web/locales/ar.json
+++ b/apps/web/locales/ar.json
@@ -259,6 +259,15 @@
 			"ADD_PLAN": "إضافة خطة",
 			"DELETE_THIS_PLAN": "احذف هذه الخطة"
 		},
+		"DAYOFWEEK":{
+			"Monday": "الإثنين",
+			"Tuesday": "الثلاثاء",
+			"Wednesday": "الأربعاء",
+			"Thursday": "الخميس",
+			"Friday": "الجمعة",
+			"Saturday": "السبت",
+			"Sunday": "الأحد"
+		},
 		"teamStats": {
 			"MEMBER": "عضو",
 			"MEMBERS_WORKED": "الأعضاء الذين عملوا",

--- a/apps/web/locales/bg.json
+++ b/apps/web/locales/bg.json
@@ -277,6 +277,15 @@
 			"ADD_PLAN": "Добави план",
 			"DELETE_THIS_PLAN": "Изтрийте този план"
 		},
+		"DAYOFWEEK":{
+			"Monday": "Понеделник",
+			"Tuesday": "Вторник",
+			"Wednesday": "Сряда",
+			"Thursday": "Четвъртък",
+			"Friday": "Петък",
+			"Saturday": "Събота",
+			"Sunday": "Неделя"
+		},
 		"teamStats": {
 			"MEMBER": "Член",
 			"MEMBERS_WORKED": "Членове, които са работили",

--- a/apps/web/locales/de.json
+++ b/apps/web/locales/de.json
@@ -277,6 +277,15 @@
 			"ADD_PLAN": "Plan hinzufügen",
 			"DELETE_THIS_PLAN": "Diesen Plan löschen"
 		},
+		"DAYOFWEEK":{
+			"Monday": "Montag",
+			"Tuesday": "Dienstag",
+			"Wednesday": "Mittwoch",
+			"Thursday": "Donnerstag",
+			"Friday": "Freitag",
+			"Saturday": "Samstag",
+			"Sunday": "Sonntag"
+		},
 		"teamStats": {
 			"MEMBER": "Mitglied",
 			"MEMBERS_WORKED": "Mitglieder, die gearbeitet haben",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -288,6 +288,15 @@
 			"ADD_PLAN": "Add Plan",
 			"DELETE_THIS_PLAN": "Delete this plan"
 		},
+		"DAYOFWEEK":{
+			"Monday": "Monday",
+			"Tuesday": "Tuesday",
+			"Wednesday": "Wednesday",
+			"Thursday": "Thursday",
+			"Friday": "Friday",
+			"Saturday": "Saturday",
+			"Sunday": "Sunday"
+		},
 		"teamStats": {
 			"MEMBER": "Member",
 			"MEMBERS_WORKED": "Members Worked",

--- a/apps/web/locales/es.json
+++ b/apps/web/locales/es.json
@@ -283,6 +283,15 @@
 			"FOR_TOMORROW": "Plan de mañana",
 			"DELETE_THIS_PLAN": "Eliminar este plan"
 		},
+		"DAYOFWEEK":{
+			"Monday": "Lunes",
+			"Tuesday": "Martes",
+			"Wednesday": "Miércoles",
+			"Thursday": "Jueves",
+			"Friday": "Viernes",
+			"Saturday": "Sábado",
+			"Sunday": "Domingo"
+		},
 		"teamStats": {
 			"MEMBER": "Miembro",
 			"MEMBERS_WORKED": "Miembros que Trabajaron",

--- a/apps/web/locales/fr.json
+++ b/apps/web/locales/fr.json
@@ -283,6 +283,15 @@
 			"ADD_PLAN": "Ajouter un plan",
 			"DELETE_THIS_PLAN": "Supprimer ce plan"
 		},
+		"DAYOFWEEK":{
+			"Monday": "Lundi",
+			"Tuesday": "Mardi",
+			"Wednesday": "Mercredi",
+			"Thursday": "Jeudi",
+			"Friday": "Vendredi",
+			"Saturday": "Samedi",
+			"Sunday": "Dimanche"
+		},
 		"teamStats": {
 			"MEMBER": "Membre",
 			"MEMBERS_WORKED": "Membres Ayant Travaillé",

--- a/apps/web/locales/he.json
+++ b/apps/web/locales/he.json
@@ -283,6 +283,15 @@
 			"ADD_PLAN": "הוסף תוכנית",
 			"DELETE_THIS_PLAN": "מחק את התוכנית הזו"
 		},
+		"DAYOFWEEK":{
+			"Monday": "יום ראשון",
+			"Tuesday": "יום שני",
+			"Wednesday": "יום שלישי",
+			"Thursday": "יום רביעי",
+			"Friday": "יום חמישי",
+			"Saturday": "יום שישי",
+			"Sunday": "יום שבת"
+		},
 		"teamStats": {
 			"MEMBER": "חבר",
 			"MEMBERS_WORKED": "חברים שעבדו",

--- a/apps/web/locales/it.json
+++ b/apps/web/locales/it.json
@@ -264,6 +264,7 @@
 			"SINGULAR": "Scheda attività",
 			"PLURAL": "Schede attività"
 		},
+
 		"DAYS": {
 			"sun": "Dom",
 			"mon": "Lun",
@@ -289,6 +290,15 @@
 			"SEE_PLANS": "Vedi piani",
 			"ADD_PLAN": "Aggiungi Piano",
 			"DELETE_THIS_PLAN": "Elimina questo piano"
+		},
+		"DAYOFWEEK": {
+			"Monday": "Lunedì",
+			"Tuesday": "Martedì",
+			"Wednesday": "Mercoledì",
+			"Thursday": "Giovedì",
+			"Friday": "Venerdì",
+			"Saturday": "Sabato",
+			"Sunday": "Domenica"
 		},
 		"teamStats": {
 			"MEMBER": "Membro",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -296,6 +296,15 @@
 			"ADD_PLAN": "Plan toevoegen",
 			"DELETE_THIS_PLAN": "Verwijder dit plan"
 		},
+		"DAYOFWEEK": {
+			"Monday": "Maandag",
+			"Tuesday": "Dinsdag",
+			"Wednesday": "Woensdag",
+			"Thursday": "Donderdag",
+			"Friday": "Vrijdag",
+			"Saturday": "Zaterdag",
+			"Sunday": "Zondag"
+		},
 		"teamStats": {
 			"MEMBER": "Lid",
 			"MEMBERS_WORKED": "Leden die Hebben Gewerkt",

--- a/apps/web/locales/pl.json
+++ b/apps/web/locales/pl.json
@@ -290,6 +290,15 @@
 			"ADD_PLAN": "Dodaj plan",
 			"DELETE_THIS_PLAN": "Usuń ten plan"
 		},
+		"DAYOFWEEK": {
+			"Monday": "Poniedziałek",
+			"Tuesday": "Wtorek",
+			"Wednesday": "Środa",
+			"Thursday": "Czwartek",
+			"Friday": "Piątek",
+			"Saturday": "Sobota",
+			"Sunday": "Niedziela"
+		},
 		"teamStats": {
 			"MEMBER": "Członek",
 			"MEMBERS_WORKED": "Członkowie, Którzy Pracowali",

--- a/apps/web/locales/pt.json
+++ b/apps/web/locales/pt.json
@@ -291,6 +291,15 @@
 			"ADD_PLAN": "Adicionar Plano",
 			"DELETE_THIS_PLAN": "Excluir este plano"
 		},
+		"DAYOFWEEK": {
+			"Monday": "Segunda-feira",
+			"Tuesday": "Terça-feira",
+			"Wednesday": "Quarta-feira",
+			"Thursday": "Quinta-feira",
+			"Friday": "Sexta-feira",
+			"Saturday": "Sábado",
+			"Sunday": "Domingo"
+		},
 		"teamStats": {
 			"MEMBER": "Membro",
 			"MEMBERS_WORKED": "Membros que Trabalharam",

--- a/apps/web/locales/ru.json
+++ b/apps/web/locales/ru.json
@@ -290,6 +290,15 @@
 			"ADD_PLAN": "Agregar Plan",
 			"DELETE_THIS_PLAN": "Удалить этот план"
 		},
+		"DAYOFWEEK": {
+			"Monday": "Понедельник",
+			"Tuesday": "Вторник",
+			"Wednesday": "Среда",
+			"Thursday": "Четверг",
+			"Friday": "Пятница",
+			"Saturday": "Суббота",
+			"Sunday": "Воскресенье"
+		},
 		"teamStats": {
 			"MEMBER": "Участник",
 			"MEMBERS_WORKED": "Участники, Которые Работали",

--- a/apps/web/locales/zh.json
+++ b/apps/web/locales/zh.json
@@ -296,6 +296,15 @@
 			"ADD_PLAN": "添加计划",
 			"DELETE_THIS_PLAN": "删除此计划"
 		},
+		"DAYOFWEEK": {
+			"Monday": "星期一",
+			"Tuesday": "星期二",
+			"Wednesday": "星期三",
+			"Thursday": "星期四",
+			"Friday": "星期五",
+			"Saturday": "星期六",
+			"Sunday": "星期天"
+		},
 		"teamStats": {
 			"MEMBER": "成员",
 			"MEMBERS_WORKED": "已工作的成员",


### PR DESCRIPTION
- Add localized day names for working hours in multiple languages
- Update working-hours component to use localized day names
- Improve working hours component layout and functionality

## Description

Please include a summary of the changes and the related issues.

## Type of Change

-   [x] Bug fix
-   [x] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Previous screenshots

Please add here videos or images of the previous status

## Current screenshots

Please add here videos or images of the current (new) status


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the working hours view by displaying day names using localized translations.
  - Added comprehensive translations for days of the week in Arabic, Bulgarian, German, English, Spanish, French, Hebrew, Italian, Dutch, Polish, Portuguese, Russian, and Chinese, enhancing the experience for international users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->