### PR TITLE
[Bug] : Team Settings | Members & Roles Pagination

### DIFF
--- a/apps/web/app/hooks/features/usePagination.ts
+++ b/apps/web/app/hooks/features/usePagination.ts
@@ -3,58 +3,42 @@ import { useEffect, useRef, useState } from 'react';
 export function usePagination<T>(items: T[], defaultItemsPerPage = 5) {
   const [itemOffset, setItemOffset] = useState(0);
   const [itemsPerPage, setItemsPerPage] = useState(defaultItemsPerPage);
-  const [filteredItems, setFilteredItems] = useState<T[]>([]);
-  const [hasUserSelectedFilter, setHasUserSelectedFilter] = useState(false);
-  const ITEMS_PER_PAGE_VIEW = 5;
 
-  const totalItems = items?.length || 0;
+  // Total number of items
+  const total = items?.length || 0;
 
-  useEffect(() => {
-    if (!hasUserSelectedFilter) {
-      setFilteredItems(items || []);
-    }
-  }, [items, hasUserSelectedFilter]);
+  // Calculate end offset based on items per page from dropdown
+  const endOffset = Math.min(itemOffset + itemsPerPage, total);
 
-  useEffect(() => {
-    if (hasUserSelectedFilter) {
-      const itemsToShow = Math.min(itemsPerPage, totalItems);
-      setFilteredItems(items?.slice(0, itemsToShow) || []);
-      setItemOffset(0);
-    }
-  }, [items, itemsPerPage, totalItems, hasUserSelectedFilter]);
+  // Get current items to display based on itemsPerPage selection
+  const currentItems = items?.slice(itemOffset, endOffset) || [];
 
-  const filteredTotal = filteredItems.length;
+  // Calculate page count based on itemsPerPage selection
+  const pageCount = Math.ceil(total / itemsPerPage);
 
-  const endOffset = Math.min(itemOffset + ITEMS_PER_PAGE_VIEW, filteredTotal);
-
-  const currentItems = filteredItems.slice(itemOffset, endOffset);
-
-  const pageCount = Math.ceil(filteredTotal / ITEMS_PER_PAGE_VIEW);
-
+  // Handle page change
   const onPageChange = (selectedItem: { selected: number }) => {
-    const newOffset =  filteredTotal === 0 ? 0 :(selectedItem.selected * ITEMS_PER_PAGE_VIEW) % filteredTotal;
+    const newOffset = total === 0 ? 0 : (selectedItem.selected * itemsPerPage) % total;
     setItemOffset(newOffset);
   };
 
-  const setItemsPerPageWithFlag = (value: React.SetStateAction<number>) => {
-    setHasUserSelectedFilter(true);
-    setItemsPerPage(value);
-  };
+  // Reset to first page when changing items per page
+  useEffect(() => {
+    setItemOffset(0);
+  }, [itemsPerPage]);
 
   return {
-    total: filteredTotal,
-    totalAll: totalItems,
+    total,
     onPageChange,
     itemsPerPage,
     itemOffset,
     endOffset,
-    setItemsPerPage: setItemsPerPageWithFlag,
+    setItemsPerPage,
     currentItems,
     setItemOffset,
     pageCount
   };
 }
