### PR TITLE
[Fix]: UI - The color picker input overlapping the profile dropdown

### DIFF
--- a/apps/web/lib/settings/team-setting-form.tsx
+++ b/apps/web/lib/settings/team-setting-form.tsx
@@ -235,11 +235,11 @@ export const TeamSettingForm = () => {
               </div>
 
               {/* Team Color */}
-              <div className="flex flex-col lg:flex-row items-center justify-between w-full gap-1 lg:gap-12 ">
-                <Text className="flex-none flex-grow-0 w-full lg:w-1/5 mb-2 text-lg font-normal text-gray-400">
+              <div className="flex flex-col items-center justify-between w-full gap-1 lg:flex-row lg:gap-12 ">
+                <Text className="flex-none flex-grow-0 w-full mb-2 text-lg font-normal text-gray-400 lg:w-1/5">
                   {t('pages.settingsTeam.TEAM_COLOR')}
                 </Text>
-                <div className="z-50 flex flex-row items-center justify-between flex-grow-0 w-full lg:w-4/5">
+                <div className="z-10 flex flex-row items-center justify-between flex-grow-0 w-full lg:w-4/5" >
                   <ColorPicker
                     defaultColor={activeTeam?.color}
                     onChange={(color: any | null) => {
@@ -254,8 +254,8 @@ export const TeamSettingForm = () => {
               </div>
 
               {/* Emoji */}
-              <div className="flex flex-col lg:flex-row items-center justify-between w-full gap-1 lg:gap-12 ">
-                <Text className="flex-none flex-grow-0 w-full lg:w-1/5 mb-2 text-lg font-normal text-gray-400">
+              <div className="flex flex-col items-center justify-between w-full gap-1 lg:flex-row lg:gap-12 ">
+                <Text className="flex-none flex-grow-0 w-full mb-2 text-lg font-normal text-gray-400 lg:w-1/5">
                   {t('pages.settingsTeam.EMOJI')}
                 </Text>
                 <div className="flex flex-row items-start lg:items-center justify-between flex-grow-0 w-full max-w-[88vw] lg:w-4/5">
@@ -273,8 +273,8 @@ export const TeamSettingForm = () => {
 
               {/* Team Size */}
               {
-                <div className="flex flex-col lg:flex-row items-center justify-between w-full gap-1 lg:gap-12 mt-3 ">
-                  <Text className="flex-none flex-grow-0 w-full lg:w-1/5 mb-2 text-lg font-normal text-gray-400">
+                <div className="flex flex-col items-center justify-between w-full gap-1 mt-3 lg:flex-row lg:gap-12 ">
+                  <Text className="flex-none flex-grow-0 w-full mb-2 text-lg font-normal text-gray-400 lg:w-1/5">
                     {t('pages.settingsTeam.TEAM_SIZE')}
                   </Text>
                   <div className="flex flex-row items-center justify-between flex-grow-0 w-full lg:w-4/5">
@@ -293,7 +293,7 @@ export const TeamSettingForm = () => {
 
               {/* Team Type */}
               <div className="flex flex-col items-center w-full mt-8 sm:gap-12 sm:flex-row">
-                <Text className="flex-none flex-grow-0 mb-2 text-lg font-normal text-gray-400 w-full sm:w-1/5">
+                <Text className="flex-none flex-grow-0 w-full mb-2 text-lg font-normal text-gray-400 sm:w-1/5">
                   {t('pages.settingsTeam.TEAM_TYPE')}
                 </Text>
                 <div className="flex lg:gap-x-[30px] flex-col sm:flex-row items-center">
@@ -344,7 +344,7 @@ export const TeamSettingForm = () => {
                   )}
                   {getTeamLink() && (
                     <div className="flex flex-col items-center gap-4 sm:flex-row">
-                      <div className="flex flex-row items-center justify-between flex-grow-0 w-full lg:w-64 mb-0">
+                      <div className="flex flex-row items-center justify-between flex-grow-0 w-full mb-0 lg:w-64">
                         <Tooltip
                           label={getTeamLink()}
                           placement="auto"


### PR DESCRIPTION
## Description

Fixed the color-picker overlapping the user profile drop-down menu

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots

![Screenshot from 2025-04-07 11-33-49](https://github.com/user-attachments/assets/78c6f39f-245a-404b-acaa-2723e612eb69)

## Current screenshots
![Screenshot from 2025-04-08 13-09-51](https://github.com/user-attachments/assets/33c38e7e-b41b-418a-8c52-e56ca672e0db)

Please add here videos or images of the current (new) status


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the layout and visual presentation of the team settings form by reorganizing the arrangement and spacing of key elements (such as color, emoji, and team size sections), resulting in a more balanced and consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->