### PR TITLE
[Refactor] Project Management | Navigation in Create / Edit project form

### DIFF
--- a/apps/web/app/[locale]/projects/components/page-component.tsx
+++ b/apps/web/app/[locale]/projects/components/page-component.tsx
@@ -14,7 +14,7 @@ import { LAST_SELECTED_PROJECTS_VIEW } from '@/app/constants';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import FiltersCardModal from './filters-card-modal';
-import AddOrEditProjectModal from '@/lib/features/project/add-or-edit-project';
+// import AddOrEditProjectModal from '@/lib/features/project/add-or-edit-project';
 import { ProjectsListView } from './project-views/list-view';
 import { VisibilityState } from '@tanstack/react-table';
 import { ProjectViewDataType } from './project-views';
@@ -25,6 +25,7 @@ import { hidableColumnNames } from './project-views/list-view/data-table';
 import { Checkbox } from '@components/ui/checkbox';
 import { BulkArchiveProjectsModal } from '@/lib/features/project/bulk-actions/bulk-archive-projects-modal';
 import { BulkRestoreProjectsModal } from '@/lib/features/project/bulk-actions/bulk-restore-projects-modal';
+import { CreateProjectModal } from '@/lib/features/project/create-project-modal';
 
 type TViewMode = 'GRID' | 'LIST';
 
@@ -396,7 +397,7 @@ function PageComponent() {
 					) : null}
 				</div>
 				<FiltersCardModal closeModal={closeFiltersCardModal} open={isFiltersCardModalOpen} />
