### PR TITLE
[Fix]: Vertical alignment of titles with their corresponding card content -issue(#3462)

### DIFF
--- a/apps/web/lib/features/team/user-team-card/task-skeleton.tsx
+++ b/apps/web/lib/features/team/user-team-card/task-skeleton.tsx
@@ -43,33 +43,38 @@ export function InviteUserTeamSkeleton() {
 export function UserTeamCardHeader() {
 	const t = useTranslations();
 	return (
-		<div className="w-full h-14  dark:text-[#7B8089] font-normal  -mt-1 z-50 dark:bg-dark-high px-8 m-0">
+		<div className="w-full h-14 dark:text-[#7B8089] font-normal -mt-1 z-50 dark:bg-dark-high px-8 m-0">
 			<div className="w-full h-full px-4 ml-4 md:px-8">
-				<div className="relative flex items-center justify-around w-full h-full m-0">
-					<div className="inline-flex items-center space-x-2 2xl:w-[20.625rem] w-1/4">
-						<div className="w-[50px] h-full flex justify-center items-center"></div>
-						<div className="lg:w-64 w-1/2 flex flex-col gap-1.5 text-nowrap">
+				<div className="relative flex items-center w-full h-full m-0">
+					<div className="flex items-center ml-6 w-72">
+						<div className="text-nowrap">
 							{t('common.TEAM')} {t('common.MEMBER')}
 						</div>
 					</div>
+
 					<div className="w-1 self-stretch border-l-[0.125rem] border-l-transparent" />
-					<div className="flex justify-between items-center min-w-[24%]">
-						<div className="h-full w-full flex flex-col items-center justify-center text-nowrap gap-[1.0620rem] max-h-full overflow-hidden flex-1 lg:px-4 px-2 overflow-y-hidden">
-							{t('common.TASK')}
-						</div>
+
+					<div className="flex-1 md:min-w-[25%] xl:min-w-[30%] !max-w-[250px] px-2 lg:px-4">
+						<div className="text-nowrap">{t('common.TASK')}</div>
 					</div>
-					<div className="w-4 self-stretch border-l-[0.125rem] border-l-transparent " />
-					<div className="2xl:w-48 3xl:w-[12rem] capitalize w-1/5 lg:px-4 !pl-6 lg:!pl-8  flex flex-col items-center text-center  justify-center">
+
+					<div className="w-1 self-stretch border-l-[0.125rem] border-l-transparent" />
+
+					<div className="2xl:w-48 3xl:w-[12rem] w-1/5 lg:px-4 px-2 flex justify-start items-center pl-6">
 						<Tooltip label={t('task.taskTableHead.WORKED_ON_TASK_HEADER_TOOLTIP')} className="text-nowrap">
 							{t('dailyPlan.TASK_TIME')}
 						</Tooltip>
 					</div>
+
 					<div className="w-1 self-stretch border-l-[0.125rem] border-l-transparent" />
-					<div className="w-1/5 lg:px-3 2xl:w-52 3xl:w-64 !pl-14 text-center text-nowrap">
-						{t('common.ESTIMATE')}
+
+					<div className="flex items-center justify-start pl-6 2xl:w-52 3xl:w-64">
+						<div className="text-nowrap">{t('common.ESTIMATE')}</div>
 					</div>
+
 					<div className="w-1 self-stretch border-l-[0.125rem] border-l-transparent" />
-					<div className="flex justify-center items-center cursor-pointer w-1/5 gap-4 lg:px-3 2xl:w-52 max-w-[13rem] !pl-14 text-center">
+
+					<div className="w-1/5 2xl:w-52 max-w-[13rem] flex justify-center">
 						<Tooltip
 							label={t('task.taskTableHead.TOTAL_WORKED_TODAY_HEADER_TOOLTIP')}
 							className="text-nowrap"
@@ -77,6 +82,8 @@ export function UserTeamCardHeader() {
 							{t('dailyPlan.TOTAL_TODAY')}
 						</Tooltip>
 					</div>
+
+					<div className="w-10"></div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Description

-  align the titles vertically to their repective related content in the card on all the screen sizes 

## Type of Change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots
![image](https://github.com/user-attachments/assets/b4c7f34d-49f6-4c7f-80b8-4c5a139e99dc)

## Current screenshots

Please add here videos or images of the current (new) status


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the team card interface with improved spacing, alignment, and responsiveness.
  - Streamlined the layout for cleaner, more consistent visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->