-
 export function useScrollPagination<T>({
   enabled,
   defaultItemsPerPage = 10,

--- a/apps/web/app/hooks/features/usePagination.ts
+++ b/apps/web/app/hooks/features/usePagination.ts
@@ -1,87 +1,116 @@
 import { useEffect, useRef, useState } from 'react';
 
-export function usePagination<T>(items: T[], defaultItemsPerPage = 10) {
-	const [itemOffset, setItemOffset] = useState(0);
-	const [itemsPerPage, setItemsPerPage] = useState(defaultItemsPerPage);
+export function usePagination<T>(items: T[], defaultItemsPerPage = 5) {
+  const [itemOffset, setItemOffset] = useState(0);
+  const [itemsPerPage, setItemsPerPage] = useState(defaultItemsPerPage);
+  const [filteredItems, setFilteredItems] = useState<T[]>([]);
+  const [hasUserSelectedFilter, setHasUserSelectedFilter] = useState(false);
+  const ITEMS_PER_PAGE_VIEW = 5;
 
-	const total = items?.length || 0;
+  const totalItems = items?.length || 0;
 
-	const endOffset = itemOffset + itemsPerPage;
-	const currentItems = items?.slice(itemOffset, endOffset);
+  useEffect(() => {
+    if (!hasUserSelectedFilter) {
+      setFilteredItems(items || []);
+    }
+  }, [items, hasUserSelectedFilter]);
 
-	const onPageChange = (selectedItem: { selected: number }) => {
-		const newOffset = (selectedItem.selected * itemsPerPage) % total;
-		setItemOffset(newOffset);
-	};
+  useEffect(() => {
+    if (hasUserSelectedFilter) {
+      const itemsToShow = Math.min(itemsPerPage, totalItems);
+      setFilteredItems(items?.slice(0, itemsToShow) || []);
+      setItemOffset(0);
+    }
+  }, [items, itemsPerPage, totalItems, hasUserSelectedFilter]);
 
-	return {
-		total: items?.length || 0,
-		onPageChange,
-		itemsPerPage,
-		itemOffset,
-		endOffset,
-		setItemsPerPage,
-		currentItems,
-		setItemOffset
-	};
+  const filteredTotal = filteredItems.length;
+
+  const endOffset = Math.min(itemOffset + ITEMS_PER_PAGE_VIEW, filteredTotal);
+
+  const currentItems = filteredItems.slice(itemOffset, endOffset);
+
+  const pageCount = Math.ceil(filteredTotal / ITEMS_PER_PAGE_VIEW);
+
+  const onPageChange = (selectedItem: { selected: number }) => {
+    const newOffset = (selectedItem.selected * ITEMS_PER_PAGE_VIEW) % filteredTotal;
+    setItemOffset(newOffset);
+  };
+
+  const setItemsPerPageWithFlag = (value: React.SetStateAction<number>) => {
+    setHasUserSelectedFilter(true);
+    setItemsPerPage(value);
+  };
+
+  return {
+    total: filteredTotal,
+    totalAll: totalItems,
+    onPageChange,
+    itemsPerPage,
+    itemOffset,
+    endOffset,
+    setItemsPerPage: setItemsPerPageWithFlag,
+    currentItems,
+    setItemOffset,
+    pageCount
+  };
 }
 
 export function useScrollPagination<T>({
-	enabled,
-	defaultItemsPerPage = 10,
-	items,
-	scrollableElement
+  enabled,
+  defaultItemsPerPage = 10,
+  items,
+  scrollableElement
 }: {
-	items: T[];
-	enabled?: boolean;
-	defaultItemsPerPage?: number;
-	scrollableElement?: HTMLElement | null;
+  items: T[];
+  enabled?: boolean;
+  defaultItemsPerPage?: number;
+  scrollableElement?: HTMLElement | null;
 }) {
-	const [slicedItems, setSlicedItems] = useState(items.slice(0, defaultItemsPerPage));
-	const [page, setPage] = useState(1);
+  const [slicedItems, setSlicedItems] = useState(items.slice(0, defaultItemsPerPage));
+  const [page, setPage] = useState(1);
 
-	const $scrollableElement = useRef<HTMLElement | null>(null);
+  const $scrollableElement = useRef<HTMLElement | null>(null);
 
-	$scrollableElement.current = scrollableElement || $scrollableElement.current;
+  $scrollableElement.current = scrollableElement || $scrollableElement.current;
 
-	useEffect(() => {
-		if (enabled) {
-			setPage(1);
-			setSlicedItems(items.slice(0, defaultItemsPerPage));
-		}
-	}, [enabled, items, defaultItemsPerPage]);
+  useEffect(() => {
+    if (enabled) {
+      setPage(1);
+      setSlicedItems(items.slice(0, defaultItemsPerPage));
+    }
+  }, [enabled, items, defaultItemsPerPage]);
 
-	useEffect(() => {
-		const container = $scrollableElement.current;
-		if (!container || !enabled) return;
+  useEffect(() => {
+    const container = $scrollableElement.current;
+    if (!container || !enabled) return;
 
-		const handleScroll = () => {
-			if (
-				container.scrollTop + container.clientHeight >=
-				container.scrollHeight - 100 // Adjust this value for how close to the bottom you want to trigger loading
-			) {
-				setPage((prevPage) => prevPage + 1);
-			}
-		};
+    const handleScroll = () => {
+      if (
+        container.scrollTop + container.clientHeight >=
+        container.scrollHeight - 100 // Adjust this value for how close to the bottom you want to trigger loading
+      ) {
+        setPage((prevPage) => prevPage + 1);
+      }
+    };
 
-		container.addEventListener('scroll', handleScroll);
+    container.addEventListener('scroll', handleScroll);
 
-		return () => {
-			container.removeEventListener('scroll', handleScroll);
-		};
+    return () => {
+      container.removeEventListener('scroll', handleScroll);
+    };
 
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [$scrollableElement.current, enabled]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [$scrollableElement.current, enabled]);
 
-	useEffect(() => {
-		const newItems = items.slice(0, defaultItemsPerPage * page);
-		if (items.length > newItems.length) {
-			setSlicedItems((prevItems) => (prevItems.length === newItems.length ? prevItems : newItems));
-		}
-	}, [page, items, defaultItemsPerPage]);
+  useEffect(() => {
+    const newItems = items.slice(0, defaultItemsPerPage * page);
+    if (items.length > newItems.length) {
+      setSlicedItems((prevItems) => (prevItems.length === newItems.length ? prevItems : newItems));
+    }
+  }, [page, items, defaultItemsPerPage]);
 
-	return {
-		slicedItems: enabled ? slicedItems : items,
-		scrollableElement: $scrollableElement
-	};
+  return {
+    slicedItems: enabled ? slicedItems : items,
+    scrollableElement: $scrollableElement
+  };
 }

--- a/apps/web/app/hooks/features/usePagination.ts
+++ b/apps/web/app/hooks/features/usePagination.ts
@@ -32,7 +32,7 @@ export function usePagination<T>(items: T[], defaultItemsPerPage = 5) {
   const pageCount = Math.ceil(filteredTotal / ITEMS_PER_PAGE_VIEW);
 
   const onPageChange = (selectedItem: { selected: number }) => {
-    const newOffset = (selectedItem.selected * ITEMS_PER_PAGE_VIEW) % filteredTotal;
+    const newOffset =  filteredTotal === 0 ? 0 :(selectedItem.selected * ITEMS_PER_PAGE_VIEW) % filteredTotal;
     setItemOffset(newOffset);
   };
 

--- a/apps/web/lib/components/pagination.tsx
+++ b/apps/web/lib/components/pagination.tsx
@@ -5,91 +5,92 @@ import ReactPaginate, { ReactPaginateProps } from 'react-paginate';
 import { cn } from '@/lib/utils';
 
 type Props = {
-  total: number;
-  totalAll?: number; // Added to show total unfiltered items
-  itemsPerPage?: number;
-  itemOffset: number;
-  endOffset: number;
-  setItemsPerPage: Dispatch<SetStateAction<number>>;
-  className?: string;
-  pageCount: number; // This now comes from the hook
+	total: number;
+	totalAll?: number; // Added to show total unfiltered items
+	itemsPerPage?: number;
+	itemOffset: number;
+	endOffset: number;
+	setItemsPerPage: Dispatch<SetStateAction<number>>;
+	className?: string;
+	pageCount: number; // This now comes from the hook
 } & ReactPaginateProps;
 
 export function Paginate({
-  total,
-  totalAll,
-//   itemsPerPage = 5,
-  onPageChange,
-  itemOffset,
-  endOffset,
-  setItemsPerPage,
-  className,
-  pageCount
+	total,
+	totalAll,
+	//   itemsPerPage = 5,
+	onPageChange,
+	itemOffset,
+	endOffset,
+	setItemsPerPage,
+	className,
+	pageCount
 }: Props) {
-  const t = useTranslations();
+	const t = useTranslations();
 
-  return (
-    <div
-      className={cn('flex flex-col md:flex-row gap-2 items-center justify-between pt-4 relative', className)}
-      aria-label="Table navigation"
-    >
-      <ReactPaginate
-        activeLinkClassName='text-primary'
-        breakLabel=". . ."
-        nextLabel={
-          <div className="block relative w-10 h-10 justify-center items-center leading-tight text-gray-500 bg-white border border-[#23232329] rounded-r-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white rounded-[8px] p-2 disabled:opacity-25 outline-none">
-            <span className="sr-only">{t('common.NEXT')}</span>
-            <svg
-              className="w-5 h-5"
-              aria-hidden="true"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fillRule="evenodd"
-                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                clipRule="evenodd"
-              ></path>
-            </svg>
-          </div>
-        }
-        onPageChange={onPageChange}
-        pageRangeDisplayed={1}
-        pageCount={pageCount}
-        previousLabel={
-          <div className="block relative w-10 h-10 justify-center items-center rounded-[8px] ml-0 leading-tight text-gray-500 bg-white border border-[#23232329] rounded-l-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white mr-1 p-2 outline-none">
-            <span className="sr-only">{t('common.PREV')}</span>
-            <svg
-              className="w-5 h-5"
-              aria-hidden="true"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fillRule="evenodd"
-                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                clipRule="evenodd"
-              ></path>
-            </svg>
-          </div>
-        }
-        renderOnZeroPageCount={null}
-        className={'flex items-center justify-between'}
-        pageClassName={'pl-4 pr-4 pt-2 pb-2 text-gray-500 font-normal text-[#B1AEBC]'}
-        activeClassName={'text-[#1A1C1E] dark:text-white'}
-        breakClassName={'pl-5 pr-5 pt-1 pb-2'}
-      />
+	return (
+		<div
+			className={cn('flex flex-col md:flex-row gap-2 items-center justify-between pt-4 relative', className)}
+			aria-label="Table navigation"
+		>
+			<ReactPaginate
+				activeLinkClassName="text-primary"
+				breakLabel=". . ."
+				nextLabel={
+					<div className="block relative w-10 h-10 justify-center items-center leading-tight text-gray-500 bg-white border border-[#23232329] rounded-r-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white rounded-[8px] p-2 disabled:opacity-25 outline-none">
+						<span className="sr-only">{t('common.NEXT')}</span>
+						<svg
+							className="w-5 h-5"
+							aria-hidden="true"
+							fill="currentColor"
+							viewBox="0 0 20 20"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path
+								fillRule="evenodd"
+								d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+								clipRule="evenodd"
+							></path>
+						</svg>
+					</div>
+				}
+				onPageChange={onPageChange}
+				pageRangeDisplayed={1}
+				pageCount={pageCount}
+				previousLabel={
+					<div className="block relative w-10 h-10 justify-center items-center rounded-[8px] ml-0 leading-tight text-gray-500 bg-white border border-[#23232329] rounded-l-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white mr-1 p-2 outline-none">
+						<span className="sr-only">{t('common.PREV')}</span>
+						<svg
+							className="w-5 h-5"
+							aria-hidden="true"
+							fill="currentColor"
+							viewBox="0 0 20 20"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path
+								fillRule="evenodd"
+								d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+								clipRule="evenodd"
+							></path>
+						</svg>
+					</div>
+				}
+				renderOnZeroPageCount={null}
+				className={'flex items-center justify-between'}
+				pageClassName={'pl-4 pr-4 pt-2 pb-2 text-gray-500 font-normal text-[#B1AEBC]'}
+				activeClassName={'text-[#1A1C1E] dark:text-white'}
+				breakClassName={'pl-5 pr-5 pt-1 pb-2'}
+			/>
 
-<div className="relative flex items-center gap-x-5">
-        <PaginationDropdown setValue={setItemsPerPage} />
-        <div className="min-w-[240px] text-sm font-normal text-gray-500 dark:text-gray-400">
-          {totalAll !== undefined && totalAll > total
-            ? `Showing ${itemOffset + 1} to ${Math.min(endOffset, total)} of ${total} entries`
-            : `Showing ${itemOffset + 1} to ${Math.min(endOffset, total)} of ${total} entries`}
-        </div>
-      </div>
-    </div>
-  );
+			<div className="relative flex items-center gap-x-5">
+				<PaginationDropdown setValue={setItemsPerPage} />
+				<div className="min-w-[240px] text-sm font-normal text-gray-500 dark:text-gray-400">
+					{`Showing ${itemOffset + 1} to ${Math.min(endOffset, total)} of ${total} entries`}
+					{totalAll !== undefined && totalAll > total && (
+						<span className="block text-xs text-gray-400">(filtered from {totalAll})</span>
+					)}
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/apps/web/lib/components/pagination.tsx
+++ b/apps/web/lib/components/pagination.tsx
@@ -5,86 +5,91 @@ import ReactPaginate, { ReactPaginateProps } from 'react-paginate';
 import { cn } from '@/lib/utils';
 
 type Props = {
-	total: number;
-	itemsPerPage?: number;
-	itemOffset: number;
-	endOffset: number;
-	setItemsPerPage: Dispatch<SetStateAction<number>>;
-	className?: string;
+  total: number;
+  totalAll?: number; // Added to show total unfiltered items
+  itemsPerPage?: number;
+  itemOffset: number;
+  endOffset: number;
+  setItemsPerPage: Dispatch<SetStateAction<number>>;
+  className?: string;
+  pageCount: number; // This now comes from the hook
 } & ReactPaginateProps;
 
 export function Paginate({
-	total,
-	itemsPerPage = 10,
-	onPageChange,
-	itemOffset,
-	endOffset,
-	setItemsPerPage,
-	className
+  total,
+  totalAll,
+//   itemsPerPage = 5,
+  onPageChange,
+  itemOffset,
+  endOffset,
+  setItemsPerPage,
+  className,
+  pageCount
 }: Props) {
-	const t = useTranslations();
-	const pageCount: number = Math.ceil(total / itemsPerPage);
+  const t = useTranslations();
 
-	return (
-		<div
-			className={cn('flex flex-col md:flex-row gap-2 items-center justify-between pt-4 relative', className)}
-			aria-label="Table navigation"
-		>
-			<ReactPaginate
-			activeLinkClassName=' text-primary'
-				breakLabel=". . ."
-				nextLabel={
-					<div className="block relative w-10 h-10 justify-center items-center leading-tight text-gray-500 bg-white border border-[#23232329] rounded-r-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white rounded-[8px] p-2 disabled:opacity-25 outline-none">
-						<span className="sr-only">{t('common.NEXT')}</span>
-						<svg
-							className="w-5 h-5"
-							aria-hidden="true"
-							fill="currentColor"
-							viewBox="0 0 20 20"
-							xmlns="http://www.w3.org/2000/svg"
-						>
-							<path
-								fillRule="evenodd"
-								d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-								clipRule="evenodd"
-							></path>
-						</svg>
-					</div>
-				}
-				onPageChange={onPageChange}
-				pageRangeDisplayed={1}
-				pageCount={pageCount}
-				previousLabel={
-					<div className="block relative w-10 h-10 justify-center items-center rounded-[8px] ml-0 leading-tight text-gray-500 bg-white border border-[#23232329] rounded-l-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white mr-1 p-2 outline-none">
-						<span className="sr-only">{t('common.PREV')}</span>
-						<svg
-							className="w-5 h-5"
-							aria-hidden="true"
-							fill="currentColor"
-							viewBox="0 0 20 20"
-							xmlns="http://www.w3.org/2000/svg"
-						>
-							<path
-								fillRule="evenodd"
-								d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-								clipRule="evenodd"
-							></path>
-						</svg>
-					</div>
-				}
-				renderOnZeroPageCount={null}
-				className={'flex items-center justify-between'}
-				pageClassName={'pl-4 pr-4 pt-2 pb-2 text-gray-500 font-normal text-[#B1AEBC]'}
-				activeClassName={'text-[#1A1C1E] dark:text-white'}
-				breakClassName={'pl-5 pr-5 pt-1 pb-2'}
-			/>
+  return (
+    <div
+      className={cn('flex flex-col md:flex-row gap-2 items-center justify-between pt-4 relative', className)}
+      aria-label="Table navigation"
+    >
+      <ReactPaginate
+        activeLinkClassName='text-primary'
+        breakLabel=". . ."
+        nextLabel={
+          <div className="block relative w-10 h-10 justify-center items-center leading-tight text-gray-500 bg-white border border-[#23232329] rounded-r-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white rounded-[8px] p-2 disabled:opacity-25 outline-none">
+            <span className="sr-only">{t('common.NEXT')}</span>
+            <svg
+              className="w-5 h-5"
+              aria-hidden="true"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fillRule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clipRule="evenodd"
+              ></path>
+            </svg>
+          </div>
+        }
+        onPageChange={onPageChange}
+        pageRangeDisplayed={1}
+        pageCount={pageCount}
+        previousLabel={
+          <div className="block relative w-10 h-10 justify-center items-center rounded-[8px] ml-0 leading-tight text-gray-500 bg-white border border-[#23232329] rounded-l-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white mr-1 p-2 outline-none">
+            <span className="sr-only">{t('common.PREV')}</span>
+            <svg
+              className="w-5 h-5"
+              aria-hidden="true"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fillRule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clipRule="evenodd"
+              ></path>
+            </svg>
+          </div>
+        }
+        renderOnZeroPageCount={null}
+        className={'flex items-center justify-between'}
+        pageClassName={'pl-4 pr-4 pt-2 pb-2 text-gray-500 font-normal text-[#B1AEBC]'}
+        activeClassName={'text-[#1A1C1E] dark:text-white'}
+        breakClassName={'pl-5 pr-5 pt-1 pb-2'}
+      />
 
-			<div className="flex items-center relative gap-x-5">
-				<PaginationDropdown setValue={setItemsPerPage} />
-				<span className="text-sm font-normal text-gray-500 dark:text-gray-400">
-					{`Showing ${itemOffset + 1} to ${Math.min(endOffset, total)} of ${total} entries`}
-				</span>
-			</div>
-		</div>
-	);
+<div className="relative flex items-center gap-x-5">
+        <PaginationDropdown setValue={setItemsPerPage} />
+        <div className="min-w-[240px] text-sm font-normal text-gray-500 dark:text-gray-400">
+          {totalAll !== undefined && totalAll > total
+            ? `Showing ${itemOffset + 1} to ${Math.min(endOffset, total)} of ${total} entries`
+            : `Showing ${itemOffset + 1} to ${Math.min(endOffset, total)} of ${total} entries`}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/lib/components/pagination.tsx
+++ b/apps/web/lib/components/pagination.tsx
@@ -5,92 +5,87 @@ import ReactPaginate, { ReactPaginateProps } from 'react-paginate';
 import { cn } from '@/lib/utils';
 
 type Props = {
-	total: number;
-	totalAll?: number; // Added to show total unfiltered items
-	itemsPerPage?: number;
-	itemOffset: number;
-	endOffset: number;
-	setItemsPerPage: Dispatch<SetStateAction<number>>;
-	className?: string;
-	pageCount: number; // This now comes from the hook
+  total: number;
+  itemsPerPage: number;
+  itemOffset: number;
+  endOffset: number;
+  setItemsPerPage: Dispatch<SetStateAction<number>>;
+  className?: string;
+  pageCount: number;
 } & ReactPaginateProps;
 
 export function Paginate({
-	total,
-	totalAll,
-	//   itemsPerPage = 5,
-	onPageChange,
-	itemOffset,
-	endOffset,
-	setItemsPerPage,
-	className,
-	pageCount
+  total,
+//   itemsPerPage,
+  onPageChange,
+  itemOffset,
+  endOffset,
+  setItemsPerPage,
+  className,
+  pageCount
 }: Props) {
-	const t = useTranslations();
+  const t = useTranslations();
 
-	return (
-		<div
-			className={cn('flex flex-col md:flex-row gap-2 items-center justify-between pt-4 relative', className)}
-			aria-label="Table navigation"
-		>
-			<ReactPaginate
-				activeLinkClassName="text-primary"
-				breakLabel=". . ."
-				nextLabel={
-					<div className="block relative w-10 h-10 justify-center items-center leading-tight text-gray-500 bg-white border border-[#23232329] rounded-r-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white rounded-[8px] p-2 disabled:opacity-25 outline-none">
-						<span className="sr-only">{t('common.NEXT')}</span>
-						<svg
-							className="w-5 h-5"
-							aria-hidden="true"
-							fill="currentColor"
-							viewBox="0 0 20 20"
-							xmlns="http://www.w3.org/2000/svg"
-						>
-							<path
-								fillRule="evenodd"
-								d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-								clipRule="evenodd"
-							></path>
-						</svg>
-					</div>
-				}
-				onPageChange={onPageChange}
-				pageRangeDisplayed={1}
-				pageCount={pageCount}
-				previousLabel={
-					<div className="block relative w-10 h-10 justify-center items-center rounded-[8px] ml-0 leading-tight text-gray-500 bg-white border border-[#23232329] rounded-l-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white mr-1 p-2 outline-none">
-						<span className="sr-only">{t('common.PREV')}</span>
-						<svg
-							className="w-5 h-5"
-							aria-hidden="true"
-							fill="currentColor"
-							viewBox="0 0 20 20"
-							xmlns="http://www.w3.org/2000/svg"
-						>
-							<path
-								fillRule="evenodd"
-								d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-								clipRule="evenodd"
-							></path>
-						</svg>
-					</div>
-				}
-				renderOnZeroPageCount={null}
-				className={'flex items-center justify-between'}
-				pageClassName={'pl-4 pr-4 pt-2 pb-2 text-gray-500 font-normal text-[#B1AEBC]'}
-				activeClassName={'text-[#1A1C1E] dark:text-white'}
-				breakClassName={'pl-5 pr-5 pt-1 pb-2'}
-			/>
+  return (
+    <div
+      className={cn('flex flex-col md:flex-row gap-2 items-center justify-between pt-4 relative', className)}
+      aria-label="Table navigation"
+    >
+      <ReactPaginate
+        activeLinkClassName="text-primary"
+        breakLabel=". . ."
+        nextLabel={
+          <div className="block relative w-10 h-10 justify-center items-center leading-tight text-gray-500 bg-white border border-[#23232329] rounded-r-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white rounded-[8px] p-2 disabled:opacity-25 outline-none">
+            <span className="sr-only">{t('common.NEXT')}</span>
+            <svg
+              className="w-5 h-5"
+              aria-hidden="true"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fillRule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clipRule="evenodd"
+              ></path>
+            </svg>
+          </div>
+        }
+        onPageChange={onPageChange}
+        pageRangeDisplayed={1}
+        pageCount={pageCount}
+        previousLabel={
+          <div className="block relative w-10 h-10 justify-center items-center rounded-[8px] ml-0 leading-tight text-gray-500 bg-white border border-[#23232329] rounded-l-lg hover:bg-gray-100 hover:text-gray-700 dark:bg-dark--theme-light dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white mr-1 p-2 outline-none">
+            <span className="sr-only">{t('common.PREV')}</span>
+            <svg
+              className="w-5 h-5"
+              aria-hidden="true"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fillRule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clipRule="evenodd"
+              ></path>
+            </svg>
+          </div>
+        }
+        renderOnZeroPageCount={null}
+        className={'flex items-center justify-between'}
+        pageClassName={'pl-4 pr-4 pt-2 pb-2 text-gray-500 font-normal text-[#B1AEBC]'}
+        activeClassName={'text-[#1A1C1E] dark:text-white'}
+        breakClassName={'pl-5 pr-5 pt-1 pb-2'}
+      />
 
-			<div className="relative flex items-center gap-x-5">
-				<PaginationDropdown setValue={setItemsPerPage} />
-				<div className="min-w-[240px] text-sm font-normal text-gray-500 dark:text-gray-400">
-					{`Showing ${itemOffset + 1} to ${Math.min(endOffset, total)} of ${total} entries`}
-					{totalAll !== undefined && totalAll > total && (
-						<span className="block text-xs text-gray-400">(filtered from {totalAll})</span>
-					)}
-				</div>
-			</div>
-		</div>
-	);
+      <div className="relative flex items-center gap-x-5">
+        <PaginationDropdown setValue={setItemsPerPage} />
+        <div className="min-w-[240px] text-sm font-normal text-gray-500 dark:text-gray-400">
+          {`Showing ${itemOffset + 1} to ${Math.min(endOffset, total)} of ${total} entries`}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/lib/settings/member-table.tsx
+++ b/apps/web/lib/settings/member-table.tsx
@@ -21,7 +21,6 @@ export const MemberTable = ({ members }: { members: OT_Member[] }) => {
 	const t = useTranslations();
 	const {
 		total,
-		totalAll,
 		onPageChange,
 		itemsPerPage,
 		itemOffset,
@@ -149,7 +148,13 @@ export const MemberTable = ({ members }: { members: OT_Member[] }) => {
 
 	return (
 		<div>
-			<div className="sm:rounded-lg h-[28rem] overflow-hidden">
+			<div className={clsxm(
+				"sm:rounded-lg overflow-auto",
+				itemsPerPage <= 5 ? "h-[28rem]" : "",
+				itemsPerPage > 5 && itemsPerPage <= 10 ? "h-[35rem]" : "",
+				itemsPerPage > 10 && itemsPerPage <= 20 ? "h-[45rem]" : "",
+				itemsPerPage > 20 ? "h-[55rem]" : ""
+			)}>
 				<table className="w-full text-sm text-left text-gray-500 dark:bg-dark--theme-light">
 					<thead className="text-xs text-gray-700 uppercase border-b">
 						<tr>
@@ -185,7 +190,7 @@ export const MemberTable = ({ members }: { members: OT_Member[] }) => {
 							</th>
 							<th
 								scope="col"
-								className="text-sm font-normal capitalize  text-[#B1AEBC] dark:text-white w-6"
+								className="text-sm font-normal capitalize text-[#B1AEBC] dark:text-white w-6"
 							></th>
 						</tr>
 					</thead>
@@ -302,9 +307,8 @@ export const MemberTable = ({ members }: { members: OT_Member[] }) => {
 
 			<Paginate
 				total={total}
-				totalAll={totalAll}
 				onPageChange={onPageChange}
-				pageCount={pageCount} // Use the dynamic pageCount from the hook
+				pageCount={pageCount}
 				itemsPerPage={itemsPerPage}
 				itemOffset={itemOffset}
 				endOffset={endOffset}

--- a/apps/web/lib/settings/member-table.tsx
+++ b/apps/web/lib/settings/member-table.tsx
@@ -19,8 +19,17 @@ import { EditUserRoleDropdown } from './edit-role-dropdown';
 
 export const MemberTable = ({ members }: { members: OT_Member[] }) => {
 	const t = useTranslations();
-	const { total, onPageChange, itemsPerPage, itemOffset, endOffset, setItemsPerPage, currentItems } =
-		usePagination<OT_Member>(members, 5);
+	const {
+		total,
+		totalAll,
+		onPageChange,
+		itemsPerPage,
+		itemOffset,
+		endOffset,
+		setItemsPerPage,
+		currentItems,
+		pageCount
+	} = usePagination<OT_Member>(members, 5);
 	const { activeTeam, updateOrganizationTeam } = useOrganizationTeams();
 	const { updateAvatar } = useSettings();
 
@@ -83,7 +92,7 @@ export const MemberTable = ({ members }: { members: OT_Member[] }) => {
 
 	const handleRoleChange = useCallback(
 		(newRole: IRole) => {
-			if (!editMemberRef.current || !activeTeamRef.current) return;			
+			if (!editMemberRef.current || !activeTeamRef.current) return;
 
 			const { employeeId, role } = editMemberRef.current;
 
@@ -141,7 +150,7 @@ export const MemberTable = ({ members }: { members: OT_Member[] }) => {
 	return (
 		<div>
 			<div className="sm:rounded-lg h-[28rem] overflow-hidden">
-				<table className="w-full  text-sm text-left text-gray-500 dark:bg-dark--theme-light">
+				<table className="w-full text-sm text-left text-gray-500 dark:bg-dark--theme-light">
 					<thead className="text-xs text-gray-700 uppercase border-b">
 						<tr>
 							<th
@@ -293,8 +302,9 @@ export const MemberTable = ({ members }: { members: OT_Member[] }) => {
 
 			<Paginate
 				total={total}
+				totalAll={totalAll}
 				onPageChange={onPageChange}
-				pageCount={1} // Set Static to 1 - It will be calculated dynamically in the Paginate component
+				pageCount={pageCount} // Use the dynamic pageCount from the hook
 				itemsPerPage={itemsPerPage}
 				itemOffset={itemOffset}
 				endOffset={endOffset}


### PR DESCRIPTION
## Description

Fix the broken pagination issue on select

## Type of Change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screencasts

[Please add here videos or images of the previous status](https://github.com/user-attachments/assets/7d5366fd-c7af-420f-893e-5708a1ba0996)

## Current screencasts
[Screencast from 2025-04-10 16-49-26.webm](https://github.com/user-attachments/assets/8c800f41-cf6e-4f47-bb46-94def4dc5e31)

Please add here videos or images of the current (new) status


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced pagination controls now show 5 items per page by default, offering a more streamlined browsing experience.
  - Pagination components have been updated to require `itemsPerPage` and include a new `pageCount` property for better data representation.
  - Improved filtering integration ensures that changes reset pagination appropriately, providing a more responsive user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->