-				<AddOrEditProjectModal closeModal={closeProjectModal} open={isProjectModalOpen} />
+				<CreateProjectModal key={'create-project'} open={isProjectModalOpen} closeModal={closeProjectModal} />
 				{isBulkAction && (
 					<>
 						<BulkArchiveProjectsModal

--- a/apps/web/app/[locale]/projects/components/page-component.tsx
+++ b/apps/web/app/[locale]/projects/components/page-component.tsx
@@ -14,7 +14,6 @@ import { LAST_SELECTED_PROJECTS_VIEW } from '@/app/constants';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import FiltersCardModal from './filters-card-modal';
-// import AddOrEditProjectModal from '@/lib/features/project/add-or-edit-project';
 import { ProjectsListView } from './project-views/list-view';
 import { VisibilityState } from '@tanstack/react-table';
 import { ProjectViewDataType } from './project-views';

--- a/apps/web/app/[locale]/projects/components/project-views/index.tsx
+++ b/apps/web/app/[locale]/projects/components/project-views/index.tsx
@@ -1,9 +1,9 @@
 import { useModal } from '@/app/hooks';
 import { IProject } from '@/app/interfaces';
 import { HorizontalSeparator } from '@/lib/components';
-import AddOrEditProjectModal from '@/lib/features/project/add-or-edit-project';
 import { ArchiveProjectModal } from '@/lib/features/project/archive-project-modal';
 import { DeleteProjectConfirmModal } from '@/lib/features/project/delete-project-modal';
+import { EditProjectModal } from '@/lib/features/project/edit-project-modal';
 import { Menu, Transition } from '@headlessui/react';
 import { Archive, Ellipsis, Eye, Pencil, Trash } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -110,12 +110,11 @@ export function ProjectItemActions({ item }: { item: ProjectViewDataType }) {
 				open={isDeleteProjectModalOpen}
 				closeModal={closeDeleteProjectModal}
 			/>
-			<AddOrEditProjectModal
-				key={`${item.project.id}-add-or-edit-project`}
+			<EditProjectModal
 				projectId={item.project.id}
-				mode="edit"
-				closeModal={closeProjectModal}
 				open={isProjectModalOpen}
+				closeModal={closeProjectModal}
+				key={`${item.project.id}-edit-project`}
 			/>
 			<ArchiveProjectModal
 				key={`${item.project.id}-archive-project`}

--- a/apps/web/app/[locale]/projects/components/project-views/index.tsx
+++ b/apps/web/app/[locale]/projects/components/project-views/index.tsx
@@ -111,10 +111,10 @@ export function ProjectItemActions({ item }: { item: ProjectViewDataType }) {
 				closeModal={closeDeleteProjectModal}
 			/>
 			<EditProjectModal
+				key={`${item.project.id}-edit-project`}
 				projectId={item.project.id}
 				open={isProjectModalOpen}
 				closeModal={closeProjectModal}
-				key={`${item.project.id}-edit-project`}
 			/>
 			<ArchiveProjectModal
 				key={`${item.project.id}-archive-project`}

--- a/apps/web/app/components/ui/pagination/index.tsx
+++ b/apps/web/app/components/ui/pagination/index.tsx
@@ -48,7 +48,7 @@ export function Pagination({
             }
         }
 
-        for (let i of range) {
+        for (const i of range) {
             if (l) {
                 if (i - l === 2) {
                     rangeWithDots.push(l + 1);

--- a/apps/web/app/hooks/features/useDailyPlan.ts
+++ b/apps/web/app/hooks/features/useDailyPlan.ts
@@ -56,12 +56,6 @@ export function useDailyPlan() {
 	const [taskPlanList, setTaskPlans] = useAtom(taskPlans);
 	const { firstLoadData: firstLoadDailyPlanData } = useFirstLoad();
 
-	// useEffect(() => {
-	// 	if (firstLoad) {
-	// 		setDailyPlanFetching(getDayPlansByEmployeeLoading);
-	// 	}
-	// }, [getDayPlansByEmployeeLoading, firstLoad, setDailyPlanFetching]);
-
 	// All day plans
 
 	const getAllDayPlans = useCallback(async () => {
@@ -71,7 +65,6 @@ export function useDailyPlan() {
 			if (res) {
 				return res.data;
 			} else {
-<<<<<<< HEAD
 				console.error('Error fetching all day plans');
 			}
 		} catch (error) {
@@ -112,17 +105,6 @@ export function useDailyPlan() {
 	}, [getMyDailyPlans, setMyDailyPlans]);
 
 	// Employee day plans
-=======
-				// If no plans found, initialize with empty array
-				setMyDailyPlans({ items: [], total: 0 });
-			}
-		}).catch((error) => {
-			console.error('Failed to fetch daily plans:', error);
-			// In case of error, initialize with empty array
-			setMyDailyPlans({ items: [], total: 0 });
-		});
-	}, [getMyDailyPlansQueryCall, setMyDailyPlans]);
->>>>>>> e5db32f0 (docs: translate comments to English in useDailyPlan)
 
 	const getEmployeeDayPlans = useCallback(
 		async (employeeId: string) => {

--- a/apps/web/components/pages/task/details-section/blocks/task-secondary-info.tsx
+++ b/apps/web/components/pages/task/details-section/blocks/task-secondary-info.tsx
@@ -27,7 +27,7 @@ import { clsxm } from '@/app/utils';
 import { organizationProjectsState } from '@/app/stores/organization-projects';
 import ProjectIcon from '@components/ui/svgs/project-icon';
 import { ScrollArea, ScrollBar } from '@components/ui/scroll-bar';
-import { CreateProjectModal } from '@/lib/features/project/create-project-modal';
+import { QuickCreateProjectModal } from '@/lib/features/project/quick-create-project-modal';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 
 type StatusType = 'version' | 'epic' | 'status' | 'label' | 'size' | 'priority';
@@ -446,7 +446,7 @@ export function ProjectDropDown(props: ITaskProjectDropdownProps) {
 					}}
 				</Listbox>
 			</div>
-			<CreateProjectModal
+			<QuickCreateProjectModal
 				onSuccess={(project) => {
 					setSelected(project);
 					onChange?.(project);

--- a/apps/web/components/sidebar-opt-in-form.tsx
+++ b/apps/web/components/sidebar-opt-in-form.tsx
@@ -25,7 +25,7 @@ export function SidebarOptInForm() {
 	});
 
 	const subscribe = async () => {
-		let tags = ['Ever Teams, Ever Teams App', 'Open', 'Cloud'];
+		const tags = ['Ever Teams, Ever Teams App', 'Open', 'Cloud'];
 		setLoading((prev) => true);
 		const res = await fetch('/api/subscribe', {
 			body: JSON.stringify({

--- a/apps/web/lib/features/project/add-or-edit-project/container.tsx
+++ b/apps/web/lib/features/project/add-or-edit-project/container.tsx
@@ -4,6 +4,7 @@ import { TModalMode } from '.';
 
 interface IAddOrEditContainerProps extends PropsWithChildren {
 	onNext?: (data: TStepData) => void;
+	onPrevious?: (data: TStepData) => void;
 	onFinish?: (project: IProject) => void;
 	step: number;
 	currentData: TStepData;
@@ -20,13 +21,14 @@ export type TStepData = Partial<
 
 export interface IStepElementProps extends PropsWithChildren {
 	goToNext: (stepData: TStepData) => void;
+	goToPrevious: (stepData: TStepData) => void;
 	finish: (newProject: IProject) => void;
 	currentData: TStepData;
 	mode: TModalMode;
 }
 
 export default function AddOrEditContainer(props: IAddOrEditContainerProps) {
-	const { onNext, children, step, onFinish, currentData, mode } = props;
+	const { onNext, onPrevious, children, step, onFinish, currentData, mode } = props;
 
 	const childrenArray = Children.toArray(children) as ReactElement<IStepElementProps>[];
 
@@ -35,6 +37,12 @@ export default function AddOrEditContainer(props: IAddOrEditContainerProps) {
 	const handleNext = (data: TStepData) => {
 		if (step < childrenArray.length - 1) {
 			onNext?.(data);
+		}
+	};
+
+	const handlePrevious = (data: TStepData) => {
+		if (step > 0) {
+			onPrevious?.(data);
 		}
 	};
 
@@ -48,6 +56,7 @@ export default function AddOrEditContainer(props: IAddOrEditContainerProps) {
 	if (isValidElement<IStepElementProps>(currentStep)) {
 		return cloneElement(currentStep as ReactElement<IStepElementProps>, {
 			goToNext: handleNext,
+			goToPrevious: handlePrevious,
 			finish: handleFinish,
 			currentData,
 			mode

--- a/apps/web/lib/features/project/add-or-edit-project/index.tsx
+++ b/apps/web/lib/features/project/add-or-edit-project/index.tsx
@@ -1,7 +1,7 @@
-import { Card, Modal } from '@/lib/components';
+import { Card } from '@/lib/components';
 import { cn } from '@/lib/utils';
 import { Check } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import AddOrEditContainer, { TStepData } from './container';
 import TeamAndRelationsForm from './steps/team-and-relations-form';
 import BasicInformationForm from './steps/basic-information-form';
@@ -9,85 +9,19 @@ import CategorizationForm from './steps/categorization-form';
 import FinancialSettingsForm from './steps/financial-settings-form';
 import FinalReview from './steps/review-summary';
 import { useTranslations } from 'next-intl';
-import {
-	OrganizationProjectBudgetTypeEnum,
-	ProjectBillingEnum,
-	ProjectOwnerEnum,
-	TaskStatusEnum
-} from '@/app/interfaces';
-import { useOrganizationProjects } from '@/app/hooks';
-import { useRoles } from '@/app/hooks/features/useRoles';
-import { RolesEnum } from '@/app/interfaces/IRoles';
+import { ICreateProjectInput } from '@/app/interfaces';
 
 export type TModalMode = 'edit' | 'create';
 
-interface IAddOrEditProjectModalProps {
-	open: boolean;
-	closeModal: () => void;
+interface IAddOrEditProjectFormProps {
 	mode?: TModalMode;
-	projectId?: string;
+	projectData: ICreateProjectInput | object;
+	onFinish?: VoidFunction;
 }
 
-export default function AddOrEditProjectModal(props: IAddOrEditProjectModalProps) {
-	const { open, closeModal, mode = 'create', projectId } = props;
+export default function AddOrEditProjectForm(props: IAddOrEditProjectFormProps) {
+	const { mode = 'create', projectData, onFinish } = props;
 	const t = useTranslations();
-	const { organizationProjects } = useOrganizationProjects();
-	const project = useMemo(
-		() => organizationProjects.find((el) => el.id === projectId),
-		[organizationProjects, projectId]
-	);
-	const { roles } = useRoles();
-
-	const simpleMemberRole = roles?.find((role) => role.name == RolesEnum.EMPLOYEE);
-	const managerRole = roles?.find((role) => role.name == RolesEnum.MANAGER);
-
-	// Initialize step data
-	const handleInitStepData = (): Omit<TStepData, 'organizationId' | 'tenantId' | 'projectImage'> => {
-		const initialValues = {
-			name: '',
-			budgetType: OrganizationProjectBudgetTypeEnum.HOURS,
-			description: '',
-			memberIds: [],
-			managerIds: [],
-			labels: [],
-			tags: [],
-			startDate: '',
-			endDate: '',
-			billing: ProjectBillingEnum.FLAT_FEE,
-			currency: '',
-			imageUrl: '',
-			imageId: '',
-			relations: [],
-			color: '#000',
-			website: '',
-			teams: [],
-			isActive: true,
-			isArchived: false,
-			isTasksAutoSync: false,
-			isTasksAutoSyncOnLabel: false,
-			status: TaskStatusEnum.OPEN,
-			owner: ProjectOwnerEnum.CLIENT
-		};
-		if (mode === 'create') {
-			return initialValues;
-		} else if (mode === 'edit' && project !== undefined) {
-			const projectData = {
-				...project,
-				members:
-					project.members?.map((el) => ({
-						id: `${el.id}-${String(el.role)}`,
-						memberId: el.employeeId,
-						roleId: el.isManager ? managerRole?.id : simpleMemberRole?.id
-					})) || [],
-				tags: project.tags?.map((el) => el.id),
-
-				relations: []
-			} as TStepData;
-			return projectData;
-		} else {
-			return initialValues;
-		}
-	};
 
 	const initialSteps = [
 		{ id: 1, title: t('pages.projects.addOrEditModal.steps.createProject'), isCompleted: false },
@@ -98,24 +32,27 @@ export default function AddOrEditProjectModal(props: IAddOrEditProjectModalProps
 
 	const [steps, setSteps] = useState(initialSteps);
 	const [currentStep, setCurrentStep] = useState(0);
-	const [data, setData] = useState<TStepData>(handleInitStepData);
+	const [data, setData] = useState<TStepData>(projectData);
 
 	const onNextStep = useCallback(() => {
-		if (currentStep < steps.length - 1) {
+		if (currentStep <= steps.length - 1) {
 			const updatedSteps = [...steps];
 			updatedSteps[currentStep].isCompleted = true;
-			updatedSteps[currentStep + 1].isCompleted = false;
-			setCurrentStep(currentStep + 1);
-			setSteps(updatedSteps);
-		}
 
-		if (currentStep === steps.length - 1) {
-			const updatedSteps = [...steps];
-			updatedSteps[currentStep].isCompleted = true;
+			if (currentStep < steps.length - 1) {
+				updatedSteps[currentStep + 1].isCompleted = false;
+			}
+
 			setCurrentStep(currentStep + 1);
 			setSteps(updatedSteps);
 		}
 	}, [currentStep, steps]);
+
+	const handlePreviousStep = useCallback(() => {
+		if (currentStep > 0) {
+			setCurrentStep(currentStep - 1);
+		}
+	}, [currentStep]);
 
 	const handleNext = (stepData: TStepData) => {
 		setData((prev) => ({
@@ -125,83 +62,86 @@ export default function AddOrEditProjectModal(props: IAddOrEditProjectModalProps
 		onNextStep();
 	};
 
+	const handlePrevious = (stepData: TStepData) => {
+		setData((prev) => ({
+			...prev,
+			...stepData
+		}));
+		handlePreviousStep();
+	};
+
 	const handleFinish = () => {
 		//Reset the flow
 		setCurrentStep(0);
 		setSteps(initialSteps);
 		setData({});
-		closeModal();
+		onFinish?.();
 	};
 
 	return (
-		<Modal className="w-[50rem]" isOpen={open} closeModal={closeModal}>
-			<Card className="w-full  h-full " shadow="custom">
-				<div className="flex flex-row items-center justify-between h-12 gap-4">
-					{steps.map((step, index) => {
-						const isCurrent = index === currentStep;
-						const isCompleted = step.isCompleted;
-						const isLastStep = index == steps.length - 1;
+		<Card className="w-full  h-full " shadow="custom">
+			<div className="flex flex-row items-center justify-between h-12 gap-4">
+				{steps.map((step, index) => {
+					const isCurrent = index === currentStep;
+					const isCompleted = step.isCompleted;
+					const isLastStep = index == steps.length - 1;
 
-						return (
-							<div key={step.id} className={cn('flex gap-2 items-center', !isLastStep && 'grow')}>
-								<div
-									className={cn(
-										'h-4 w-4 shrink-0 bg-gray-400 flex items-center justify-center rounded-full text-white',
-										step.isCompleted && 'bg-green-700 text-white',
-										isCurrent && 'bg-primary text-primary-foreground'
-									)}
-								>
-									{step.isCompleted ? (
-										<Check size={10} />
-									) : (
-										<span className=" text-xs">{step.id}</span>
-									)}
-								</div>
-								<div
-									className={cn(
-										'text-xs shrink-0 font-medium text-gray-400',
-										isCompleted && 'text-green-700',
-										isCurrent && 'text-primary'
-									)}
-								>
-									{step.title}
-								</div>
-								{!isLastStep && <div className="h-[1px] bg-gray-300 grow"></div>}
+					return (
+						<div key={step.id} className={cn('flex gap-2 items-center', !isLastStep && 'grow')}>
+							<div
+								className={cn(
+									'h-4 w-4 shrink-0 bg-gray-400 flex items-center justify-center rounded-full text-white',
+									step.isCompleted && 'bg-green-700 text-white',
+									isCurrent && 'bg-primary text-primary-foreground'
+								)}
+							>
+								{step.isCompleted ? <Check size={10} /> : <span className=" text-xs">{step.id}</span>}
 							</div>
-						);
-					})}
-				</div>
-				<div className="w-full">
-					<AddOrEditContainer
-						currentData={data}
-						onFinish={handleFinish}
-						onNext={handleNext}
-						step={currentStep}
-						mode={mode}
-					>
-						{
-							//@ts-ignore
-							<BasicInformationForm />
-						}
-						{
-							//@ts-ignore
-							<FinancialSettingsForm />
-						}
-						{
-							//@ts-ignore
-							<CategorizationForm />
-						}
-						{
-							//@ts-ignore
-							<TeamAndRelationsForm />
-						}
-						{
-							//@ts-ignore
-							<FinalReview />
-						}
-					</AddOrEditContainer>
-				</div>
-			</Card>
-		</Modal>
+							<div
+								className={cn(
+									'text-xs shrink-0 font-medium text-gray-400',
+									isCompleted && 'text-green-700',
+									isCurrent && 'text-primary'
+								)}
+							>
+								{step.title}
+							</div>
+							{!isLastStep && <div className="h-[1px] bg-gray-300 grow"></div>}
+						</div>
+					);
+				})}
+			</div>
+			<div className="w-full">
+				<AddOrEditContainer
+					currentData={data}
+					onFinish={handleFinish}
+					onNext={handleNext}
+					onPrevious={handlePrevious}
+					step={currentStep}
+					mode={mode}
+				>
+					{
+						//@ts-ignore
+						<BasicInformationForm />
+					}
+					{
+						//@ts-ignore
+						<FinancialSettingsForm />
+					}
+					{
+						//@ts-ignore
+						<CategorizationForm />
+					}
+					{
+						//@ts-ignore
+						<TeamAndRelationsForm />
+					}
+					{
+						//@ts-ignore
+						<FinalReview />
+					}
+				</AddOrEditContainer>
+			</div>
+		</Card>
 	);
 }

--- a/apps/web/lib/features/project/add-or-edit-project/steps/basic-information-form.tsx
+++ b/apps/web/lib/features/project/add-or-edit-project/steps/basic-information-form.tsx
@@ -20,12 +20,12 @@ type BasicInfoErrorKeys = 'dateRange' | 'websiteUrl' | 'projectTitle' | 'project
 
 export default function BasicInformationForm(props: IStepElementProps) {
 	const { goToNext, currentData, mode } = props;
-	const [startDate, setStartDate] = useState(() => getInitialValue(currentData, mode, 'startDate', new Date()));
-	const [endDate, setEndDate] = useState(() => getInitialValue(currentData, mode, 'endDate', new Date()));
-	const [projectTitle, setProjectTitle] = useState(() => getInitialValue(currentData, mode, 'name', ''));
-	const [description, setDescription] = useState(() => getInitialValue(currentData, mode, 'description', ''));
+	const [startDate, setStartDate] = useState(() => getInitialValue(currentData, 'startDate', new Date()));
+	const [endDate, setEndDate] = useState(() => getInitialValue(currentData, 'endDate', new Date()));
+	const [projectTitle, setProjectTitle] = useState(() => getInitialValue(currentData, 'name', ''));
+	const [description, setDescription] = useState(() => getInitialValue(currentData, 'description', ''));
 	const [projectImageFile, setProjectImageFile] = useState<File | null>(null);
-	const [websiteUrl, setWebsiteUrl] = useState<string>(() => getInitialValue(currentData, mode, 'projectUrl', ''));
+	const [websiteUrl, setWebsiteUrl] = useState<string>(() => getInitialValue(currentData, 'projectUrl', ''));
 	const [errors, setErrors] = useState<Map<BasicInfoErrorKeys, string>>(new Map());
 	const t = useTranslations();
 	const { createImageAssets, loading: createImageAssetLoading } = useImageAssets();

--- a/apps/web/lib/features/project/add-or-edit-project/steps/categorization-form.tsx
+++ b/apps/web/lib/features/project/add-or-edit-project/steps/categorization-form.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/lib/components';
 import { cn } from '@/lib/utils';
 import { Popover } from '@headlessui/react';
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useState } from 'react';
 import { HexColorPicker } from 'react-colorful';
 import { Select } from './basic-information-form';
 import { CheckIcon } from 'lucide-react';
@@ -11,9 +11,9 @@ import { useTranslations } from 'next-intl';
 import { getInitialValue } from '../utils';
 
 export default function CategorizationForm(props: IStepElementProps) {
-	const { goToNext, currentData, mode } = props;
-	const [tags, setTags] = useState<string[]>(() => getInitialValue(currentData, mode, 'tags', []));
-	const [colorCode, setColorCode] = useState<string>(() => getInitialValue(currentData, mode, 'color', '#000'));
+	const { goToNext, goToPrevious, currentData } = props;
+	const [tags, setTags] = useState<string[]>(() => getInitialValue(currentData, 'tags', []));
+	const [colorCode, setColorCode] = useState<string>(() => getInitialValue(currentData, 'color', '#000'));
 	const { tags: tagData, getTags, createTag, createTagLoading } = useTags();
 	const t = useTranslations();
 
@@ -29,7 +29,12 @@ export default function CategorizationForm(props: IStepElementProps) {
 		});
 	};
 
-	console.log(currentData);
+	const handlePrevious = useCallback(() => {
+		goToPrevious({
+			tags: tagData?.filter((tag) => tags.includes(tag.id)),
+			color: colorCode
+		});
+	}, [colorCode, goToPrevious, tagData, tags]);
 
 	return (
 		<form onSubmit={handleSubmit} className="w-full space-y-5 pt-4">
@@ -69,7 +74,7 @@ export default function CategorizationForm(props: IStepElementProps) {
 							}}
 							renderItem={(item, selected) => {
 								return (
-									<div className="w-full h-full p-1 px-2 flex items-center gap-2">
+									<div key={item.id} className="w-full h-full p-1 px-2 flex items-center gap-2">
 										<span
 											className={cn(
 												'h-4 w-4 rounded border border-primary flex items-center justify-center',
@@ -120,7 +125,10 @@ export default function CategorizationForm(props: IStepElementProps) {
 					</div>
 				</div>
 			</div>
-			<div className="w-full flex items-center justify-end">
+			<div className="w-full flex items-center justify-between">
+				<Button onClick={handlePrevious} className=" h-[2.5rem]" type="button">
+					{t('common.BACK')}
+				</Button>
 				<Button type="submit" className=" h-[2.5rem]">
 					{t('common.NEXT')}
 				</Button>

--- a/apps/web/lib/features/project/add-or-edit-project/steps/financial-settings-form.tsx
+++ b/apps/web/lib/features/project/add-or-edit-project/steps/financial-settings-form.tsx
@@ -1,5 +1,5 @@
 import { Button, InputField } from '@/lib/components';
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useState } from 'react';
 import { Select } from './basic-information-form';
 import { IStepElementProps } from '../container';
 import { OrganizationProjectBudgetTypeEnum, ProjectBillingEnum } from '@/app/interfaces';
@@ -9,18 +9,16 @@ import { getInitialValue } from '../utils';
 import { cn } from '@/lib/utils';
 
 export default function FinancialSettingsForm(props: IStepElementProps) {
-	const { goToNext, currentData, mode } = props;
+	const { goToNext, goToPrevious, currentData } = props;
 	const { currencies, getCurrencies } = useCurrencies();
-	const [currency, setCurrency] = useState<string>(() => getInitialValue(currentData, mode, 'currency', undefined));
+	const [currency, setCurrency] = useState<string>(() => getInitialValue(currentData, 'currency', undefined));
 	const [billingType, setBillingType] = useState<ProjectBillingEnum>(() =>
-		getInitialValue(currentData, mode, 'billing', ProjectBillingEnum.FLAT_FEE)
+		getInitialValue(currentData, 'billing', ProjectBillingEnum.FLAT_FEE)
 	);
 	const [budgetType, setBudgetType] = useState<OrganizationProjectBudgetTypeEnum>(() =>
-		getInitialValue(currentData, mode, 'budgetType', OrganizationProjectBudgetTypeEnum.HOURS)
+		getInitialValue(currentData, 'budgetType', OrganizationProjectBudgetTypeEnum.HOURS)
 	);
-	const [budgetAmount, setBudgetAmount] = useState<number>(() =>
-		getInitialValue(currentData, mode, 'budget', undefined)
-	);
+	const [budgetAmount, setBudgetAmount] = useState<number>(() => getInitialValue(currentData, 'budget', undefined));
 	const budgetTypes = Object.values(OrganizationProjectBudgetTypeEnum).map((value) => ({
 		id: value,
 		value: value
@@ -45,7 +43,14 @@ export default function FinancialSettingsForm(props: IStepElementProps) {
 		getCurrencies();
 	}, [getCurrencies]);
 
-	console.log(currentData);
+	const handlePrevious = useCallback(() => {
+		goToPrevious({
+			currency: currencies.find((el) => el.isoCode === currency)?.isoCode,
+			budget: budgetAmount,
+			budgetType,
+			billing: billingType
+		});
+	}, [billingType, budgetAmount, budgetType, currencies, currency, goToPrevious]);
 
 	return (
 		<form onSubmit={handleSubmit} className="w-full space-y-5 pt-4">
@@ -124,7 +129,10 @@ export default function FinancialSettingsForm(props: IStepElementProps) {
 					</div>
 				</div>
 			</div>
-			<div className="w-full flex items-center justify-end">
+			<div className="w-full flex items-center justify-between">
+				<Button onClick={handlePrevious} className=" h-[2.5rem]" type="button">
+					{t('common.BACK')}
+				</Button>
 				<Button type="submit" className=" h-[2.5rem]">
 					{t('common.NEXT')}
 				</Button>

--- a/apps/web/lib/features/project/add-or-edit-project/steps/review-summary.tsx
+++ b/apps/web/lib/features/project/add-or-edit-project/steps/review-summary.tsx
@@ -1,5 +1,5 @@
 import { Button, VerticalSeparator } from '@/lib/components';
-import { Fragment, ReactNode } from 'react';
+import { Fragment, ReactNode, useCallback } from 'react';
 import { Calendar, Clipboard } from 'lucide-react';
 import { useOrganizationProjects, useOrganizationTeams } from '@/app/hooks';
 import { Thumbnail } from './basic-information-form';
@@ -18,7 +18,7 @@ import { useRoles } from '@/app/hooks/features/useRoles';
 import { RolesEnum } from '@/app/interfaces/IRoles';
 
 export default function FinalReview(props: IStepElementProps) {
-	const { finish, currentData: finalData, mode } = props;
+	const { goToPrevious, finish, currentData: finalData, mode } = props;
 	const {
 		createOrganizationProject,
 		createOrganizationProjectLoading,
@@ -94,6 +94,10 @@ export default function FinalReview(props: IStepElementProps) {
 		}
 	};
 
+	const handlePrevious = useCallback(() => {
+		goToPrevious(finalData);
+	}, [finalData, goToPrevious]);
+
 	return (
 		<form onSubmit={handleSubmit} className="w-full space-y-5 pt-4">
 			<div className="w-full flex flex-col gap-6">
@@ -126,7 +130,10 @@ export default function FinalReview(props: IStepElementProps) {
 					/>
 				</div>
 			</div>
-			<div className="w-full flex items-center justify-end">
+			<div className="w-full flex items-center justify-between">
+				<Button onClick={handlePrevious} className=" h-[2.5rem]" type="button">
+					{t('common.BACK')}
+				</Button>
 				{mode == 'edit' ? (
 					<Button
 						loading={editOrganizationProjectLoading}

--- a/apps/web/lib/features/project/add-or-edit-project/steps/review-summary.tsx
+++ b/apps/web/lib/features/project/add-or-edit-project/steps/review-summary.tsx
@@ -131,7 +131,12 @@ export default function FinalReview(props: IStepElementProps) {
 				</div>
 			</div>
 			<div className="w-full flex items-center justify-between">
-				<Button onClick={handlePrevious} className=" h-[2.5rem]" type="button">
+				<Button
+					disabled={createOrganizationProjectLoading || editOrganizationProjectLoading}
+					onClick={handlePrevious}
+					className=" h-[2.5rem]"
+					type="button"
+				>
 					{t('common.BACK')}
 				</Button>
 				{mode == 'edit' ? (

--- a/apps/web/lib/features/project/add-or-edit-project/steps/team-and-relations-form.tsx
+++ b/apps/web/lib/features/project/add-or-edit-project/steps/team-and-relations-form.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/lib/components';
 import { CheckIcon, Plus, X } from 'lucide-react';
-import { FormEvent, useState } from 'react';
+import { FormEvent, useCallback, useState } from 'react';
 import { Identifiable, Select, Thumbnail } from './basic-information-form';
 import { IStepElementProps } from '../container';
 import { useOrganizationProjects, useOrganizationTeams } from '@/app/hooks';
@@ -12,9 +12,9 @@ import { useTranslations } from 'next-intl';
 import { getInitialValue } from '../utils';
 
 export default function TeamAndRelationsForm(props: IStepElementProps) {
-	const { goToNext, currentData, mode } = props;
+	const { goToNext, goToPrevious, currentData } = props;
 	const [members, setMembers] = useState<{ memberId: string; roleId: string; id: string }[]>(() =>
-		getInitialValue(currentData, mode, 'members', [])
+		getInitialValue(currentData, 'members', [])
 	);
 	const [relations, setRelations] = useState<(IProjectRelation & { id: string })[]>([]);
 	const { organizationProjects } = useOrganizationProjects();
@@ -48,6 +48,13 @@ export default function TeamAndRelationsForm(props: IStepElementProps) {
 			relations: relations.filter((el) => el.projectId && el.relationType)
 		});
 	};
+
+	const handlePrevious = useCallback(() => {
+		goToPrevious({
+			members,
+			relations: relations.filter((el) => el.projectId && el.relationType)
+		});
+	}, [goToPrevious, members, relations]);
 
 	return (
 		<form onSubmit={handleSubmit} className="w-full space-y-5 pt-4">
@@ -184,7 +191,10 @@ export default function TeamAndRelationsForm(props: IStepElementProps) {
 				</div>
 			</div>
 
-			<div className="w-full flex items-center justify-end">
+			<div className="w-full flex items-center justify-between">
+				<Button onClick={handlePrevious} className=" h-[2.5rem]" type="button">
+					{t('common.BACK')}
+				</Button>
 				<Button type="submit" className=" h-[2.5rem]">
 					{t('common.NEXT')}
 				</Button>

--- a/apps/web/lib/features/project/add-or-edit-project/utils.ts
+++ b/apps/web/lib/features/project/add-or-edit-project/utils.ts
@@ -1,24 +1,24 @@
-import { TModalMode } from '.';
 import { TStepData } from './container';
 
 /**
- * Retrieves the initial value for a given key based on the current mode and data.
- * If in "edit" mode and the key exists in `currentData`, it returns the corresponding value.
+ * Retrieves the initial value for the project steps form.
+ * If the key exists in `currentData`, it returns the corresponding value.
  * Converts `startDate` and `endDate` to Date objects.
  * Falls back to the provided `fallback` value if conditions are not met.
  *
  * @param {TStepData} currentData - The current step data object.
- * @param {TModalMode} mode - The mode of the modal (e.g., "edit").
  * @param {keyof TStepData} key - The key to retrieve from `currentData`.
  * @param {any} fallback - The fallback value if no valid value is found.
  * @returns {any} The processed initial value.
  */
-export const getInitialValue = (currentData: TStepData, mode: TModalMode, key: keyof TStepData, fallback: any) => {
-	if (mode === 'edit' && currentData?.[key] !== undefined) {
+export const getInitialValue = (currentData: TStepData, key: keyof TStepData, fallback: any) => {
+	if (currentData?.[key] !== undefined) {
 		switch (key) {
 			case 'startDate':
 			case 'endDate':
 				return currentData[key] ? new Date(currentData[key] ?? 0) : fallback;
+			case 'tags':
+				return currentData[key]?.map((tag) => tag.id) || [];
 			default:
 				return currentData[key] || fallback;
 		}

--- a/apps/web/lib/features/project/create-project-modal.tsx
+++ b/apps/web/lib/features/project/create-project-modal.tsx
@@ -1,16 +1,12 @@
-import { useOrganizationProjects } from '@/app/hooks';
-import { IProject } from '@/app/interfaces';
-import { Button, Card, InputField, Modal, Text } from 'lib/components';
-import { useTranslations } from 'next-intl';
-import { useCallback, useEffect, useState } from 'react';
+import { Modal } from 'lib/components';
+import AddOrEditProjectForm from './add-or-edit-project';
 
 interface ICreateProjectModalProps {
 	open: boolean;
 	closeModal: () => void;
-	onSuccess?: (project: IProject) => void;
 }
 /**
- * A modal that allow to create a new project
+ * A modal to create a project
  *
  * @param {Object} props - The props Object
  * @param {boolean} props.open - If true open the modal otherwise close the modal
@@ -19,78 +15,11 @@ interface ICreateProjectModalProps {
  * @returns {JSX.Element} The modal element
  */
 export function CreateProjectModal(props: ICreateProjectModalProps) {
-	const t = useTranslations();
-	const { open, closeModal, onSuccess } = props;
-	const { createOrganizationProject, createOrganizationProjectLoading } = useOrganizationProjects();
-	const [name, setName] = useState('');
-
-	// Cleanup
-	useEffect(() => {
-		return () => {
-			setName('');
-		};
-	}, []);
-
-	const handleCreateProject = useCallback(async () => {
-		try {
-			if (name.trim() === '') {
-				return;
-			}
-			const data = await createOrganizationProject({ name });
-
-			if (data) {
-				onSuccess?.(data);
-			}
-
-			closeModal();
-		} catch (error) {
-			console.error(error);
-		}
-	}, [closeModal, createOrganizationProject, name, onSuccess]);
+	const { open, closeModal } = props;
 
 	return (
-		<Modal isOpen={open} closeModal={closeModal} alignCloseIcon>
-			<Card className=" sm:w-[33rem] w-[20rem]" shadow="custom">
-				<div className="flex flex-col items-center justify-between gap-8">
-					<Text.Heading as="h3" className="text-center">
-						{t('common.CREATE_PROJECT')}
-					</Text.Heading>
-
-					<div className="w-full">
-						<InputField
-							name="name"
-							autoCustomFocus
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-							placeholder={'Please enter the project name'}
-							required
-							className="w-full"
-							wrapperClassName=" h-full border border-blue-500"
-							noWrapper
-						/>
-					</div>
-
-					<div className="flex items-center justify-between w-full">
-						<Button
-							disabled={createOrganizationProjectLoading}
-							onClick={closeModal}
-							className="h-[2.75rem]"
-							variant="outline"
-						>
-							{t('common.CANCEL')}
-						</Button>
-						<Button
-							disabled={createOrganizationProjectLoading}
-							loading={createOrganizationProjectLoading}
-							className="h-[2.75rem]"
-							type="submit"
-							onClick={handleCreateProject}
-						>
-							{t('common.CREATE')}
-						</Button>
-					</div>
-				</div>
-			</Card>
+		<Modal className="w-[50rem]" isOpen={open} closeModal={closeModal} alignCloseIcon>
+			<AddOrEditProjectForm onFinish={closeModal} mode="create" projectData={{}} />
 		</Modal>
 	);
 }

--- a/apps/web/lib/features/project/edit-project-modal.tsx
+++ b/apps/web/lib/features/project/edit-project-modal.tsx
@@ -1,0 +1,53 @@
+import { useOrganizationProjects } from '@/app/hooks';
+import { Modal } from 'lib/components';
+import { useMemo } from 'react';
+import AddOrEditProjectForm from './add-or-edit-project';
+import { RolesEnum } from '@/app/interfaces/IRoles';
+import { useRoles } from '@/app/hooks/features/useRoles';
+
+interface IEditProjectModalProps {
+	open: boolean;
+	closeModal: () => void;
+	projectId: string;
+}
+/**
+ * A modal to edit a project
+ *
+ * @param {Object} props - The props Object
+ * @param {boolean} props.open - If true open the modal otherwise close the modal
+ * @param {() => void} props.closeModal - A function to close the modal
+ *
+ * @returns {JSX.Element} The modal element
+ */
+export function EditProjectModal(props: IEditProjectModalProps) {
+	const { open, closeModal, projectId } = props;
+	const { organizationProjects } = useOrganizationProjects();
+	const { roles } = useRoles();
+
+	const simpleMemberRole = roles?.find((role) => role.name == RolesEnum.EMPLOYEE);
+	const managerRole = roles?.find((role) => role.name == RolesEnum.MANAGER);
+
+	const data = useMemo(() => {
+		const project = organizationProjects.find((project) => project.id === projectId);
+
+		return project
+			? {
+					...project,
+					members:
+						project.members?.map((el) => ({
+							id: `${el.id}-${String(el.role)}`,
+							memberId: el.employeeId,
+							roleId: el.isManager ? managerRole?.id : simpleMemberRole?.id
+						})) || [],
+					tags: project.tags?.map((el) => el.id),
+					relations: []
+				}
+			: {};
+	}, [managerRole?.id, organizationProjects, projectId, simpleMemberRole?.id]);
+
+	return (
+		<Modal className="w-[50rem]" isOpen={open} closeModal={closeModal} alignCloseIcon>
+			<AddOrEditProjectForm onFinish={closeModal} mode="edit" projectData={data} />
+		</Modal>
+	);
+}

--- a/apps/web/lib/features/project/quick-create-project-modal.tsx
+++ b/apps/web/lib/features/project/quick-create-project-modal.tsx
@@ -1,0 +1,96 @@
+import { useOrganizationProjects } from '@/app/hooks';
+import { IProject } from '@/app/interfaces';
+import { Button, Card, InputField, Modal, Text } from 'lib/components';
+import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useState } from 'react';
+
+interface IQuickCreateProjectModalProps {
+	open: boolean;
+	closeModal: () => void;
+	onSuccess?: (project: IProject) => void;
+}
+/**
+ * A modal that allow to create a new project
+ *
+ * @param {Object} props - The props Object
+ * @param {boolean} props.open - If true open the modal otherwise close the modal
+ * @param {() => void} props.closeModal - A function to close the modal
+ *
+ * @returns {JSX.Element} The modal element
+ */
+export function QuickCreateProjectModal(props: IQuickCreateProjectModalProps) {
+	const t = useTranslations();
+	const { open, closeModal, onSuccess } = props;
+	const { createOrganizationProject, createOrganizationProjectLoading } = useOrganizationProjects();
+	const [name, setName] = useState('');
+
+	// Cleanup
+	useEffect(() => {
+		return () => {
+			setName('');
+		};
+	}, []);
+
+	const handleCreateProject = useCallback(async () => {
+		try {
+			if (name.trim() === '') {
+				return;
+			}
+			const data = await createOrganizationProject({ name });
+
+			if (data) {
+				onSuccess?.(data);
+			}
+
+			closeModal();
+		} catch (error) {
+			console.error(error);
+		}
+	}, [closeModal, createOrganizationProject, name, onSuccess]);
+
+	return (
+		<Modal isOpen={open} closeModal={closeModal} alignCloseIcon>
+			<Card className=" sm:w-[33rem] w-[20rem]" shadow="custom">
+				<div className="flex flex-col items-center justify-between gap-8">
+					<Text.Heading as="h3" className="text-center">
+						{t('common.CREATE_PROJECT')}
+					</Text.Heading>
+
+					<div className="w-full">
+						<InputField
+							name="name"
+							autoCustomFocus
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							placeholder={'Please enter the project name'}
+							required
+							className="w-full"
+							wrapperClassName=" h-full border border-blue-500"
+							noWrapper
+						/>
+					</div>
+
+					<div className="flex items-center justify-between w-full">
+						<Button
+							disabled={createOrganizationProjectLoading}
+							onClick={closeModal}
+							className="h-[2.75rem]"
+							variant="outline"
+						>
+							{t('common.CANCEL')}
+						</Button>
+						<Button
+							disabled={createOrganizationProjectLoading}
+							loading={createOrganizationProjectLoading}
+							className="h-[2.75rem]"
+							type="submit"
+							onClick={handleCreateProject}
+						>
+							{t('common.CREATE')}
+						</Button>
+					</div>
+				</div>
+			</Card>
+		</Modal>
+	);
+}


### PR DESCRIPTION
## Description

- Add a 'Back' button that allow manager to go back to previous steps if needed
- Separate create and edit modals for maintainability while sharing the same form for code reusability

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

## Current screenshots

[Loom](https://www.loom.com/share/0236e359119f47dd8bc3163cfa8e02d6?sid=c4355194-3b03-4ae9-bd3a-6541bb6802b3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `QuickCreateProjectModal` for streamlined project creation.
	- Added `EditProjectModal` for editing project details.
	- Implemented back navigation across multi-step project forms for user convenience.
- **Refactor**
	- Renamed and simplified `AddOrEditProjectModal` to `AddOrEditProjectForm`, enhancing state management.
	- Streamlined modal handling for project creation and editing.
- **Style**
	- Enhanced button layouts and overall alignment for improved user interface.
- **Bug Fixes**
	- Removed unused import statements and unnecessary state management from the `CreateProjectModal`.
- **Chores**
	- Cleaned up commented-out code and improved error handling in the `useDailyPlan` hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->