### PR TITLE
[Feat]: Show input borders only in edit mode  -issue(#3736)

### DIFF
--- a/apps/web/app/[locale]/settings/personal/page.tsx
+++ b/apps/web/app/[locale]/settings/personal/page.tsx
@@ -9,47 +9,47 @@ import { SyncZone } from 'lib/settings/sync.zone';
 import { WorkingHours } from '@/lib/settings/working-hours';
 
 const Personal = () => {
-	const t = useTranslations();
+    const t = useTranslations();
 
-	return (
-		<div className="pb-16 overflow-auto">
-			<Link href={'/settings/team'} className="w-full">
-				<button className="w-full p-4 mt-2 border lg:hidden hover:bg-white rounded-xl border-dark text-dark">
-					Go to Team settings
-				</button>
-			</Link>
-			<Accordian
-				title={t('pages.settingsPersonal.HEADING_TITLE')}
-				className="w-full max-w-[96vw] p-4 mt-5 dark:bg-dark--theme"
-				id="general"
-			>
-				{/* <Text className="text-base font-normal text-center text-gray-400 sm:text-left">
-					{t('pages.settings.HEADING_DESCRIPTION')}
-				</Text> */}
-				<ProfileAvatar />
-				<PersonalSettingForm />
-			</Accordian>
-			<Accordian
-				title='Working hours'
-				className="p-4 mt-4 dark:bg-dark--theme"
-				id="working-hours">
-				<WorkingHours />
-			</Accordian>
-			<Accordian
-				title={t('pages.settingsPersonal.DATA_SYNCHRONIZATION')}
-				className="p-4 mt-4 dark:bg-dark--theme"
-				id="sync-zone"
-			>
-				<SyncZone />
-			</Accordian>
-			<Accordian
-				title={t('pages.settings.DANDER_ZONE')}
-				className="p-4 mt-4 dark:bg-dark--theme"
-				id="danger-zone"
-			>
-				<DangerZone />
-			</Accordian>
-		</div>
-	);
+    return (
+        <div className="pb-16 overflow-auto">
+            <Link href={'/settings/team'} className="w-full">
+                <button className="w-full p-4 mt-2 border lg:hidden hover:bg-white rounded-xl border-dark text-dark">
+                    Go to Team settings
+                </button>
+            </Link>
+            <Accordian
+                title={t('pages.settingsPersonal.HEADING_TITLE')}
+                className="w-full max-w-[96vw] p-4 mt-5 dark:bg-dark--theme"
+                id="general"
+            >
+                {/* <Text className="text-base font-normal text-center text-gray-400 sm:text-left">
+                    {t('pages.settings.HEADING_DESCRIPTION')}
+                </Text> */}
+                <ProfileAvatar />
+                <PersonalSettingForm />
+            </Accordian>
+            <Accordian
+                title='Working hours'
+                className="p-4 mt-4 dark:bg-dark--theme"
+                id="working-hours">
+                <WorkingHours />
+            </Accordian>
+            <Accordian
+                title={t('pages.settingsPersonal.DATA_SYNCHRONIZATION')}
+                className="p-4 mt-4 dark:bg-dark--theme"
+                id="sync-zone"
+            >
+                <SyncZone />
+            </Accordian>
+            <Accordian
+                title={t('pages.settings.DANDER_ZONE')}
+                className="p-4 mt-4 dark:bg-dark--theme"
+                id="danger-zone"
+            >
+                <DangerZone />
+            </Accordian>
+        </div>
+    );
 };
 export default withAuthentication(Personal, { displayName: 'Personal' });

--- a/apps/web/lib/settings/personal-setting-form.tsx
+++ b/apps/web/lib/settings/personal-setting-form.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-mixed-spaces-and-tabs */
 import {
   PHONE_REGEX,
   getActiveLanguageIdCookie,
@@ -35,9 +34,7 @@ export const PersonalSettingForm = () => {
   const { theme } = useTheme();
   const [editFullname, setEditFullname] = useState<boolean>(false);
   const [editContacts, setEditContacts] = useState<boolean>(false);
-  const [showEmailResetModal, setShowEmailResetModal] = useState<boolean>(
-    false
-  );
+  const [showEmailResetModal, setShowEmailResetModal] = useState<boolean>(false);
   const [newEmail, setNewEmail] = useState<string>('');
   const [isValid, setIsValid] = useState<IValidation>({
     email: true,
@@ -66,7 +63,6 @@ export const PersonalSettingForm = () => {
 
   const checkPhoneValidity = (e: React.ChangeEvent<HTMLInputElement>) => {
     const phone = e.target.value;
-
     phone
       ? setIsValid({ ...isValid, phone: phone.match(PHONE_REGEX) !== null })
       : setIsValid({ ...isValid, phone: true });
@@ -105,10 +101,12 @@ export const PersonalSettingForm = () => {
     },
     [setCurrentTimezone, setValue, updateAvatar, user]
   );
+
   useEffect(() => {
     setCurrentTimezone(user?.timeZone || getActiveTimezoneIdCookie());
     setValue('timeZone', user?.timeZone || getActiveTimezoneIdCookie());
   }, [setCurrentTimezone, setValue, user, user?.timeZone]);
+
   useEffect(() => {
     setValue('firstName', user?.firstName);
     setValue('lastName', user?.lastName);
@@ -132,6 +130,7 @@ export const PersonalSettingForm = () => {
       user?.preferredLanguage || getActiveLanguageIdCookie()
     );
   }, [user, user?.preferredLanguage, setValue]);
+
   const handleChangeLanguage = useCallback(
     (newLanguage: string) => {
       setActiveLanguageIdCookie(newLanguage);
@@ -150,6 +149,14 @@ export const PersonalSettingForm = () => {
     [user, setValue, updateAvatar, changeLanguage, router]
   );
 
+  const displayValueField = (value: string | undefined, placeholder: string) => {
+    return (
+      <div className="h-[54px] w-full rounded-lg flex  items-center px-4 text-base font-normal text-gray-400 bg-light--theme-light dark:bg-dark--theme-light">
+        {value || placeholder}
+      </div>
+    );
+  };
+
   return (
     <>
       <form
@@ -161,10 +168,7 @@ export const PersonalSettingForm = () => {
           handleContactChange();
         }}
       >
-        <div
-          id="general"
-          className="flex flex-col items-center justify-between"
-        >
+        <div id="general" className="flex flex-col items-center justify-between">
           <div className="w-full mt-5">
             <div className="">
               <div className="flex flex-col items-center justify-between w-full sm:gap-8 sm:flex-row">
@@ -172,30 +176,39 @@ export const PersonalSettingForm = () => {
                   <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
                     {t('common.FULL_NAME')}
                   </Text>
-                  <div className="flex flex-col gap-2 lg:flex-row justify-start w-full">
-                    <InputField
-                      type="text"
-                      placeholder={t('form.FIRST_NAME_PLACEHOLDER')}
-                      {...register('firstName', {
-                        required: true,
-                        maxLength: 80
-                      })}
-                      className={`w-full m-0 h-[54px] ${!editFullname ? 'disabled:bg-[#FCFCFC]' : ''
-                        }`}
-                      disabled={!editFullname}
-                      wrapperClassName={`rounded-lg w-full lg:w-[230px] mb-0 mr-5`}
-                    />
-                    <InputField
-                      type="text"
-                      placeholder={t('form.LAST_NAME_PLACEHOLDER')}
-                      {...register('lastName', {
-                        maxLength: 80
-                      })}
-                      className={`w-full m-0 h-[54px] ${!editFullname ? 'disabled:bg-[#FCFCFC]' : ''
-                        }`}
-                      disabled={!editFullname}
-                      wrapperClassName={`rounded-lg w-full lg:w-[230px] mb-0 mr-5`}
-                    />
+                  <div className="flex flex-col justify-start w-full gap-2 lg:flex-row">
+                    {editFullname ? (
+                      <>
+                        <InputField
+                          type="text"
+                          placeholder={t('form.FIRST_NAME_PLACEHOLDER')}
+                          {...register('firstName', {
+                            required: true,
+                            maxLength: 80
+                          })}
+                          className="w-full m-0 h-[54px]"
+                          wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
+                        />
+                        <InputField
+                          type="text"
+                          placeholder={t('form.LAST_NAME_PLACEHOLDER')}
+                          {...register('lastName', {
+                            maxLength: 80
+                          })}
+                          className="w-full m-0 h-[54px]"
+                          wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
+                        />
+                      </>
+                    ) : (
+                      <>
+                        <div className="w-full lg:w-[230px] mb-0 mr-5">
+                          {displayValueField(getValues('firstName'), t('form.FIRST_NAME_PLACEHOLDER'))}
+                        </div>
+                        <div className="w-full lg:w-[230px] mb-0 mr-5">
+                          {displayValueField(getValues('lastName'), t('form.LAST_NAME_PLACEHOLDER'))}
+                        </div>
+                      </>
+                    )}
 
                     {editFullname ? (
                       <Button
@@ -230,48 +243,57 @@ export const PersonalSettingForm = () => {
                   <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
                     {t('common.CONTACT')}
                   </Text>
-                  <div className="flex flex-col lg:flex-row gap-2 justify-start w-full">
-                    <div className="relative">
-                      <InputField
-                        type="email"
-                        placeholder={t('form.EMAIL_PLACEHOLDER')}
-                        {...register('email', {
-                          required: true,
-                          pattern: /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-                        })}
-                        className={`w-full m-0 h-[54px]  ${!editContacts ? 'disabled:bg-[#FCFCFC]' : ''
-                          }`}
-                        onChange={checkEmailValidity}
-                        disabled={!editContacts}
-                        notValidBorder={!isValid.email}
-                        wrapperClassName={`rounded-lg w-full lg:w-[230px] mb-0 mr-5 `}
-                      />
-                      {!isValid.email && (
-                        <p className="absolute text-xs text-red-500 -bottom-5">
-                          {t('pages.settingsPersonal.emailNotValid')}
-                        </p>
-                      )}
-                    </div>
-                    <div className="relative">
-                      <InputField
-                        type="text"
-                        placeholder={t('form.PHONE_PLACEHOLDER')}
-                        {...register('phoneNumber', {
-                          valueAsNumber: true
-                        })}
-                        className={`w-full m-0 h-[54px] ${!editContacts ? 'disabled:bg-[#FCFCFC]' : ''
-                          }`}
-                        onChange={checkPhoneValidity}
-                        disabled={!editContacts}
-                        notValidBorder={!isValid.phone}
-                        wrapperClassName={`rounded-lg w-full lg:w-[230px] mb-0 mr-5`}
-                      />
-                      {!isValid.phone && (
-                        <p className="absolute text-xs text-red-500 -bottom-5">
-                          {t('pages.settingsPersonal.phoneNotValid')}
-                        </p>
-                      )}
-                    </div>
+                  <div className="flex flex-col justify-start w-full gap-2 lg:flex-row">
+                    {editContacts ? (
+                      <>
+                        <div className="relative">
+                          <InputField
+                            type="email"
+                            placeholder={t('form.EMAIL_PLACEHOLDER')}
+                            {...register('email', {
+                              required: true,
+                              pattern: /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+                            })}
+                            className="w-full m-0 h-[54px]"
+                            onChange={checkEmailValidity}
+                            notValidBorder={!isValid.email}
+                            wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
+                          />
+                          {!isValid.email && (
+                            <p className="absolute text-xs text-red-500 -bottom-5">
+                              {t('pages.settingsPersonal.emailNotValid')}
+                            </p>
+                          )}
+                        </div>
+                        <div className="relative">
+                          <InputField
+                            type="text"
+                            placeholder={t('form.PHONE_PLACEHOLDER')}
+                            {...register('phoneNumber', {
+                              valueAsNumber: true
+                            })}
+                            className="w-full m-0 h-[54px]"
+                            onChange={checkPhoneValidity}
+                            notValidBorder={!isValid.phone}
+                            wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
+                          />
+                          {!isValid.phone && (
+                            <p className="absolute text-xs text-red-500 -bottom-5">
+                              {t('pages.settingsPersonal.phoneNotValid')}
+                            </p>
+                          )}
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <div className="w-full lg:w-[230px] mb-0 mr-5">
+                          {displayValueField(getValues('email'), t('form.EMAIL_PLACEHOLDER'))}
+                        </div>
+                        <div className="w-full lg:w-[230px] mb-0 mr-5">
+                          {displayValueField(getValues('phoneNumber'), t('form.PHONE_PLACEHOLDER'))}
+                        </div>
+                      </>
+                    )}
 
                     {editContacts ? (
                       <Button
@@ -309,7 +331,7 @@ export const PersonalSettingForm = () => {
                   <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
                     {t('common.THEME')}
                   </Text>
-                  <div className="flex items-center lg:items-start w-full">
+                  <div className="flex items-center w-full lg:items-start">
                     <ThemeToggler />
                     <Text className="flex items-center ml-5 mt-2.5 text-sm font-normal text-gray-400">
                       {theme === 'light' ? 'Light' : 'Dark'} Mode
@@ -323,7 +345,7 @@ export const PersonalSettingForm = () => {
                   <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
                     {t('common.LANGUAGE')}
                   </Text>
-                  <div className="flex flex-col relative lg:flex-row w-full">
+                  <div className="relative flex flex-col w-full lg:flex-row">
                     <LanguageDropDown
                       currentLanguage={currentLanguage}
                       onChangeLanguage={(t: string) => {
@@ -339,13 +361,13 @@ export const PersonalSettingForm = () => {
                   <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
                     {t('common.TIME_ZONE')}
                   </Text>
-                  <div className="flex flex-col relative lg:flex-row gap-2 w-full">
+                  <div className="relative flex flex-col w-full gap-2 lg:flex-row">
                     <TimezoneDropDown
                       currentTimezone={currentTimezone}
                       onChange={(t: string) => {
                         handleChangeTimezone(t);
                       }}
-					  className='md:w-[469px]'
+                      className='md:w-[469px]'
                     />
                     <Button
                       variant="grey"

--- a/apps/web/lib/settings/personal-setting-form.tsx
+++ b/apps/web/lib/settings/personal-setting-form.tsx
@@ -1,10 +1,10 @@
 import {
-  PHONE_REGEX,
-  getActiveLanguageIdCookie,
-  getActiveTimezoneIdCookie,
-  setActiveLanguageIdCookie,
-  setActiveTimezoneCookie,
-  userTimezone
+	PHONE_REGEX,
+	getActiveLanguageIdCookie,
+	getActiveTimezoneIdCookie,
+	setActiveLanguageIdCookie,
+	setActiveTimezoneCookie,
+	userTimezone
 } from '@app/helpers';
 import { useLanguage, useSettings } from '@app/hooks';
 import { userState } from '@app/stores';
@@ -21,411 +21,414 @@ import { TimezoneDropDown } from './timezone-dropdown';
 import { useRouter } from 'next/navigation';
 
 interface IValidation {
-  email: boolean;
-  phone: boolean;
+	email: boolean;
+	phone: boolean;
 }
 
 export const PersonalSettingForm = () => {
-  const [user] = useAtom(userState);
-  const { currentLanguage, changeLanguage } = useLanguage();
-  const { register, setValue, getValues, setFocus } = useForm();
-  const [currentTimezone, setCurrentTimezone] = useState('');
-  const { updateAvatar } = useSettings();
-  const { theme } = useTheme();
-  const [editFullname, setEditFullname] = useState<boolean>(false);
-  const [editContacts, setEditContacts] = useState<boolean>(false);
-  const [showEmailResetModal, setShowEmailResetModal] = useState<boolean>(false);
-  const [newEmail, setNewEmail] = useState<string>('');
-  const [isValid, setIsValid] = useState<IValidation>({
-    email: true,
-    phone: true
-  });
-  const t = useTranslations();
-  const router = useRouter();
+	const [user] = useAtom(userState);
+	const { currentLanguage, changeLanguage } = useLanguage();
+	const { register, setValue, getValues, setFocus } = useForm();
+	const [currentTimezone, setCurrentTimezone] = useState('');
+	const { updateAvatar } = useSettings();
+	const { theme } = useTheme();
+	const [editFullname, setEditFullname] = useState<boolean>(false);
+	const [editContacts, setEditContacts] = useState<boolean>(false);
+	const [showEmailResetModal, setShowEmailResetModal] = useState<boolean>(false);
+	const [newEmail, setNewEmail] = useState<string>('');
+	const [isValid, setIsValid] = useState<IValidation>({
+		email: true,
+		phone: true
+	});
+	const t = useTranslations();
+	const router = useRouter();
 
-  const handleFullnameChange = useCallback(() => {
-    const values = getValues();
-    if (user) {
-      updateAvatar({
-        firstName: values.firstName,
-        lastName: values.lastName,
-        id: user.id
-      }).then(() => {
-        setEditFullname(false);
-      });
-    }
-  }, [updateAvatar, user, getValues]);
+	const handleFullnameChange = useCallback(() => {
+		const values = getValues();
+		if (user) {
+			updateAvatar({
+				firstName: values.firstName,
+				lastName: values.lastName,
+				id: user.id
+			}).then(() => {
+				setEditFullname(false);
+			});
+		}
+	}, [updateAvatar, user, getValues]);
 
-  const checkEmailValidity = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const email = e.target.value;
-    setIsValid({ ...isValid, email: validator.isEmail(email) });
-  };
+	const checkEmailValidity = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const email = e.target.value;
+		setIsValid({ ...isValid, email: validator.isEmail(email) });
+	};
 
-  const checkPhoneValidity = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const phone = e.target.value;
-    phone
-      ? setIsValid({ ...isValid, phone: phone.match(PHONE_REGEX) !== null })
-      : setIsValid({ ...isValid, phone: true });
-  };
+	const checkPhoneValidity = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const phone = e.target.value;
+		phone
+			? setIsValid({ ...isValid, phone: phone.match(PHONE_REGEX) !== null })
+			: setIsValid({ ...isValid, phone: true });
+	};
 
-  const handleContactChange = useCallback(() => {
-    const values = getValues();
+	const handleContactChange = useCallback(() => {
+		const values = getValues();
 
-    if (values.email !== user?.email && isValid.email && isValid.phone) {
-      setNewEmail(values.email || '');
-      setShowEmailResetModal(true);
-    }
+		if (values.email !== user?.email && isValid.email && isValid.phone) {
+			setNewEmail(values.email || '');
+			setShowEmailResetModal(true);
+		}
 
-    if (user && isValid.phone && isValid.email) {
-      updateAvatar({
-        phoneNumber: values.phoneNumber,
-        id: user.id
-      }).then(() => {
-        setEditContacts(false);
-      });
-    }
-  }, [updateAvatar, user, getValues, isValid.email, isValid.phone]);
+		if (user && isValid.phone && isValid.email) {
+			updateAvatar({
+				phoneNumber: values.phoneNumber,
+				id: user.id
+			}).then(() => {
+				setEditContacts(false);
+			});
+		}
+	}, [updateAvatar, user, getValues, isValid.email, isValid.phone]);
 
-  const handleChangeTimezone = useCallback(
-    (newTimezone: string | undefined) => {
-      setActiveTimezoneCookie(newTimezone || userTimezone());
-      setCurrentTimezone(newTimezone || userTimezone());
-      setValue('timeZone', newTimezone || userTimezone());
+	const handleChangeTimezone = useCallback(
+		(newTimezone: string | undefined) => {
+			setActiveTimezoneCookie(newTimezone || userTimezone());
+			setCurrentTimezone(newTimezone || userTimezone());
+			setValue('timeZone', newTimezone || userTimezone());
 
-      if (user) {
-        updateAvatar({
-          timeZone: newTimezone || userTimezone(),
-          id: user.id
-        });
-      }
-    },
-    [setCurrentTimezone, setValue, updateAvatar, user]
-  );
+			if (user) {
+				updateAvatar({
+					timeZone: newTimezone || userTimezone(),
+					id: user.id
+				});
+			}
+		},
+		[setCurrentTimezone, setValue, updateAvatar, user]
+	);
 
-  useEffect(() => {
-    setCurrentTimezone(user?.timeZone || getActiveTimezoneIdCookie());
-    setValue('timeZone', user?.timeZone || getActiveTimezoneIdCookie());
-  }, [setCurrentTimezone, setValue, user, user?.timeZone]);
+	useEffect(() => {
+		setCurrentTimezone(user?.timeZone || getActiveTimezoneIdCookie());
+		setValue('timeZone', user?.timeZone || getActiveTimezoneIdCookie());
+	}, [setCurrentTimezone, setValue, user, user?.timeZone]);
 
-  useEffect(() => {
-    setValue('firstName', user?.firstName);
-    setValue('lastName', user?.lastName);
-    setValue('email', user?.email);
-    setValue('timeZone', user?.timeZone);
-    setValue('preferredLanguage', user?.preferredLanguage);
-    setValue('phoneNumber', user?.phoneNumber);
+	useEffect(() => {
+		setValue('firstName', user?.firstName);
+		setValue('lastName', user?.lastName);
+		setValue('email', user?.email);
+		setValue('timeZone', user?.timeZone);
+		setValue('preferredLanguage', user?.preferredLanguage);
+		setValue('phoneNumber', user?.phoneNumber);
 
-    /**
-     * Set Default current timezone.
-     * User can change it anytime if wants
-     */
-    if (!user?.timeZone) {
-      handleChangeTimezone(undefined);
-    }
-  }, [user, currentTimezone, currentLanguage, setValue, handleChangeTimezone]);
+		/**
+		 * Set Default current timezone.
+		 * User can change it anytime if wants
+		 */
+		if (!user?.timeZone) {
+			handleChangeTimezone(undefined);
+		}
+	}, [user, currentTimezone, currentLanguage, setValue, handleChangeTimezone]);
 
-  useEffect(() => {
-    setValue(
-      'preferredLanguage',
-      user?.preferredLanguage || getActiveLanguageIdCookie()
-    );
-  }, [user, user?.preferredLanguage, setValue]);
+	useEffect(() => {
+		setValue('preferredLanguage', user?.preferredLanguage || getActiveLanguageIdCookie());
+	}, [user, user?.preferredLanguage, setValue]);
 
-  const handleChangeLanguage = useCallback(
-    (newLanguage: string) => {
-      setActiveLanguageIdCookie(newLanguage);
-      changeLanguage(newLanguage);
-      setValue('preferredLanguage', newLanguage);
+	const handleChangeLanguage = useCallback(
+		(newLanguage: string) => {
+			setActiveLanguageIdCookie(newLanguage);
+			changeLanguage(newLanguage);
+			setValue('preferredLanguage', newLanguage);
 
-      if (user) {
-        updateAvatar({
-          preferredLanguage: newLanguage,
-          id: user.id
-        });
-      }
+			if (user) {
+				updateAvatar({
+					preferredLanguage: newLanguage,
+					id: user.id
+				});
+			}
 
-      router.replace(`/${newLanguage}/settings/personal`);
-    },
-    [user, setValue, updateAvatar, changeLanguage, router]
-  );
+			router.replace(`/${newLanguage}/settings/personal`);
+		},
+		[user, setValue, updateAvatar, changeLanguage, router]
+	);
 
-  const displayValueField = (value: string | undefined, placeholder: string) => {
-    return (
-      <div className="h-[54px] w-full rounded-lg flex  items-center px-4 text-base font-normal text-gray-400 bg-light--theme-light dark:bg-dark--theme-light">
-        {value || placeholder}
-      </div>
-    );
-  };
+	const displayValueField = (value: string | undefined, placeholder: string) => {
+		return (
+			<div className="h-[54px] w-full rounded-lg flex items-center px-4 text-base font-normal text-gray-400 bg-light--theme-light dark:bg-dark--theme-light border-2 border-gray-200 dark:border-gray-600 outline-none">
+				{value || placeholder}
+			</div>
+		);
+	};
 
-  return (
-    <>
-      <form
-        className="w-[96%]"
-        autoComplete="off"
-        onSubmit={(e) => {
-          e.preventDefault();
-          handleFullnameChange();
-          handleContactChange();
-        }}
-      >
-        <div id="general" className="flex flex-col items-center justify-between">
-          <div className="w-full mt-5">
-            <div className="">
-              <div className="flex flex-col items-center justify-between w-full sm:gap-8 sm:flex-row">
-                <div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
-                  <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
-                    {t('common.FULL_NAME')}
-                  </Text>
-                  <div className="flex flex-col justify-start w-full gap-2 lg:flex-row">
-                    {editFullname ? (
-                      <>
-                        <InputField
-                          type="text"
-                          placeholder={t('form.FIRST_NAME_PLACEHOLDER')}
-                          {...register('firstName', {
-                            required: true,
-                            maxLength: 80
-                          })}
-                          className="w-full m-0 h-[54px]"
-                          wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
-                        />
-                        <InputField
-                          type="text"
-                          placeholder={t('form.LAST_NAME_PLACEHOLDER')}
-                          {...register('lastName', {
-                            maxLength: 80
-                          })}
-                          className="w-full m-0 h-[54px]"
-                          wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
-                        />
-                      </>
-                    ) : (
-                      <>
-                        <div className="w-full lg:w-[230px] mb-0 mr-5">
-                          {displayValueField(getValues('firstName'), t('form.FIRST_NAME_PLACEHOLDER'))}
-                        </div>
-                        <div className="w-full lg:w-[230px] mb-0 mr-5">
-                          {displayValueField(getValues('lastName'), t('form.LAST_NAME_PLACEHOLDER'))}
-                        </div>
-                      </>
-                    )}
+	return (
+		<>
+			<form
+				className="w-[96%]"
+				autoComplete="off"
+				onSubmit={(e) => {
+					e.preventDefault();
+					handleFullnameChange();
+					handleContactChange();
+				}}
+			>
+				<div id="general" className="flex flex-col items-center justify-between">
+					<div className="w-full mt-5">
+						<div className="">
+							<div className="flex flex-col items-center justify-between w-full sm:gap-8 sm:flex-row">
+								<div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
+									<Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
+										{t('common.FULL_NAME')}
+									</Text>
+									<div className="flex flex-col justify-start w-full gap-2 lg:flex-row">
+										{editFullname ? (
+											<>
+												<InputField
+													type="text"
+													placeholder={t('form.FIRST_NAME_PLACEHOLDER')}
+													{...register('firstName', {
+														required: true,
+														maxLength: 80
+													})}
+													className="w-full m-0 h-[54px]"
+													wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
+												/>
+												<InputField
+													type="text"
+													placeholder={t('form.LAST_NAME_PLACEHOLDER')}
+													{...register('lastName', {
+														maxLength: 80
+													})}
+													className="w-full m-0 h-[54px]"
+													wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
+												/>
+											</>
+										) : (
+											<>
+												<div className="w-full lg:w-[230px] mb-0 mr-5">
+													{displayValueField(
+														getValues('firstName'),
+														t('form.FIRST_NAME_PLACEHOLDER')
+													)}
+												</div>
+												<div className="w-full lg:w-[230px] mb-0 mr-5">
+													{displayValueField(
+														getValues('lastName'),
+														t('form.LAST_NAME_PLACEHOLDER')
+													)}
+												</div>
+											</>
+										)}
 
-                    {editFullname ? (
-                      <Button
-                        variant="primary"
-                        className="min-w-[100px] h-[54px] rounded-[8px] font-[600]"
-                        type="button"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handleFullnameChange();
-                        }}
-                      >
-                        {t('common.SAVE')}
-                      </Button>
-                    ) : (
-                      <Button
-                        variant="grey"
-                        className="min-w-[100px] h-[54px] rounded-[8px] font-[600]"
-                        type="button"
-                        onClick={() => {
-                          setEditFullname(true);
-                        }}
-                      >
-                        {t('common.EDIT')}
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              </div>
+										{editFullname ? (
+											<Button
+												variant="primary"
+												className="min-w-[100px] h-[54px] rounded-[8px] font-[600]"
+												type="button"
+												onClick={(e) => {
+													e.preventDefault();
+													handleFullnameChange();
+												}}
+											>
+												{t('common.SAVE')}
+											</Button>
+										) : (
+											<Button
+												variant="grey"
+												className="min-w-[100px] h-[54px] rounded-[8px] font-[600]"
+												type="button"
+												onClick={() => {
+													setEditFullname(true);
+												}}
+											>
+												{t('common.EDIT')}
+											</Button>
+										)}
+									</div>
+								</div>
+							</div>
 
-              <div className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row">
-                <div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
-                  <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
-                    {t('common.CONTACT')}
-                  </Text>
-                  <div className="flex flex-col justify-start w-full gap-2 lg:flex-row">
-                    {editContacts ? (
-                      <>
-                        <div className="relative">
-                          <InputField
-                            type="email"
-                            placeholder={t('form.EMAIL_PLACEHOLDER')}
-                            {...register('email', {
-                              required: true,
-                              pattern: /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-                            })}
-                            className="w-full m-0 h-[54px]"
-                            onChange={checkEmailValidity}
-                            notValidBorder={!isValid.email}
-                            wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
-                          />
-                          {!isValid.email && (
-                            <p className="absolute text-xs text-red-500 -bottom-5">
-                              {t('pages.settingsPersonal.emailNotValid')}
-                            </p>
-                          )}
-                        </div>
-                        <div className="relative">
-                          <InputField
-                            type="text"
-                            placeholder={t('form.PHONE_PLACEHOLDER')}
-                            {...register('phoneNumber', {
-                              valueAsNumber: true
-                            })}
-                            className="w-full m-0 h-[54px]"
-                            onChange={checkPhoneValidity}
-                            notValidBorder={!isValid.phone}
-                            wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
-                          />
-                          {!isValid.phone && (
-                            <p className="absolute text-xs text-red-500 -bottom-5">
-                              {t('pages.settingsPersonal.phoneNotValid')}
-                            </p>
-                          )}
-                        </div>
-                      </>
-                    ) : (
-                      <>
-                        <div className="w-full lg:w-[230px] mb-0 mr-5">
-                          {displayValueField(getValues('email'), t('form.EMAIL_PLACEHOLDER'))}
-                        </div>
-                        <div className="w-full lg:w-[230px] mb-0 mr-5">
-                          {displayValueField(getValues('phoneNumber'), t('form.PHONE_PLACEHOLDER'))}
-                        </div>
-                      </>
-                    )}
+							<div className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row">
+								<div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
+									<Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
+										{t('common.CONTACT')}
+									</Text>
+									<div className="flex flex-col justify-start w-full gap-2 lg:flex-row">
+										{editContacts ? (
+											<>
+												<div className="relative">
+													<InputField
+														type="email"
+														placeholder={t('form.EMAIL_PLACEHOLDER')}
+														{...register('email', {
+															required: true,
+															pattern:
+																/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+														})}
+														className="w-full m-0 h-[54px]"
+														onChange={checkEmailValidity}
+														notValidBorder={!isValid.email}
+														wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
+													/>
+													{!isValid.email && (
+														<p className="absolute text-xs text-red-500 -bottom-5">
+															{t('pages.settingsPersonal.emailNotValid')}
+														</p>
+													)}
+												</div>
+												<div className="relative">
+													<InputField
+														type="text"
+														placeholder={t('form.PHONE_PLACEHOLDER')}
+														{...register('phoneNumber', {
+															valueAsNumber: true
+														})}
+														className="w-full m-0 h-[54px]"
+														onChange={checkPhoneValidity}
+														notValidBorder={!isValid.phone}
+														wrapperClassName="rounded-lg w-full lg:w-[230px] mb-0 mr-5"
+													/>
+													{!isValid.phone && (
+														<p className="absolute text-xs text-red-500 -bottom-5">
+															{t('pages.settingsPersonal.phoneNotValid')}
+														</p>
+													)}
+												</div>
+											</>
+										) : (
+											<>
+												<div className="w-full lg:w-[230px] mb-0 mr-5">
+													{displayValueField(getValues('email'), t('form.EMAIL_PLACEHOLDER'))}
+												</div>
+												<div className="w-full lg:w-[230px] mb-0 mr-5">
+													{displayValueField(
+														getValues('phoneNumber'),
+														t('form.PHONE_PLACEHOLDER')
+													)}
+												</div>
+											</>
+										)}
 
-                    {editContacts ? (
-                      <Button
-                        variant="primary"
-                        className="min-w-[100px] h-[54px] rounded-[8px] font-[600]"
-                        type="button"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handleContactChange();
-                        }}
-                      >
-                        {t('common.SAVE')}
-                      </Button>
-                    ) : (
-                      <Button
-                        variant="grey"
-                        className="min-w-[100px] h-[54px] rounded-[8px] font-[600]"
-                        type="button"
-                        onClick={() => {
-                          setEditContacts(true);
-                          setTimeout(() => {
-                            setFocus('email');
-                          }, 10);
-                        }}
-                      >
-                        {t('common.EDIT')}
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              </div>
+										{editContacts ? (
+											<Button
+												variant="primary"
+												className="min-w-[100px] h-[54px] rounded-[8px] font-[600]"
+												type="button"
+												onClick={(e) => {
+													e.preventDefault();
+													handleContactChange();
+												}}
+											>
+												{t('common.SAVE')}
+											</Button>
+										) : (
+											<Button
+												variant="grey"
+												className="min-w-[100px] h-[54px] rounded-[8px] font-[600]"
+												type="button"
+												onClick={() => {
+													setEditContacts(true);
+													setTimeout(() => {
+														setFocus('email');
+													}, 10);
+												}}
+											>
+												{t('common.EDIT')}
+											</Button>
+										)}
+									</div>
+								</div>
+							</div>
 
-              <div className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row">
-                <div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
-                  <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
-                    {t('common.THEME')}
-                  </Text>
-                  <div className="flex items-center w-full lg:items-start">
-                    <ThemeToggler />
-                    <Text className="flex items-center ml-5 mt-2.5 text-sm font-normal text-gray-400">
-                      {theme === 'light' ? 'Light' : 'Dark'} Mode
-                    </Text>
-                  </div>
-                </div>
-              </div>
+							<div className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row">
+								<div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
+									<Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
+										{t('common.THEME')}
+									</Text>
+									<div className="flex items-center w-full lg:items-start">
+										<ThemeToggler />
+										<Text className="flex items-center ml-5 mt-2.5 text-sm font-normal text-gray-400">
+											{theme === 'light' ? 'Light' : 'Dark'} Mode
+										</Text>
+									</div>
+								</div>
+							</div>
 
-              <div className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row">
-                <div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
-                  <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
-                    {t('common.LANGUAGE')}
-                  </Text>
-                  <div className="relative flex flex-col w-full lg:flex-row">
-                    <LanguageDropDown
-                      currentLanguage={currentLanguage}
-                      onChangeLanguage={(t: string) => {
-                        handleChangeLanguage(t);
-                      }}
-                    />
-                  </div>
-                </div>
-              </div>
+							<div className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row">
+								<div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
+									<Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
+										{t('common.LANGUAGE')}
+									</Text>
+									<div className="relative flex flex-col w-full lg:flex-row">
+										<LanguageDropDown
+											currentLanguage={currentLanguage}
+											onChangeLanguage={(t: string) => {
+												handleChangeLanguage(t);
+											}}
+										/>
+									</div>
+								</div>
+							</div>
 
-              <div className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row">
-                <div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
-                  <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
-                    {t('common.TIME_ZONE')}
-                  </Text>
-                  <div className="relative flex flex-col w-full gap-2 lg:flex-row">
-                    <TimezoneDropDown
-                      currentTimezone={currentTimezone}
-                      onChange={(t: string) => {
-                        handleChangeTimezone(t);
-                      }}
-                      className='md:w-[469px]'
-                    />
-                    <Button
-                      variant="grey"
-                      type="button"
-                      onClick={() => {
-                        handleChangeTimezone(undefined);
-                      }}
-                      className="min-w-[100px] shrink-0 h-[54px] rounded-[8px] font-[600] ml-5"
-                    >
-                      {t('common.DETECT')}
-                    </Button>
-                  </div>
-                </div>
-              </div>
+							<div className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row">
+								<div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
+									<Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
+										{t('common.TIME_ZONE')}
+									</Text>
+									<div className="relative flex flex-col w-full gap-2 lg:flex-row">
+										<TimezoneDropDown
+											currentTimezone={currentTimezone}
+											onChange={(t: string) => {
+												handleChangeTimezone(t);
+											}}
+											className="md:w-[469px]"
+										/>
+										<Button
+											variant="grey"
+											type="button"
+											onClick={() => {
+												handleChangeTimezone(undefined);
+											}}
+											className="min-w-[100px] shrink-0 h-[54px] rounded-[8px] font-[600] ml-5"
+										>
+											{t('common.DETECT')}
+										</Button>
+									</div>
+								</div>
+							</div>
 
-              <div
-                id="work-schedule"
-                className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row"
-              >
-                <div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
-                  <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
-                    {t('pages.settingsPersonal.WORK_SCHEDULE')}
-                  </Text>
-                  <div className="flex w-full">
-                    <Text className="text-lg font-normal">
-                      {t('common.NO')}
-                    </Text>
-                  </div>
-                </div>
-              </div>
+							<div
+								id="work-schedule"
+								className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row"
+							>
+								<div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
+									<Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
+										{t('pages.settingsPersonal.WORK_SCHEDULE')}
+									</Text>
+									<div className="flex w-full">
+										<Text className="text-lg font-normal">{t('common.NO')}</Text>
+									</div>
+								</div>
+							</div>
 
-              <div
-                id="subscription"
-                className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row"
-              >
-                <div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
-                  <Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
-                    {t('pages.settingsPersonal.SUBSCRIPTION')}
-                  </Text>
-                  <div className="flex w-full">
-                    <Text className="text-lg font-normal">
-                      {t('common.BASIC')}
-                    </Text>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </form>
+							<div
+								id="subscription"
+								className="flex flex-col items-center justify-between w-full mt-8 sm:gap-8 sm:flex-row"
+							>
+								<div className="flex flex-col items-center justify-between w-full sm:gap-4 sm:flex-row">
+									<Text className="font-normal min-w-[25%] text-gray-400 text-lg justify-center">
+										{t('pages.settingsPersonal.SUBSCRIPTION')}
+									</Text>
+									<div className="flex w-full">
+										<Text className="text-lg font-normal">{t('common.BASIC')}</Text>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</form>
 
-      <EmailResetModal
-        open={showEmailResetModal}
-        closeModal={() => {
-          setShowEmailResetModal(false);
-        }}
-        email={newEmail}
-      />
-    </>
-  );
+			<EmailResetModal
+				open={showEmailResetModal}
+				closeModal={() => {
+					setShowEmailResetModal(false);
+				}}
+				email={newEmail}
+			/>
+		</>
+	);
 };

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -10,6 +10,11 @@ const isSentryEnabled = isProduction && process.env.SENTRY_DSN;
 
 const BUILD_OUTPUT_MODE = process.env.NEXT_BUILD_OUTPUT_TYPE;
 
+
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+	enabled: process.env.ANALYZE === 'true',
+  })
+
 const sentryConfig = isSentryEnabled && {
 	sentry: {
 		// For all available options, see: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -10,11 +10,6 @@ const isSentryEnabled = isProduction && process.env.SENTRY_DSN;
 
 const BUILD_OUTPUT_MODE = process.env.NEXT_BUILD_OUTPUT_TYPE;
 
-
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
-	enabled: process.env.ANALYZE === 'true',
-  })
-
 const sentryConfig = isSentryEnabled && {
 	sentry: {
 		// For all available options, see: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -129,7 +129,6 @@
 		"react-resizable-panels": "^2.0.19",
 		"react-turnstile": "^1.1.4",
 		"recharts": "^2.15.0",
-		"sharp": "^0.33.4",
 		"slate": "^0.90.0",
 		"slate-history": "^0.93.0",
 		"slate-hyperscript": "^0.77.0",

--- a/package.json
+++ b/package.json
@@ -193,7 +193,6 @@
 		"@cucumber/gherkin": "^25.0.2",
 		"@cypress/browserify-preprocessor": "^3.0.2",
 		"@lerna/legacy-package-management": "^8.1.2",
-		"@next/bundle-analyzer": "^15.2.4",
 		"@next/eslint-plugin-next": "^13.0.5",
 		"@nx/cypress": "^16.7.4",
 		"@nx/detox": "^16.7.4",

--- a/package.json
+++ b/package.json
@@ -179,8 +179,8 @@
 		"@lexical/react": "^0.8.0",
 		"dotenv": "^16.4.5",
 		"lexical": "^0.8.0",
-		"yargs": "^17.5.0",
-		"sharp": "^0.33.4"
+		"sharp": "^0.33.4",
+		"yargs": "^17.5.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^17.6.6",
@@ -193,6 +193,7 @@
 		"@cucumber/gherkin": "^25.0.2",
 		"@cypress/browserify-preprocessor": "^3.0.2",
 		"@lerna/legacy-package-management": "^8.1.2",
+		"@next/bundle-analyzer": "^15.2.4",
 		"@next/eslint-plugin-next": "^13.0.5",
 		"@nx/cypress": "^16.7.4",
 		"@nx/detox": "^16.7.4",
@@ -221,7 +222,6 @@
 		"concurrently": "^8.2.2",
 		"conventional-changelog": "^3.1.25",
 		"conventional-changelog-cli": "^2.2.2",
-		"cross-env": "^7.0.3",
 		"cspell": "8.0.0",
 		"cypress": "^11.2.0",
 		"cypress-file-upload": "^5.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4059,6 +4059,13 @@
     jsonc-parser "3.2.0"
     pluralize "8.0.0"
 
+"@next/bundle-analyzer@^15.2.4":
+  version "15.2.4"
+  resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-15.2.4.tgz#d8eef01ec26a1b3e5339d8ba87f9ca29931c3b75"
+  integrity sha512-72OXS/+r3Q6PW9oCBlkxogsEJ9DIoD64dGe8OZc2nKcHu3HbKKaXoDkutC8u7cxmBFd+ERt3D0/MoP7eZkhhog==
+  dependencies:
+    webpack-bundle-analyzer "4.10.1"
+
 "@next/env@14.2.26":
   version "14.2.26"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-14.2.26.tgz#5d55f72d2edb7246607c78f61e7d3ff21516bc2e"
@@ -12205,7 +12212,7 @@ create-require@^1.1.0:
 
 cross-env@^7.0.3:
   version "7.0.3"
-  resolved "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
   integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
   dependencies:
     cross-spawn "^7.0.1"
@@ -26911,6 +26918,25 @@ webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+webpack-bundle-analyzer@4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz#84b7473b630a7b8c21c741f81d8fe4593208b454"
+  integrity sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==
+  dependencies:
+    "@discoveryjs/json-ext" "0.5.7"
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    commander "^7.2.0"
+    debounce "^1.2.1"
+    escape-string-regexp "^4.0.0"
+    gzip-size "^6.0.0"
+    html-escaper "^2.0.2"
+    is-plain-object "^5.0.0"
+    opener "^1.5.2"
+    picocolors "^1.0.0"
+    sirv "^2.0.3"
+    ws "^7.3.1"
 
 webpack-bundle-analyzer@^4.9.1:
   version "4.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4059,13 +4059,6 @@
     jsonc-parser "3.2.0"
     pluralize "8.0.0"
 
-"@next/bundle-analyzer@^15.2.4":
-  version "15.2.4"
-  resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-15.2.4.tgz#d8eef01ec26a1b3e5339d8ba87f9ca29931c3b75"
-  integrity sha512-72OXS/+r3Q6PW9oCBlkxogsEJ9DIoD64dGe8OZc2nKcHu3HbKKaXoDkutC8u7cxmBFd+ERt3D0/MoP7eZkhhog==
-  dependencies:
-    webpack-bundle-analyzer "4.10.1"
-
 "@next/env@14.2.26":
   version "14.2.26"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-14.2.26.tgz#5d55f72d2edb7246607c78f61e7d3ff21516bc2e"
@@ -26918,25 +26911,6 @@ webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
-
-webpack-bundle-analyzer@4.10.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz#84b7473b630a7b8c21c741f81d8fe4593208b454"
-  integrity sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==
-  dependencies:
-    "@discoveryjs/json-ext" "0.5.7"
-    acorn "^8.0.4"
-    acorn-walk "^8.0.0"
-    commander "^7.2.0"
-    debounce "^1.2.1"
-    escape-string-regexp "^4.0.0"
-    gzip-size "^6.0.0"
-    html-escaper "^2.0.2"
-    is-plain-object "^5.0.0"
-    opener "^1.5.2"
-    picocolors "^1.0.0"
-    sirv "^2.0.3"
-    ws "^7.3.1"
 
 webpack-bundle-analyzer@^4.9.1:
   version "4.10.2"


### PR DESCRIPTION
## Description
- When a user updates their personal information, they should be able to distinguish between editing their details and simply viewing the information they have already provided.

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots
![Screenshot from 2025-04-08 11-30-51](https://github.com/user-attachments/assets/4ddc299e-163a-424f-80da-f9ee44c65667)
Please add here videos or images of the previous status

## Updates
[Screencast from 2025-04-08 12-17-02.webm](https://github.com/user-attachments/assets/64eefd21-d16f-477c-8c5e-bf915b04f65c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved layout formatting on the personal settings page for a more consistent user experience.
- **Refactor**
  - Enhanced the display logic for personal input fields in the settings form for clearer visual presentation.
- **Chore**
  - Organized dependency management by reordering items and removing an unused image processing dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->