### PR TITLE
[Fix]: (Task card) Tabs and tasks cards in the container UI - issue (#3732)

### DIFF
--- a/apps/web/lib/features/team/user-team-card/index.tsx
+++ b/apps/web/lib/features/team/user-team-card/index.tsx
@@ -99,7 +99,7 @@ export function UserTeamCard({
 		);
 
 		totalWork = (
-			<div className={clsxm('flex space-x-2 items-center font-normal flex-col mr-4')}>
+			<div className={clsxm('flex flex-col items-center mr-4 space-x-2 font-normal')}>
 				<span className="text-xs text-gray-500">{t('common.TOTAL_TIME')}:</span>
 				<Text className="text-xs">
 					{h}h : {m}m
@@ -116,7 +116,7 @@ export function UserTeamCard({
 				<InputField
 					type="checkbox"
 					checked={user_selected()}
-					className={clsxm('border-none w-4 h-4 mr-1 accent-primary-light', 'border-2 border-primary-light')}
+					className={clsxm('mr-1 w-4 h-4 border-none accent-primary-light', 'border-2 border-primary-light')}
 					noWrapper={true}
 					onChange={onUserSelect}
 				/>
@@ -160,14 +160,14 @@ export function UserTeamCard({
 					className
 				)}
 			>
-				<div className="relative flex items-center m-0">
+				<div className="flex relative items-center m-0">
 					<div className="absolute left-0 cursor-pointer">
 						<SixSquareGridIcon className="w-2  text-[#CCCCCC] dark:text-[#4F5662]" />
 					</div>
 
 					{/* Show user name, email and image */}
 					<div className="relative">
-						<UserInfo memberInfo={memberInfo} className=" w-72" publicTeam={publicTeam} />
+						<UserInfo memberInfo={memberInfo} className="w-72" publicTeam={publicTeam} />
 						{!publicTeam && (
 							<div
 								onClick={() => {
@@ -178,7 +178,7 @@ export function UserTeamCard({
 									);
 									setShowActivity(false);
 								}}
-								className={clsxm('h-6 w-6 absolute right-4 top-0 cursor-pointer p-[3px]')}
+								className={clsxm('absolute top-0 right-4 w-6 h-6 cursor-pointer p-[3px]')}
 							>
 								<ChevronDoubleDownIcon
 									className={clsxm(
@@ -196,14 +196,14 @@ export function UserTeamCard({
 						<TaskInfo
 							edition={taskEdition}
 							memberInfo={memberInfo}
-							className="flex-1 px-2 overflow-y-hidden lg:px-4"
+							className="overflow-y-hidden flex-1 px-2 lg:px-4"
 							publicTeam={publicTeam}
 							tab="default"
 						/>
 
 						{isManagerConnectedUser != 1 ? (
 							<p
-								className="flex items-center justify-center w-8 h-8 text-center border rounded cursor-pointer dark:border-gray-800"
+								className="flex justify-center items-center w-8 h-8 text-center rounded border cursor-pointer dark:border-gray-800"
 								onClick={() => {
 									showActivityFilter('TICKET', memberInfo.member ?? null);
 									setUserDetailAccordion('');
@@ -245,7 +245,7 @@ export function UserTeamCard({
 						{isManagerConnectedUser != -1 ? (
 							<p
 								onClick={() => showActivityFilter('DATE', memberInfo.member ?? null)}
-								className="flex items-center justify-center w-8 h-8 text-center border rounded cursor-pointer dark:border-gray-800"
+								className="flex justify-center items-center w-8 h-8 text-center rounded border cursor-pointer dark:border-gray-800"
 							>
 								{!showActivity ? (
 									<ExpandIcon height={24} width={24} />
@@ -264,9 +264,9 @@ export function UserTeamCard({
 					<div className="overflow-y-auto h-96">
 						{canSeeActivity && (
 							<Container fullWidth={fullWidth} className="py-8">
-								<div className={clsxm('flex justify-start items-center gap-4 mt-3')}>
+								<div className={clsxm('flex gap-4 justify-start items-center mt-3')}>
 									{Object.keys(activityScreens).map((filter, i) => (
-										<div key={i} className="flex items-center justify-start gap-4 cursor-pointer">
+										<div key={i} className="flex gap-4 justify-start items-center cursor-pointer">
 											{i !== 0 && <VerticalSeparator />}
 											<div
 												className={clsxm(
@@ -285,7 +285,7 @@ export function UserTeamCard({
 						{activityScreens[activityFilter] ?? null}
 					</div>
 				) : userDetailAccordion == memberInfo.memberUser?.id ? (
-					<div className="flex items-center justify-center w-full h-20">
+					<div className="flex justify-center items-center w-full h-20">
 						<Loader className="animate-spin" />
 					</div>
 				) : null}
@@ -299,13 +299,13 @@ export function UserTeamCard({
 					className
 				)}
 			>
-				<div className="flex items-center justify-between mb-4">
+				<div className="flex justify-between items-center mb-4">
 					<UserInfo memberInfo={memberInfo} publicTeam={publicTeam} className="w-9/12" />
 					{/*@ts-ignore*/}
 					{totalWork}
 				</div>
 
-				<div className="flex flex-wrap items-start justify-between pb-4 border-b">
+				<div className="flex flex-wrap justify-between items-start pb-4 border-b">
 					<TaskInfo
 						edition={taskEdition}
 						memberInfo={memberInfo}

--- a/apps/web/lib/features/team/user-team-card/user-team-card-activity.tsx
+++ b/apps/web/lib/features/team/user-team-card/user-team-card-activity.tsx
@@ -14,10 +14,10 @@ import UserWorkedTaskTab from 'lib/features/activity/user-worked-task';
 
 const UserTeamActivity = ({ showActivity, member }: { showActivity: boolean; member?: OT_Member }) => {
 	const { timeSlots } = useTimeSlots(true);
-
 	const t = useTranslations();
 
 	const activityPercent = timeSlots.reduce((acc, el) => acc + el.percentage, 0) / timeSlots.length;
+
 	return (
 		<Transition
 			show={!!showActivity}
@@ -27,14 +27,14 @@ const UserTeamActivity = ({ showActivity, member }: { showActivity: boolean; mem
 			leave="transition-opacity duration-150"
 			leaveFrom="opacity-100"
 			leaveTo="opacity-0"
-			className="w-full"
+			className="px-4 w-full" // Added px-4 to ensure content doesn't touch the edges
 		>
-			<div className="transition-all">
+			<div className="w-full transition-all">
 				<HorizontalSeparator className="my-4" />
-				<h2 className="px-4 py-2 text-xl font-semibold">Activity for Today</h2>
-				<div className="flex flex-col justify-between overflow-hidden gap-y-5">
-					<div className="flex items-center gap-3 wrap">
-						<div className="shadow basis-1/4 min-w-56 max-w-80 rounded-md w-full p-4 m-4 h-32 bg-light--theme-light dark:bg-[#26272C]">
+				<h2 className="py-2 text-xl font-semibold">Activity for Today</h2>
+				<div className="flex overflow-hidden flex-col gap-y-5 justify-between w-full">
+					<div className="flex gap-3 items-center w-full">
+						<div className="shadow basis-1/4 min-w-56 max-w-80 rounded-md p-4 h-32 bg-light--theme-light dark:bg-[#26272C]">
 							<span>{t('timer.TIME_ACTIVITY')}</span>
 							<h2 className="my-3 text-3xl font-bold">
 								{activityPercent ? activityPercent.toFixed(2) : '00'} %
@@ -42,19 +42,19 @@ const UserTeamActivity = ({ showActivity, member }: { showActivity: boolean; mem
 							<ProgressBar width={'80%'} progress={`${activityPercent}%`} className="my-2" />
 						</div>
 					</div>
-					<div className="flex-1 overflow-hidden">
+					<div className="overflow-hidden flex-1 w-full">
 						<Tab.Group>
-							<Tab.List className="w-full flex space-x-1 rounded-xl bg-gray-200 dark:bg-[#FFFFFF14] p-2 mx-4">
+							<Tab.List className="w-full flex space-x-1 rounded-xl bg-gray-200 dark:bg-[#FFFFFF14] p-2">
 								{Object.values(ActivityFilters).map((filter: string) => (
 									<Tab
 										key={filter}
 										className={({ selected }) =>
 											clsxm(
 												'w-full rounded-lg py-2.5 text-sm font-medium leading-5',
-												' focus:outline-none focus:ring-2',
+												'focus:outline-none focus:ring-2',
 												selected
 													? 'bg-white dark:bg-dark text-blue-700 shadow'
-													: ' hover:bg-white/[0.50]'
+													: 'hover:bg-white/[0.50]'
 											)
 										}
 									>
@@ -62,17 +62,17 @@ const UserTeamActivity = ({ showActivity, member }: { showActivity: boolean; mem
 									</Tab>
 								))}
 							</Tab.List>
-							<Tab.Panels>
-								<Tab.Panel className="w-full p-2 mx-4 overflow-hidden">
+							<Tab.Panels className="mt-2 w-full">
+								<Tab.Panel className="overflow-hidden w-full">
 									<UserWorkedTaskTab member={member} />
 								</Tab.Panel>
-								<Tab.Panel className="w-full p-2 mx-4">
+								<Tab.Panel className="w-full">
 									<ScreenshootTeamTab />
 								</Tab.Panel>
-								<Tab.Panel className="w-full p-2 mx-4">
+								<Tab.Panel className="w-full">
 									<AppsTab />
 								</Tab.Panel>
-								<Tab.Panel className="w-full p-2 mx-4">
+								<Tab.Panel className="w-full">
 									<VisitedSitesTab />
 								</Tab.Panel>
 							</Tab.Panels>


### PR DESCRIPTION
## Description

- Fix Tabs and tasks cards moving out their container when the main card is collapsed

## Type of Change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots
How it was looking 
![Screenshot from 2025-04-05 11-01-32](https://github.com/user-attachments/assets/28f2010f-7300-41d2-b3f4-b562f4363de6)

The update
![Screenshot from 2025-04-05 11-07-57](https://github.com/user-attachments/assets/0e439a43-58a9-481e-894e-46ba57b98264)


Please add here videos or images of the previous status

## Current screenshots

Please add here videos or images of the current (new) status


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the presentation of team cards for a cleaner and consistent look.
  - Improved the spacing and alignment of activity panels to ensure a well-balanced layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->