### PR TITLE
[Fix][Mobile]: Fix Task Labels Endpoint and Team Settings Navigation

### DIFF
--- a/apps/mobile/app/navigators/AuthenticatedNavigator.tsx
+++ b/apps/mobile/app/navigators/AuthenticatedNavigator.tsx
@@ -50,22 +50,23 @@ import { useOrganizationTeam } from '../services/hooks/useOrganization';
 export type AuthenticatedTabParamList = {
 	Timer: undefined;
 	Team: undefined;
-	Setting: { activeTab: 1 | 2 };
+	Setting: { activeTab?: 1 | 2 };
 	Profile: { userId: string; activeTab: 'worked' | 'assigned' | 'unassigned' };
 	TaskScreen: { taskId: string };
 };
 
 export type AuthenticatedDrawerParamList = {
-	Setting: undefined;
+	Setting: { activeTab?: 1 | 2 };
 	AuthenticatedTab: undefined;
-	TaskLabelScreen: undefined;
-	TaskSizeScreen: undefined;
-	TaskStatus: undefined;
-	TaskPriority: undefined;
-	TaskVersion: undefined;
-	MembersSettingsScreen: undefined;
+	TaskLabelScreen: { previousTab?: number };
+	TaskSizeScreen: { previousTab?: number };
+	TaskStatus: { previousTab?: number };
+	TaskPriority: { previousTab?: number };
+	TaskVersion: { previousTab?: number };
+	MembersSettingsScreen: { previousTab?: number };
 	TaskScreen: { taskId: string };
 };
+
 /**
  * Helper for automatically generating navigation prop types for each route.
  *
@@ -91,7 +92,14 @@ export type DrawerNavigationProp<T extends keyof AuthenticatedDrawerParamList> =
 	StackNavigationProp<AppStackParamList>
 >;
 
+// Define route props for each screen that needs route parameters
 export type SettingScreenRouteProp<T extends keyof AuthenticatedTabParamList> = RouteProp<AuthenticatedTabParamList, T>;
+export type TaskVersionRouteProp = RouteProp<AuthenticatedDrawerParamList, 'TaskVersion'>;
+export type TaskStatusRouteProp = RouteProp<AuthenticatedDrawerParamList, 'TaskStatus'>;
+export type TaskLabelScreenRouteProp = RouteProp<AuthenticatedDrawerParamList, 'TaskLabelScreen'>;
+export type TaskSizeScreenRouteProp = RouteProp<AuthenticatedDrawerParamList, 'TaskSizeScreen'>;
+export type TaskPriorityRouteProp = RouteProp<AuthenticatedDrawerParamList, 'TaskPriority'>;
+export type MembersSettingsScreenRouteProp = RouteProp<AuthenticatedDrawerParamList, 'MembersSettingsScreen'>;
 
 const Tab = createBottomTabNavigator<AuthenticatedTabParamList>();
 

--- a/apps/mobile/app/screens/Authenticated/SettingScreen/Team/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/SettingScreen/Team/index.tsx
@@ -18,7 +18,7 @@ import { useTaskSizes } from '../../../../services/hooks/features/useTaskSizes';
 import { useTaskLabels } from '../../../../services/hooks/features/useTaskLabels';
 import { useTaskVersion } from '../../../../services/hooks/features/useTaskVersion';
 import SwitchTeamPublicity from '../components/SwitchTeamPublicity';
-import { NavigationProp } from '@react-navigation/native';
+// import { NavigationProp } from '@react-navigation/native';
 import { AuthenticatedDrawerParamList } from '../../../../navigators/AuthenticatedNavigator';
 
 interface ITeamSettingProps {

--- a/apps/mobile/app/screens/Authenticated/SettingScreen/Team/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/SettingScreen/Team/index.tsx
@@ -18,6 +18,8 @@ import { useTaskSizes } from '../../../../services/hooks/features/useTaskSizes';
 import { useTaskLabels } from '../../../../services/hooks/features/useTaskLabels';
 import { useTaskVersion } from '../../../../services/hooks/features/useTaskVersion';
 import SwitchTeamPublicity from '../components/SwitchTeamPublicity';
+import { NavigationProp } from '@react-navigation/native';
+import { AuthenticatedDrawerParamList } from '../../../../navigators/AuthenticatedNavigator';
 
 interface ITeamSettingProps {
 	props: any;
@@ -40,6 +42,11 @@ const TeamSettings: FC<ITeamSettingProps> = observer(({ props, onOpenBottomSheet
 	const { labels } = useTaskLabels();
 	const { versions } = useTaskVersion();
 
+	// Function to navigate to screens with previousTab param
+	const navigateWithTab = (screenName: keyof AuthenticatedDrawerParamList) => {
+		navigation.navigate(screenName, { previousTab: 2 });
+	};
+
 	return (
 		<View style={[$contentContainer, { backgroundColor: colors.background, opacity: 0.9 }]}>
 			<TransferOwnership visible={open} onDismiss={() => setOpen(false)} />
@@ -60,34 +67,34 @@ const TeamSettings: FC<ITeamSettingProps> = observer(({ props, onOpenBottomSheet
 					value={`There ${versions?.total === 1 ? 'is' : 'are'} ${versions?.total} active ${
 						versions?.total === 1 ? 'version' : 'versions'
 					}`}
-					onPress={() => navigation.navigate('TaskVersion')}
+					onPress={() => navigateWithTab('TaskVersion')}
 				/>
 				<SingleInfo
 					title={translate('settingScreen.teamSection.taskStatuses')}
 					value={`There are ${statuses?.total} active statuses`}
-					onPress={() => navigation.navigate('TaskStatus')}
+					onPress={() => navigateWithTab('TaskStatus')}
 				/>
 				<SingleInfo
 					title={translate('settingScreen.teamSection.taskPriorities')}
 					value={`There are ${priorities?.total} active priorities`}
-					onPress={() => navigation.navigate('TaskPriority')}
+					onPress={() => navigateWithTab('TaskPriority')}
 				/>
 				<SingleInfo
 					title={translate('settingScreen.teamSection.taskSizes')}
 					value={`There are ${sizes?.total} active sizes`}
-					onPress={() => navigation.navigate('TaskSizeScreen')}
+					onPress={() => navigateWithTab('TaskSizeScreen')}
 				/>
 				<SingleInfo
 					title={translate('settingScreen.teamSection.taskLabel')}
 					value={`There ${labels?.total === 1 ? 'is' : 'are'} ${labels?.total} active ${
 						labels?.total === 1 ? 'label' : 'labels'
 					}`}
-					onPress={() => navigation.navigate('TaskLabelScreen')}
+					onPress={() => navigateWithTab('TaskLabelScreen')}
 				/>
 				<SingleInfo
 					title={translate('settingScreen.teamSection.teamRole')}
 					value={isTeamManager ? 'Yes' : 'No'}
-					onPress={() => navigation.navigate('MembersSettingsScreen')}
+					onPress={() => navigateWithTab('MembersSettingsScreen')}
 				/>
 				<SingleInfo
 					title={translate('settingScreen.teamSection.workSchedule')}

--- a/apps/mobile/app/screens/Authenticated/SettingScreen/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/SettingScreen/index.tsx
@@ -6,7 +6,6 @@ import {
 	LogBox,
 	StatusBar,
 	Keyboard,
-	// Text,
 	StyleSheet,
 	Platform,
 	KeyboardAvoidingView
@@ -27,7 +26,7 @@ import PersonalSettings from './Personal';
 import TeamSettings from './Team';
 import { useAppTheme } from '../../../theme';
 import { useOrganizationTeam } from '../../../services/hooks/useOrganization';
-import { useRoute } from '@react-navigation/native';
+import { useRoute, useFocusEffect } from '@react-navigation/native';
 
 export type IPopup =
 	| 'Names'
@@ -57,12 +56,21 @@ export const AuthenticatedSettingScreen: FC<AuthenticatedDrawerScreenProps<'Sett
 		const bottomSheetRef = useRef<BottomSheet>(null);
 
 		// STATES
-		const [activeTab, setActiveTab] = useState(route.params?.activeTab || 1);
+		const [activeTab, setActiveTab] = useState(route.params?.activeTab || 1); // Initialize from route params
 		const [showPopup, setShowPopup] = useState<IPopup>(null);
 		const [bottomSheetVisible, setBottomSheetVisible] = useState(false);
 		const [keyboardVisible, setKeyboardVisible] = useState(false);
 		const [keyboardHeight, setKeyboardHeight] = useState(0);
 		const [desiredSnapIndex, setDesiredSnapIndex] = useState(1); // New state for tracking desired snap index
+
+		// Update active tab when route params change
+		useFocusEffect(
+			useCallback(() => {
+				if (route.params?.activeTab) {
+					setActiveTab(route.params.activeTab);
+				}
+			}, [route.params])
+		);
 
 		// Include multiple snap points for different sheet heights
 		const snapPoints = useMemo(() => ['1%', '50%', '70%', '85%'], []);
@@ -182,15 +190,6 @@ export const AuthenticatedSettingScreen: FC<AuthenticatedDrawerScreenProps<'Sett
 			[]
 		);
 
-		// Add navigation listener for debugging
-		useEffect(() => {
-			const unsubscribe = navigation.addListener('focus', () => {
-				// console.log('[SettingScreen] Screen focused');
-			});
-
-			return unsubscribe;
-		}, [navigation]);
-
 		return (
 			<GestureHandlerRootView style={styles.gestureRoot}>
 				{/* Main Screen Content */}
@@ -220,7 +219,7 @@ export const AuthenticatedSettingScreen: FC<AuthenticatedDrawerScreenProps<'Sett
 								) : activeTab === 1 ? (
 									<PersonalSettings onOpenBottomSheet={openBottomSheet} />
 								) : activeTeam ? (
-									<TeamSettings props={{ ..._props }} onOpenBottomSheet={openBottomSheet} />
+									<TeamSettings props={_props} onOpenBottomSheet={openBottomSheet} />
 								) : null}
 							</View>
 						</View>

--- a/apps/mobile/app/screens/Authenticated/SettingScreen/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/SettingScreen/index.tsx
@@ -50,7 +50,7 @@ export const AuthenticatedSettingScreen: FC<AuthenticatedDrawerScreenProps<'Sett
 		const { isLoading } = useSettings();
 		const { activeTeam } = useOrganizationTeam();
 		const route = useRoute<SettingScreenRouteProp<'Setting'>>();
-		const { navigation } = _props;
+		// const { navigation } = _props;
 
 		// ref
 		const bottomSheetRef = useRef<BottomSheet>(null);

--- a/apps/mobile/app/screens/Authenticated/TaskLabelScreen/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/TaskLabelScreen/index.tsx
@@ -25,11 +25,32 @@ import TaskLabelForm from './components/TaskLabelForm';
 import { ITaskLabelItem } from '../../../services/interfaces/ITaskLabel';
 import { useTaskLabels } from '../../../services/hooks/features/useTaskLabels';
 import { BlurView } from 'expo-blur';
+import { useRoute, RouteProp } from '@react-navigation/native';
+
+// Create a type for the route params
+type TaskLabelRouteParams = {
+  previousTab?: 1 | 2; // Explicitly type as 1 | 2 union type
+};
+
+// Properly type the route object
+type TaskLabelRouteProp = RouteProp<{ TaskLabelScreen: TaskLabelRouteParams }, 'TaskLabelScreen'>;
 
 export const TaskLabelScreen: FC<AuthenticatedDrawerScreenProps<'TaskLabelScreen'>> =
 	function AuthenticatedDrawerScreen(_props) {
 		const { colors, dark } = useAppTheme();
 		const { navigation } = _props;
+
+		// Use the properly typed route
+    const route = useRoute<TaskLabelRouteProp>();
+
+    // Get the previousTab parameter with type assertion
+    const previousTab = route.params?.previousTab || 2 as const;
+
+    // Handle back navigation with correct tab
+    const handleGoBack = useCallback(() => {
+      navigation.navigate('Setting', { activeTab: previousTab });
+    }, [navigation, previousTab]);
+
 		const { isLoading, labels, deleteLabel, updateLabel, createLabel } = useTaskLabels();
 		const [editMode, setEditMode] = useState(false);
 		const [itemToEdit, setItemToEdit] = useState<ITaskLabelItem>(null);
@@ -184,7 +205,7 @@ export const TaskLabelScreen: FC<AuthenticatedDrawerScreenProps<'TaskLabelScreen
 				<Animated.View style={{ flex: 1 }}>
 					<View style={[$headerContainer, { backgroundColor: colors.background }]}>
 						<View style={[styles.container, { backgroundColor: colors.background }]}>
-							<TouchableOpacity accessibilityRole="button" onPress={() => navigation.navigate('Setting')}>
+							<TouchableOpacity accessibilityRole="button" onPress={handleGoBack}>
 								<AntDesign name="arrowleft" size={24} color={colors.primary} />
 							</TouchableOpacity>
 							<Text style={[styles.title, { color: colors.primary }]}>

--- a/apps/mobile/app/screens/Authenticated/TaskPrioritiesScreen/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/TaskPrioritiesScreen/index.tsx
@@ -25,11 +25,32 @@ import TaskPriorityForm from './components/TaskPriorityForm';
 import { useTaskPriority } from '../../../services/hooks/features/useTaskPriority';
 import PriorityItem from './components/PriorityItem';
 import { BlurView } from 'expo-blur';
+import { useRoute, RouteProp } from '@react-navigation/native';
+
+// Create a type for the route params
+type TaskPriorityRouteParams = {
+  previousTab?: 1 | 2; // Explicitly type as 1 | 2 union type
+};
+
+// Properly type the route object
+type TaskPriorityRouteProp = RouteProp<{ TaskPriority: TaskPriorityRouteParams }, 'TaskPriority'>;
 
 export const TaskPriorityScreen: FC<AuthenticatedDrawerScreenProps<'TaskPriority'>> =
   function AuthenticatedDrawerScreen(_props) {
     const { colors, dark } = useAppTheme();
     const { navigation } = _props;
+
+    // Use the properly typed route
+    const route = useRoute<TaskPriorityRouteProp>();
+
+    // Get the previousTab parameter with type assertion
+    const previousTab = route.params?.previousTab || 2 as const;
+
+    // Handle back navigation with correct tab
+    const handleGoBack = useCallback(() => {
+      navigation.navigate('Setting', { activeTab: previousTab });
+    }, [navigation, previousTab]);
+
     const { isLoading, priorities, deletePriority, updatePriority, createPriority } = useTaskPriority();
     const [editMode, setEditMode] = useState(false);
     const [itemToEdit, setItemToEdit] = useState<ITaskPriorityItem>(null);
@@ -140,9 +161,8 @@ export const TaskPriorityScreen: FC<AuthenticatedDrawerScreenProps<'TaskPriority
           <View style={[$headerContainer, { backgroundColor: colors.background }]}>
             <View style={[styles.container, { backgroundColor: colors.background }]}>
               <TouchableOpacity
-                // accessibilityLabel={translate('settingScreen.backButton')}
                 accessibilityRole="button"
-                onPress={() => navigation.navigate('Setting')}
+                onPress={handleGoBack} // Use our custom handler for back navigation
               >
                 <AntDesign name="arrowleft" size={24} color={colors.primary} />
               </TouchableOpacity>
@@ -248,7 +268,6 @@ export const TaskPriorityScreen: FC<AuthenticatedDrawerScreenProps<'TaskPriority
             keyboardBehavior="interactive"
             keyboardBlurBehavior="restore"
             android_keyboardInputMode="adjustResize"
-            // handleHeight={30}
             backgroundStyle={{
               backgroundColor: colors.background,
               shadowColor: '#000',

--- a/apps/mobile/app/screens/Authenticated/TaskSizeScreen/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/TaskSizeScreen/index.tsx
@@ -26,7 +26,7 @@ import SizeItem from './components/SizeItem';
 import { useTaskSizes } from '../../../services/hooks/features/useTaskSizes';
 import { BlurView } from 'expo-blur';
 import { useRoute, RouteProp } from '@react-navigation/native';
-import { ITaskSizeItem } from '../../../services/interfaces/ITaskSize';
+// import { ITaskSizeItem } from '../../../services/interfaces/ITaskSize';
 
 // Create a type for the route params
 type TaskSizeRouteParams = {

--- a/apps/mobile/app/screens/Authenticated/TaskSizeScreen/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/TaskSizeScreen/index.tsx
@@ -26,6 +26,7 @@ import SizeItem from './components/SizeItem';
 import { useTaskSizes } from '../../../services/hooks/features/useTaskSizes';
 import { BlurView } from 'expo-blur';
 import { useRoute, RouteProp } from '@react-navigation/native';
+import { ITaskSizeItem } from '../../../services/interfaces/ITaskSize';
 
 // Create a type for the route params
 type TaskSizeRouteParams = {
@@ -54,7 +55,7 @@ export const TaskSizeScreen: FC<AuthenticatedDrawerScreenProps<'TaskSizeScreen'>
 
   const { isLoading, sizes, deleteSize, updateSize, createSize } = useTaskSizes();
   const [editMode, setEditMode] = useState(false);
-  const [itemToEdit, setItemToEdit] = useState<ITaskStatusItem>(null);
+  const [itemToEdit, setItemToEdit] = useState<ITaskStatusItem | null>(null);
   const [bottomSheetVisible, setBottomSheetVisible] = useState(false);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const [keyboardHeight, setKeyboardHeight] = useState(0);

--- a/apps/mobile/app/screens/Authenticated/TaskSizeScreen/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/TaskSizeScreen/index.tsx
@@ -25,12 +25,33 @@ import TaskSizeForm from './components/TaskSizeForm';
 import SizeItem from './components/SizeItem';
 import { useTaskSizes } from '../../../services/hooks/features/useTaskSizes';
 import { BlurView } from 'expo-blur';
+import { useRoute, RouteProp } from '@react-navigation/native';
+
+// Create a type for the route params
+type TaskSizeRouteParams = {
+  previousTab?: 1 | 2; // Explicitly type as 1 | 2 union type
+};
+
+// Properly type the route object
+type TaskSizeRouteProp = RouteProp<{ TaskSizeScreen: TaskSizeRouteParams }, 'TaskSizeScreen'>;
 
 export const TaskSizeScreen: FC<AuthenticatedDrawerScreenProps<'TaskSizeScreen'>> = function AuthenticatedDrawerScreen(
   _props
 ) {
   const { colors, dark } = useAppTheme();
   const { navigation } = _props;
+
+  // Use the properly typed route
+  const route = useRoute<TaskSizeRouteProp>();
+
+  // Get the previousTab parameter with type assertion
+  const previousTab = route.params?.previousTab || 2 as const;
+
+  // Handle back navigation with correct tab
+  const handleGoBack = useCallback(() => {
+    navigation.navigate('Setting', { activeTab: previousTab });
+  }, [navigation, previousTab]);
+
   const { isLoading, sizes, deleteSize, updateSize, createSize } = useTaskSizes();
   const [editMode, setEditMode] = useState(false);
   const [itemToEdit, setItemToEdit] = useState<ITaskStatusItem>(null);
@@ -139,7 +160,7 @@ export const TaskSizeScreen: FC<AuthenticatedDrawerScreenProps<'TaskSizeScreen'>
           <View style={[styles.container, { backgroundColor: colors.background }]}>
             <TouchableOpacity
               accessibilityRole="button"
-              onPress={() => navigation.navigate('Setting')}
+              onPress={handleGoBack} // Use our custom handler for back navigation
             >
               <AntDesign name="arrowleft" size={24} color={colors.primary} />
             </TouchableOpacity>

--- a/apps/mobile/app/screens/Authenticated/TaskStatusScreen/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/TaskStatusScreen/index.tsx
@@ -25,12 +25,28 @@ import { useTaskStatus } from '../../../services/hooks/features/useTaskStatus';
 import { ITaskStatusItem } from '../../../services/interfaces/ITaskStatus';
 import TaskStatusForm from './components/TaskStatusForm';
 import { BlurView } from 'expo-blur';
+import { useRoute, RouteProp } from '@react-navigation/native';
+
+// Create a type for the route params
+type TaskStatusRouteParams = {
+  previousTab?: 1 | 2; // Explicitly type as 1 | 2 union type
+};
+
+// Properly type the route object
+type TaskStatusRouteProp = RouteProp<{ TaskStatus: TaskStatusRouteParams }, 'TaskStatus'>;
 
 export const TaskStatusScreen: FC<AuthenticatedDrawerScreenProps<'TaskStatus'>> = function AuthenticatedDrawerScreen(
   _props
 ) {
   const { colors, dark } = useAppTheme();
   const { navigation } = _props;
+
+  // Use the properly typed route
+  const route = useRoute<TaskStatusRouteProp>();
+
+  // Get the previousTab parameter with type assertion
+  const previousTab = route.params?.previousTab || 2 as const;
+
   const { isLoading, statuses, deleteStatus, updateStatus, createStatus } = useTaskStatus();
   const [editMode, setEditMode] = useState(false);
   const [itemToEdit, setItemToEdit] = useState<ITaskStatusItem>(null);
@@ -38,6 +54,11 @@ export const TaskStatusScreen: FC<AuthenticatedDrawerScreenProps<'TaskStatus'>> 
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [desiredSnapIndex, setDesiredSnapIndex] = useState(0); // Track desired snap index
+
+  // Handle back navigation with correct tab
+  const handleGoBack = useCallback(() => {
+    navigation.navigate('Setting', { activeTab: previousTab });
+  }, [navigation, previousTab]);
 
   // ref
   const sheetRef = useRef<BottomSheet>(null);
@@ -140,9 +161,8 @@ export const TaskStatusScreen: FC<AuthenticatedDrawerScreenProps<'TaskStatus'>> 
         <View style={[$headerContainer, { backgroundColor: colors.background }]}>
           <View style={[styles.container, { backgroundColor: colors.background }]}>
             <TouchableOpacity
-            //   accessibilityLabel={translate('settingScreen.backButton')}
               accessibilityRole="button"
-              onPress={() => navigation.navigate('Setting')}
+              onPress={handleGoBack} // Use our custom handler for back navigation
             >
               <AntDesign name="arrowleft" size={24} color={colors.primary} />
             </TouchableOpacity>
@@ -246,7 +266,6 @@ export const TaskStatusScreen: FC<AuthenticatedDrawerScreenProps<'TaskStatus'>> 
           keyboardBehavior="interactive"
           keyboardBlurBehavior="restore"
           android_keyboardInputMode="adjustResize"
-        //   handleHeight={30}
           backgroundStyle={{
             backgroundColor: colors.background,
             shadowColor: '#000',

--- a/apps/mobile/app/screens/Authenticated/TaskVersionScreen/components/TaskVersionForm.tsx
+++ b/apps/mobile/app/screens/Authenticated/TaskVersionScreen/components/TaskVersionForm.tsx
@@ -23,18 +23,18 @@ const TaskVersionForm = ({
 	createVersionModal?: boolean;
 }) => {
 	const { colors, dark } = useAppTheme();
-	const [versionName, setVersionName] = useState<string>(null);
+	const [versionName, setVersionName] = useState<string>('');
 
 	useEffect(() => {
 		if (isEdit) {
-			setVersionName(item.name);
+			setVersionName(item?.name ?? '');
 		} else {
 			setVersionName(null);
 		}
 	}, [item, isEdit]);
 
 	const handleSubmit = async () => {
-		if (versionName.trim().length <= 0) {
+				if (!versionName || versionName.trim().length <= 0) {
 			return;
 		}
 

--- a/apps/mobile/app/screens/Authenticated/TaskVersionScreen/components/TaskVersionForm.tsx
+++ b/apps/mobile/app/screens/Authenticated/TaskVersionScreen/components/TaskVersionForm.tsx
@@ -1,201 +1,159 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+/* eslint-disable react-native/no-color-literals */
+/* eslint-disable react-native/no-inline-styles */
+import React, { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, TextInput, StyleSheet, Keyboard } from 'react-native';
 import { translate } from '../../../../i18n';
 import { typography, useAppTheme } from '../../../../theme';
+
 import { ITaskVersionCreate, ITaskVersionItemList } from '../../../../services/interfaces/ITaskVersion';
 
-// Wrap with React.memo to prevent unnecessary re-renders
-const TaskVersionForm = React.memo(({
-  isEdit,
-  onDismiss,
-  item,
-  onCreateVersion,
-  onUpdateVersion,
-  createVersionModal
+const TaskVersionForm = ({
+	isEdit,
+	onDismiss,
+	item,
+	onCreateVersion,
+	onUpdateVersion,
+	createVersionModal
 }: {
-  isEdit: boolean;
-  onDismiss: () => unknown;
-  item?: ITaskVersionItemList;
-  onUpdateVersion: (id: string, data: ITaskVersionCreate) => unknown;
-  onCreateVersion: (data: ITaskVersionCreate) => unknown;
-  createVersionModal?: boolean;
+	isEdit: boolean;
+	onDismiss: () => unknown;
+	item?: ITaskVersionItemList;
+	onUpdateVersion: (id: string, data: ITaskVersionCreate) => unknown;
+	onCreateVersion: (data: ITaskVersionCreate) => unknown;
+	createVersionModal?: boolean;
 }) => {
-  const { colors, dark } = useAppTheme();
-  const [versionName, setVersionName] = useState<string>('');
-  const inputRef = useRef<TextInput>(null);
-  const mountedRef = useRef(true);
+	const { colors, dark } = useAppTheme();
+	const [versionName, setVersionName] = useState<string>(null);
 
-  // Set initial form state
-  useEffect(() => {
-    if (isEdit && item) {
-      setVersionName(item.name);
-    } else {
-      setVersionName('');
-    }
+	useEffect(() => {
+		if (isEdit) {
+			setVersionName(item.name);
+		} else {
+			setVersionName(null);
+		}
+	}, [item, isEdit]);
 
-    // Delay focus to ensure sheet is fully open
-    const focusTimer = setTimeout(() => {
-      if (mountedRef.current && inputRef.current) {
-        inputRef.current.focus();
-      }
-    }, 300);
+	const handleSubmit = async () => {
+		if (versionName.trim().length <= 0) {
+			return;
+		}
 
-    // Cleanup on unmount
-    return () => {
-      mountedRef.current = false;
-      clearTimeout(focusTimer);
-    };
-  }, [isEdit, item]);
+		if (isEdit) {
+			await onUpdateVersion(item?.id, {
+				name: versionName
+			});
+		} else {
+			await onCreateVersion({
+				name: versionName,
+				color: '#FFFFFF'
+			});
+		}
 
-  // Use useCallback to prevent recreation of function on each render
-  const handleTextChange = useCallback((text: string) => {
-    setVersionName(text);
-  }, []);
+		setVersionName(null);
+		onDismiss();
+	};
 
-  // Use useCallback for submit handler
-  const handleSubmit = useCallback(async () => {
-    if (!versionName || versionName.trim().length <= 0) {
-      return;
-    }
+	return (
+		<View
+			style={{
+				backgroundColor: colors.background,
+				paddingHorizontal: 25,
+				paddingTop: 26,
+				paddingBottom: 40,
+				height: 452
+			}}
+		>
+			<Text style={{ ...styles.formTitle, color: colors.primary }}>
+				{translate('settingScreen.versionScreen.createNewVersionText')}
+			</Text>
+			<TextInput
+				style={{ ...styles.versionNameInput, color: colors.primary }}
+				placeholderTextColor={'#7B8089'}
+				placeholder={translate('settingScreen.versionScreen.versionNamePlaceholder')}
+				defaultValue={versionName}
+				onChangeText={(text) => setVersionName(text)}
+			/>
 
-    try {
-      if (isEdit) {
-        if (!item?.id) return;
-        await onUpdateVersion(item.id, {
-          name: versionName
-        });
-      } else {
-        await onCreateVersion({
-          name: versionName,
-          color: '#FFFFFF'
-        });
-      }
-
-      // Properly handle dismissal
-      Keyboard.dismiss();
-
-      // Small delay to ensure keyboard is dismissed
-      setTimeout(() => {
-        if (mountedRef.current) {
-          onDismiss();
-        }
-      }, 100);
-    } catch (error) {
-      console.error('Error submitting form:', error);
-    }
-  }, [isEdit, item, versionName, onUpdateVersion, onCreateVersion, onDismiss]);
-
-  // Use useCallback for cancel handler
-  const handleCancel = useCallback(() => {
-    Keyboard.dismiss();
-
-    setTimeout(() => {
-      if (mountedRef.current) {
-        onDismiss();
-      }
-    }, 100);
-  }, [onDismiss]);
-
-  return (
-    <View
-      style={{
-        backgroundColor: colors.background,
-        paddingHorizontal: 25,
-        paddingTop: 26,
-        paddingBottom: 40,
-        height: 452
-      }}
-    >
-      <Text style={{ ...styles.formTitle, color: colors.primary }}>
-        {translate('settingScreen.versionScreen.createNewVersionText')}
-      </Text>
-
-      <TextInput
-        ref={inputRef}
-        style={{ ...styles.versionNameInput, color: colors.primary }}
-        placeholderTextColor={'#7B8089'}
-        placeholder={translate('settingScreen.versionScreen.versionNamePlaceholder')}
-        value={versionName}
-        onChangeText={handleTextChange}
-        autoFocus={false} // Let our ref handle focus
-      />
-
-      <View style={{ ...styles.wrapButtons, marginTop: createVersionModal ? 20 : 40 }}>
-        <TouchableOpacity
-          style={styles.cancelBtn}
-          onPress={handleCancel}
-        >
-          <Text style={styles.cancelTxt}>{translate('settingScreen.versionScreen.cancelButtonText')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={{
-            ...styles.createBtn,
-            backgroundColor: dark ? '#6755C9' : '#3826A6',
-            opacity: !versionName ? 0.2 : 1
-          }}
-          onPress={handleSubmit}
-        >
-          <Text style={styles.createTxt}>
-            {isEdit
-              ? translate('settingScreen.versionScreen.updateButtonText')
-              : translate('settingScreen.versionScreen.createButtonText')}
-          </Text>
-        </TouchableOpacity>
-      </View>
-    </View>
-  );
-});
-
-// Name the component to help with debugging
-TaskVersionForm.displayName = 'TaskVersionForm';
+			<View style={{ ...styles.wrapButtons, marginTop: createVersionModal ? 20 : 40 }}>
+				<TouchableOpacity
+					style={styles.cancelBtn}
+					onPress={() => {
+						onDismiss();
+						Keyboard.dismiss();
+					}}
+				>
+					<Text style={styles.cancelTxt}>{translate('settingScreen.versionScreen.cancelButtonText')}</Text>
+				</TouchableOpacity>
+				<TouchableOpacity
+					style={{
+						...styles.createBtn,
+						backgroundColor: dark ? '#6755C9' : '#3826A6',
+						opacity: !versionName ? 0.2 : 1
+					}}
+					onPress={() => {
+						if (versionName) {
+							handleSubmit().finally(() => Keyboard.dismiss());
+						}
+					}}
+				>
+					<Text style={styles.createTxt}>
+						{isEdit
+							? translate('settingScreen.versionScreen.updateButtonText')
+							: translate('settingScreen.versionScreen.createButtonText')}
+					</Text>
+				</TouchableOpacity>
+			</View>
+		</View>
+	);
+};
 
 export default TaskVersionForm;
 
 const styles = StyleSheet.create({
-  cancelBtn: {
-    alignItems: 'center',
-    backgroundColor: '#E6E6E9',
-    borderRadius: 12,
-    height: 57,
-    justifyContent: 'center',
-    width: '48%'
-  },
-  cancelTxt: {
-    color: '#1A1C1E',
-    fontFamily: typography.primary.semiBold,
-    fontSize: 18
-  },
-  createBtn: {
-    alignItems: 'center',
-    backgroundColor: '#3826A6',
-    borderRadius: 12,
-    height: 57,
-    justifyContent: 'center',
-    width: '48%'
-  },
-  createTxt: {
-    color: '#FFF',
-    fontFamily: typography.primary.semiBold,
-    fontSize: 18
-  },
-  formTitle: {
-    color: '#1A1C1E',
-    fontFamily: typography.primary.semiBold,
-    fontSize: 24
-  },
-  versionNameInput: {
-    alignItems: 'center',
-    borderColor: '#DCE4E8',
-    borderRadius: 12,
-    borderWidth: 1,
-    height: 57,
-    marginTop: 16,
-    paddingHorizontal: 18,
-    width: '100%'
-  },
-  wrapButtons: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    width: '100%'
-  }
+	cancelBtn: {
+		alignItems: 'center',
+		backgroundColor: '#E6E6E9',
+		borderRadius: 12,
+		height: 57,
+		justifyContent: 'center',
+		width: '48%'
+	},
+	cancelTxt: {
+		color: '#1A1C1E',
+		fontFamily: typography.primary.semiBold,
+		fontSize: 18
+	},
+	createBtn: {
+		alignItems: 'center',
+		backgroundColor: '#3826A6',
+		borderRadius: 12,
+		height: 57,
+		justifyContent: 'center',
+		width: '48%'
+	},
+	createTxt: {
+		color: '#FFF',
+		fontFamily: typography.primary.semiBold,
+		fontSize: 18
+	},
+	formTitle: {
+		color: '#1A1C1E',
+		fontFamily: typography.primary.semiBold,
+		fontSize: 24
+	},
+	versionNameInput: {
+		alignItems: 'center',
+		borderColor: '#DCE4E8',
+		borderRadius: 12,
+		borderWidth: 1,
+		height: 57,
+		marginTop: 16,
+		paddingHorizontal: 18,
+		width: '100%'
+	},
+	wrapButtons: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+		width: '100%'
+	}
 });

--- a/apps/mobile/app/screens/Authenticated/TaskVersionScreen/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/TaskVersionScreen/index.tsx
@@ -61,7 +61,6 @@ export const TaskVersionScreen: FC<AuthenticatedDrawerScreenProps<'TaskVersion'>
 
   // Handle back navigation with the correct tab
   const handleGoBack = useCallback(() => {
-    // Now this is properly typed
     navigation.navigate('Setting', { activeTab: previousTab });
   }, [navigation, previousTab]);
 

--- a/apps/mobile/app/screens/Authenticated/TaskVersionScreen/index.tsx
+++ b/apps/mobile/app/screens/Authenticated/TaskVersionScreen/index.tsx
@@ -23,12 +23,28 @@ import { ITaskVersionItemList } from '../../../services/interfaces/ITaskVersion'
 import { BlurView } from 'expo-blur';
 import VersionItem from './components/VersionItem';
 import TaskVersionForm from './components/TaskVersionForm';
+import { useRoute, RouteProp } from '@react-navigation/native';
+
+// Create a type for the route params
+type TaskVersionRouteParams = {
+  previousTab?: 1 | 2; // Change to match the expected union type
+};
+
+// Properly type the route object
+type TaskVersionRouteProp = RouteProp<{ TaskVersion: TaskVersionRouteParams }, 'TaskVersion'>;
 
 export const TaskVersionScreen: FC<AuthenticatedDrawerScreenProps<'TaskVersion'>> = function AuthenticatedDrawerScreen(
   _props
 ) {
   const { colors, dark } = useAppTheme();
   const { navigation } = _props;
+
+  // Use the properly typed route
+  const route = useRoute<TaskVersionRouteProp>();
+
+  // Get the previousTab parameter or default to team tab (2) if not specified
+  // Now previousTab is explicitly typed as 1 | 2
+  const previousTab = route.params?.previousTab || 2 as const;
 
   const { isLoading, versions, deleteTaskVersion, updateTaskVersion, createTaskVersion } = useTaskVersion();
 
@@ -40,14 +56,16 @@ export const TaskVersionScreen: FC<AuthenticatedDrawerScreenProps<'TaskVersion'>
 
   const sheetRef = useRef<BottomSheet>(null);
 
-  // Define a single snap point for simplicity
+  // Use previous working snapPoints that showed the form correctly
   const snapPoints = useMemo(() => ['60%'], []);
 
-  // Modified to dismiss keyboard before opening the sheet
-  const openForEdit = useCallback((item: ITaskVersionItemList) => {
-    // First dismiss any existing keyboard
-    Keyboard.dismiss();
+  // Handle back navigation with the correct tab
+  const handleGoBack = useCallback(() => {
+    // Now this is properly typed
+    navigation.navigate('Setting', { activeTab: previousTab });
+  }, [navigation, previousTab]);
 
+  const openForEdit = useCallback((item: ITaskVersionItemList) => {
     setEditMode(true);
     setItemToEdit(item);
     setBottomSheetVisible(true);
@@ -60,11 +78,7 @@ export const TaskVersionScreen: FC<AuthenticatedDrawerScreenProps<'TaskVersion'>
     }, 150);
   }, []);
 
-  // Modified to dismiss keyboard before opening the sheet
   const handleCreateNew = useCallback(() => {
-    // First dismiss any existing keyboard
-    Keyboard.dismiss();
-
     setEditMode(false);
     setItemToEdit(null);
     setBottomSheetVisible(true);
@@ -77,11 +91,7 @@ export const TaskVersionScreen: FC<AuthenticatedDrawerScreenProps<'TaskVersion'>
     }, 150);
   }, []);
 
-  // Modified to ensure keyboard is dismissed first
   const handleClose = useCallback(() => {
-    // First dismiss keyboard
-    Keyboard.dismiss();
-
     if (sheetRef.current) {
       sheetRef.current.close();
     }
@@ -89,26 +99,21 @@ export const TaskVersionScreen: FC<AuthenticatedDrawerScreenProps<'TaskVersion'>
     // Clear state after animation completes
     setTimeout(() => {
       setBottomSheetVisible(false);
+      Keyboard.dismiss();
     }, 250);
   }, []);
 
   // Clean up on unmount
   useEffect(() => {
     return () => {
-      Keyboard.dismiss();
-      setBottomSheetVisible(false);
-
       if (sheetRef.current) {
         sheetRef.current.close();
       }
     };
   }, []);
 
-  // IMPORTANT CHANGE: Keyboard listeners only activate when bottom sheet is visible
+  // Keyboard listeners
   useEffect(() => {
-    // Only set up listeners if bottom sheet is visible
-    if (!bottomSheetVisible) return () => {};
-
     const keyboardWillShowListener = Keyboard.addListener(
       Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
       (e) => {
@@ -129,7 +134,7 @@ export const TaskVersionScreen: FC<AuthenticatedDrawerScreenProps<'TaskVersion'>
       keyboardWillShowListener.remove();
       keyboardWillHideListener.remove();
     };
-  }, [bottomSheetVisible]); // Only run when bottomSheetVisible changes
+  }, []);
 
   // Backdrop component
   const renderBackdrop = useCallback(
@@ -154,7 +159,7 @@ export const TaskVersionScreen: FC<AuthenticatedDrawerScreenProps<'TaskVersion'>
           <View style={[styles.container, { backgroundColor: colors.background }]}>
             <TouchableOpacity
               accessibilityRole="button"
-              onPress={() => navigation.navigate('Setting')}
+              onPress={handleGoBack} // Use our custom handler
             >
               <AntDesign name="arrowleft" size={24} color={colors.primary} />
             </TouchableOpacity>
@@ -253,11 +258,10 @@ export const TaskVersionScreen: FC<AuthenticatedDrawerScreenProps<'TaskVersion'>
           enablePanDownToClose={true}
           onClose={handleClose}
           backdropComponent={renderBackdrop}
-          enableContentPanningGesture={false} // Changed from true to false
-          keyboardBehavior="interactive" // Changed from "extend" to "interactive"
+          enableContentPanningGesture={true}
+          keyboardBehavior="extend"
           keyboardBlurBehavior="none"
           android_keyboardInputMode="adjustResize"
-          // handleHeight={30} // Set explicit handle height
           backgroundStyle={{
             backgroundColor: colors.background,
             shadowColor: '#000',
@@ -275,12 +279,13 @@ export const TaskVersionScreen: FC<AuthenticatedDrawerScreenProps<'TaskVersion'>
             marginTop: 10
           }}
         >
+          {/* Keep using BottomSheetScrollView to ensure the form is visible */}
           <BottomSheetScrollView
             style={{ backgroundColor: colors.background }}
             contentContainerStyle={{
-              padding: 0 // Changed from padding: 16
+              padding: 16
             }}
-            keyboardShouldPersistTaps="always" // Changed from "handled" to "always"
+            keyboardShouldPersistTaps="always"
             showsVerticalScrollIndicator={false}
           >
             {bottomSheetVisible && (

--- a/apps/mobile/app/services/client/requests/task-label.ts
+++ b/apps/mobile/app/services/client/requests/task-label.ts
@@ -3,69 +3,80 @@ import { ITaskLabelCreate, ITaskLabelItem } from '../../interfaces/ITaskLabel';
 import { serverFetch } from '../fetch';
 
 export function createLabelRequest({
-	datas,
-	bearer_token,
-	tenantId
+  datas,
+  bearer_token,
+  tenantId
 }: {
-	datas: ITaskLabelCreate;
-	bearer_token: string;
-	tenantId?: any;
+  datas: ITaskLabelCreate;
+  bearer_token: string;
+  tenantId?: any;
 }) {
-	return serverFetch<ITaskLabelItem>({
-		path: '/tags',
-		method: 'POST',
-		body: datas,
-		bearer_token,
-		tenantId
-	});
+  return serverFetch<ITaskLabelItem>({
+    path: '/tags',
+    method: 'POST',
+    body: datas,
+    bearer_token,
+    tenantId
+  });
 }
 
 export function updateTaskLabelsRequest({
-	id,
-	datas,
-	bearer_token,
-	tenantId
+  id,
+  datas,
+  bearer_token,
+  tenantId
 }: {
-	id: string | any;
-	datas: ITaskLabelCreate;
-	bearer_token: string;
-	tenantId?: any;
+  id: string | any;
+  datas: ITaskLabelCreate;
+  bearer_token: string;
+  tenantId?: any;
 }) {
-	return serverFetch<ITaskLabelItem>({
-		path: `/tags/${id}`,
-		method: 'PUT',
-		body: datas,
-		bearer_token,
-		tenantId
-	});
+  return serverFetch<ITaskLabelItem>({
+    path: `/tags/${id}`,
+    method: 'PUT',
+    body: datas,
+    bearer_token,
+    tenantId
+  });
 }
 
 export function deleteTaskLabelRequest({
-	id,
-	bearer_token,
-	tenantId
+  id,
+  bearer_token,
+  tenantId
 }: {
-	id: string | any;
-	bearer_token: string | any;
-	tenantId?: any;
+  id: string | any;
+  bearer_token: string | any;
+  tenantId?: any;
 }) {
-	return serverFetch<ITaskLabelItem>({
-		path: `/tags/${id}`,
-		method: 'DELETE',
-		bearer_token,
-		tenantId
-	});
+  return serverFetch<ITaskLabelItem>({
+    path: `/tags/${id}`,
+    method: 'DELETE',
+    bearer_token,
+    tenantId
+  });
 }
 
 export function getAllTaskLabelsRequest(
-	{ organizationId, tenantId }: { tenantId: string; organizationId: string },
-	bearer_token: string
+  { organizationId, tenantId }: { tenantId: string; organizationId: string },
+  bearer_token: string
 ) {
-	const data = `{"relations":["organization"],"findInput":{"tenantId":"${tenantId}","organizationId":"${organizationId}"}}`;
+  // Get activeTeamId from store
+  let activeTeamId;
+  try {
+    const { teamStore } = require('../../../models').useStores();
+    activeTeamId = teamStore.activeTeamId;
+  } catch (error) {
+    activeTeamId = null;
+  }
 
-	return serverFetch<PaginationResponse<ITaskLabelItem>>({
-		path: `/tags?data=${encodeURI(data)}&where[tenantId]=${tenantId}&where[organizationId]=${organizationId}`,
-		method: 'GET',
-		bearer_token
-	});
+  // Use the web-style endpoint with organizationTeamId parameter
+  const endpoint = `/tags/level?tenantId=${tenantId}&organizationId=${organizationId}${activeTeamId ? `&organizationTeamId=${activeTeamId}` : ''}`;
+
+  return serverFetch<PaginationResponse<ITaskLabelItem>>({
+    path: endpoint,
+    method: 'GET',
+    bearer_token,
+    tenantId
+  });
 }

--- a/apps/mobile/app/services/client/requests/task-label.ts
+++ b/apps/mobile/app/services/client/requests/task-label.ts
@@ -156,7 +156,7 @@ export async function getFilteredLabels(
 
 		// Example: Filter by active status
 		if (options?.filterByTeam && params.organizationTeamId) {
-			items = items.filter((item) => item.organizationTeamId === params.organizationTeamId);
+			items = items.filter((item) => item.organizationId === params.organizationTeamId);
 		}
 
 		return items;

--- a/apps/mobile/app/services/client/requests/task-label.ts
+++ b/apps/mobile/app/services/client/requests/task-label.ts
@@ -7,8 +7,8 @@ import { useStores } from '../../../models';
  * Request parameters interface for consistent typing
  */
 interface RequestParams {
-  bearer_token: string;
-  tenantId?: string;
+	bearer_token: string;
+	tenantId?: string;
 }
 
 /**
@@ -17,19 +17,19 @@ interface RequestParams {
  * @returns Promise with the created label
  */
 export function createLabelRequest({
-  datas,
-  bearer_token,
-  tenantId
+	datas,
+	bearer_token,
+	tenantId
 }: RequestParams & {
-  datas: ITaskLabelCreate;
+	datas: ITaskLabelCreate;
 }) {
-  return serverFetch<ITaskLabelItem>({
-    path: '/tags',
-    method: 'POST',
-    body: datas,
-    bearer_token,
-    tenantId
-  });
+	return serverFetch<ITaskLabelItem>({
+		path: '/tags',
+		method: 'POST',
+		body: datas,
+		bearer_token,
+		tenantId
+	});
 }
 
 /**
@@ -38,25 +38,25 @@ export function createLabelRequest({
  * @returns Promise with the updated label
  */
 export function updateTaskLabelsRequest({
-  id,
-  datas,
-  bearer_token,
-  tenantId
+	id,
+	datas,
+	bearer_token,
+	tenantId
 }: RequestParams & {
-  id: string;
-  datas: ITaskLabelCreate;
+	id: string;
+	datas: ITaskLabelCreate;
 }) {
-  if (!id) {
-    return Promise.reject(new Error('Label ID is required for update'));
-  }
+	if (!id) {
+		return Promise.reject(new Error('Label ID is required for update'));
+	}
 
-  return serverFetch<ITaskLabelItem>({
-    path: `/tags/${id}`,
-    method: 'PUT',
-    body: datas,
-    bearer_token,
-    tenantId
-  });
+	return serverFetch<ITaskLabelItem>({
+		path: `/tags/${id}`,
+		method: 'PUT',
+		body: datas,
+		bearer_token,
+		tenantId
+	});
 }
 
 /**
@@ -65,31 +65,31 @@ export function updateTaskLabelsRequest({
  * @returns Promise with the deletion result
  */
 export function deleteTaskLabelRequest({
-  id,
-  bearer_token,
-  tenantId
+	id,
+	bearer_token,
+	tenantId
 }: RequestParams & {
-  id: string;
+	id: string;
 }) {
-  if (!id) {
-    return Promise.reject(new Error('Label ID is required for deletion'));
-  }
+	if (!id) {
+		return Promise.reject(new Error('Label ID is required for deletion'));
+	}
 
-  return serverFetch<ITaskLabelItem>({
-    path: `/tags/${id}`,
-    method: 'DELETE',
-    bearer_token,
-    tenantId
-  });
+	return serverFetch<ITaskLabelItem>({
+		path: `/tags/${id}`,
+		method: 'DELETE',
+		bearer_token,
+		tenantId
+	});
 }
 
 /**
  * Parameters for fetching task labels
  */
 interface FetchLabelsParams {
-  organizationId: string;
-  tenantId: string;
-  organizationTeamId?: string;
+	organizationId: string;
+	tenantId: string;
+	organizationTeamId?: string;
 }
 
 /**
@@ -98,44 +98,41 @@ interface FetchLabelsParams {
  * @param bearer_token - Authentication token
  * @returns Promise with paginated list of labels
  */
-export function getAllTaskLabelsRequest(
-  { organizationId, tenantId }: FetchLabelsParams,
-  bearer_token: string
-) {
-  if (!organizationId || !tenantId) {
-    return Promise.reject(new Error('Organization ID and Tenant ID are required'));
-  }
+export function getAllTaskLabelsRequest({ organizationId, tenantId }: FetchLabelsParams, bearer_token: string) {
+	if (!organizationId || !tenantId) {
+		return Promise.reject(new Error('Organization ID and Tenant ID are required'));
+	}
 
-  // Get activeTeamId from store
-  let activeTeamId: string | null = null;
-  try {
-    // Use non-require approach to avoid potential circular dependencies
-    const stores = useStores();
-    activeTeamId = stores.teamStore.activeTeamId;
-  } catch (error) {
-    // Silent fail - will proceed without team ID
-  }
+	// Get activeTeamId from store
+	let activeTeamId: string | null = null;
+	try {
+		// Use non-require approach to avoid potential circular dependencies
+		const stores = useStores();
+		activeTeamId = stores.teamStore.activeTeamId;
+	} catch (error) {
+		// Silent fail - will proceed without team ID
+	}
 
-  // Build query parameters
-  const queryParams = new URLSearchParams({
-    tenantId,
-    organizationId
-  });
+	// Build query parameters
+	const queryParams = new URLSearchParams({
+		tenantId,
+		organizationId
+	});
 
-  // Only add team ID if it exists
-  if (activeTeamId) {
-    queryParams.append('organizationTeamId', activeTeamId);
-  }
+	// Only add team ID if it exists
+	if (activeTeamId) {
+		queryParams.append('organizationTeamId', activeTeamId);
+	}
 
-  // Use the web-style endpoint with organizationTeamId parameter
-  const endpoint = `/tags/level?${queryParams.toString()}`;
+	// Use the web-style endpoint with organizationTeamId parameter
+	const endpoint = `/tags/level?${queryParams.toString()}`;
 
-  return serverFetch<PaginationResponse<ITaskLabelItem>>({
-    path: endpoint,
-    method: 'GET',
-    bearer_token,
-    tenantId
-  });
+	return serverFetch<PaginationResponse<ITaskLabelItem>>({
+		path: endpoint,
+		method: 'GET',
+		bearer_token,
+		tenantId
+	});
 }
 
 /**
@@ -143,28 +140,28 @@ export function getAllTaskLabelsRequest(
  * This can be used if you need custom filtering or business logic
  */
 export async function getFilteredLabels(
-  params: FetchLabelsParams,
-  bearer_token: string,
-  options?: { filterByTeam?: boolean }
+	params: FetchLabelsParams,
+	bearer_token: string,
+	options?: { filterByTeam?: boolean }
 ): Promise<ITaskLabelItem[]> {
-  try {
-    const response = await getAllTaskLabelsRequest(params, bearer_token);
+	try {
+		const response = await getAllTaskLabelsRequest(params, bearer_token);
 
-    if (!response?.data?.items) {
-      return [];
-    }
+		if (!response?.data?.items) {
+			return [];
+		}
 
-    // Apply any additional filtering if needed
-    let items = response.data.items;
+		// Apply any additional filtering if needed
+		let items = response.data.items;
 
-    // Example: Filter by active status
-    if (options?.filterByTeam && params.organizationTeamId) {
-      items = items.filter(item => item.organizationId === params.organizationTeamId);
-    }
+		// Example: Filter by active status
+		if (options?.filterByTeam && params.organizationTeamId) {
+			items = items.filter((item) => item.organizationTeamId === params.organizationTeamId);
+		}
 
-    return items;
-  } catch (error) {
-    console.error('Error fetching filtered labels:', error);
-    return [];
-  }
+		return items;
+	} catch (error) {
+		console.error('Error fetching filtered labels:', error);
+		return [];
+	}
 }

--- a/apps/mobile/app/services/client/requests/task-label.ts
+++ b/apps/mobile/app/services/client/requests/task-label.ts
@@ -1,15 +1,27 @@
 import { PaginationResponse } from '../../interfaces/IDataResponse';
 import { ITaskLabelCreate, ITaskLabelItem } from '../../interfaces/ITaskLabel';
 import { serverFetch } from '../fetch';
+import { useStores } from '../../../models';
 
+/**
+ * Request parameters interface for consistent typing
+ */
+interface RequestParams {
+  bearer_token: string;
+  tenantId?: string;
+}
+
+/**
+ * Creates a new task label
+ * @param params - The request parameters
+ * @returns Promise with the created label
+ */
 export function createLabelRequest({
   datas,
   bearer_token,
   tenantId
-}: {
+}: RequestParams & {
   datas: ITaskLabelCreate;
-  bearer_token: string;
-  tenantId?: any;
 }) {
   return serverFetch<ITaskLabelItem>({
     path: '/tags',
@@ -20,17 +32,24 @@ export function createLabelRequest({
   });
 }
 
+/**
+ * Updates an existing task label
+ * @param params - The request parameters including label ID and data
+ * @returns Promise with the updated label
+ */
 export function updateTaskLabelsRequest({
   id,
   datas,
   bearer_token,
   tenantId
-}: {
-  id: string | any;
+}: RequestParams & {
+  id: string;
   datas: ITaskLabelCreate;
-  bearer_token: string;
-  tenantId?: any;
 }) {
+  if (!id) {
+    return Promise.reject(new Error('Label ID is required for update'));
+  }
+
   return serverFetch<ITaskLabelItem>({
     path: `/tags/${id}`,
     method: 'PUT',
@@ -40,15 +59,22 @@ export function updateTaskLabelsRequest({
   });
 }
 
+/**
+ * Deletes a task label
+ * @param params - The request parameters including label ID
+ * @returns Promise with the deletion result
+ */
 export function deleteTaskLabelRequest({
   id,
   bearer_token,
   tenantId
-}: {
-  id: string | any;
-  bearer_token: string | any;
-  tenantId?: any;
+}: RequestParams & {
+  id: string;
 }) {
+  if (!id) {
+    return Promise.reject(new Error('Label ID is required for deletion'));
+  }
+
   return serverFetch<ITaskLabelItem>({
     path: `/tags/${id}`,
     method: 'DELETE',
@@ -57,21 +83,52 @@ export function deleteTaskLabelRequest({
   });
 }
 
+/**
+ * Parameters for fetching task labels
+ */
+interface FetchLabelsParams {
+  organizationId: string;
+  tenantId: string;
+  organizationTeamId?: string;
+}
+
+/**
+ * Gets the list of task labels using the web-compatible endpoint
+ * @param params - The request parameters
+ * @param bearer_token - Authentication token
+ * @returns Promise with paginated list of labels
+ */
 export function getAllTaskLabelsRequest(
-  { organizationId, tenantId }: { tenantId: string; organizationId: string },
+  { organizationId, tenantId }: FetchLabelsParams,
   bearer_token: string
 ) {
+  if (!organizationId || !tenantId) {
+    return Promise.reject(new Error('Organization ID and Tenant ID are required'));
+  }
+
   // Get activeTeamId from store
-  let activeTeamId;
+  let activeTeamId: string | null = null;
   try {
-    const { teamStore } = require('../../../models').useStores();
-    activeTeamId = teamStore.activeTeamId;
+    // Use non-require approach to avoid potential circular dependencies
+    const stores = useStores();
+    activeTeamId = stores.teamStore.activeTeamId;
   } catch (error) {
-    activeTeamId = null;
+    // Silent fail - will proceed without team ID
+  }
+
+  // Build query parameters
+  const queryParams = new URLSearchParams({
+    tenantId,
+    organizationId
+  });
+
+  // Only add team ID if it exists
+  if (activeTeamId) {
+    queryParams.append('organizationTeamId', activeTeamId);
   }
 
   // Use the web-style endpoint with organizationTeamId parameter
-  const endpoint = `/tags/level?tenantId=${tenantId}&organizationId=${organizationId}${activeTeamId ? `&organizationTeamId=${activeTeamId}` : ''}`;
+  const endpoint = `/tags/level?${queryParams.toString()}`;
 
   return serverFetch<PaginationResponse<ITaskLabelItem>>({
     path: endpoint,
@@ -79,4 +136,35 @@ export function getAllTaskLabelsRequest(
     bearer_token,
     tenantId
   });
+}
+
+/**
+ * Higher-level function that returns appropriate labels based on context
+ * This can be used if you need custom filtering or business logic
+ */
+export async function getFilteredLabels(
+  params: FetchLabelsParams,
+  bearer_token: string,
+  options?: { filterByTeam?: boolean }
+): Promise<ITaskLabelItem[]> {
+  try {
+    const response = await getAllTaskLabelsRequest(params, bearer_token);
+
+    if (!response?.data?.items) {
+      return [];
+    }
+
+    // Apply any additional filtering if needed
+    let items = response.data.items;
+
+    // Example: Filter by active status
+    if (options?.filterByTeam && params.organizationTeamId) {
+      items = items.filter(item => item.organizationId === params.organizationTeamId);
+    }
+
+    return items;
+  } catch (error) {
+    console.error('Error fetching filtered labels:', error);
+    return [];
+  }
 }

--- a/apps/mobile/app/services/hooks/features/useTaskLabels.ts
+++ b/apps/mobile/app/services/hooks/features/useTaskLabels.ts
@@ -46,13 +46,24 @@ export function useTaskLabels() {
 
 	// Create the label
 	const createLabel = useCallback(async (data: ITaskStatusCreate) => {
-		await createLabelRequest({
+
+		try {
+		  // Create the label request object with full logging
+		  const requestData = {
 			tenantId,
 			datas: { ...data, organizationId, organizationTeamId: activeTeamId },
 			bearer_token: authToken
-		});
-		queryClient.invalidateQueries({ queryKey: ['labels'] });
-	}, [authToken, tenantId, organizationId, activeTeamId, queryClient]);
+		  };
+
+		  // Make the request
+		  const response = await createLabelRequest(requestData);
+		  queryClient.invalidateQueries({ queryKey: ['labels'] });
+		  return response;
+		} catch (error) {
+		  console.error('[useTaskLabels] Create label error:', error);
+		  throw error;
+		}
+	  }, [authToken, tenantId, organizationId, activeTeamId, queryClient]);
 
 	useEffect(() => {
 		if (isSuccess) {

--- a/apps/mobile/app/services/hooks/features/useTaskLabels.ts
+++ b/apps/mobile/app/services/hooks/features/useTaskLabels.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useStores } from '../../../models';
 import useFetchAllLabels from '../../client/queries/task/task-labels';
@@ -6,79 +6,143 @@ import { createLabelRequest, deleteTaskLabelRequest, updateTaskLabelsRequest } f
 import { ITaskLabelItem } from '../../interfaces/ITaskLabel';
 import { ITaskStatusCreate } from '../../interfaces/ITaskStatus';
 
+/**
+ * Hook for managing task labels with CRUD operations
+ * @returns Object containing labels data and operations
+ */
 export function useTaskLabels() {
-	const queryClient = useQueryClient();
-	const {
-		authenticationStore: { authToken, tenantId, organizationId },
-		teamStore: { activeTeamId }
-	} = useStores();
+  const queryClient = useQueryClient();
+  const {
+    authenticationStore: { authToken, tenantId, organizationId },
+    teamStore: { activeTeamId }
+  } = useStores();
 
-	const [allTaskLabels, setAllTaskLabels] = useState<ITaskLabelItem[]>([]);
-	const {
-		data: labels,
-		isLoading,
-		isSuccess,
-		isRefetching
-	} = useFetchAllLabels({ tenantId, organizationId, authToken });
+  // State to store task labels
+  const [allTaskLabels, setAllTaskLabels] = useState<ITaskLabelItem[]>([]);
 
-	// Delete the label
-	const deleteLabel = useCallback(async (id: string) => {
-		await deleteTaskLabelRequest({
-			id,
-			tenantId,
-			bearer_token: authToken
-		});
-		queryClient.invalidateQueries({ queryKey: ['labels'] });
-	}, [authToken, tenantId, queryClient]);
+  // Fetch labels using React Query hook
+  const {
+    data: labels,
+    isLoading,
+    isSuccess,
+    isRefetching,
+    refetch
+  } = useFetchAllLabels({
+    tenantId,
+    organizationId,
+    authToken
+  });
 
-	// Update the label
-	// Changed to extract id and data properties from a single parameter object
-	const updateLabel = useCallback(async (labelData: ITaskLabelItem) => {
-		const { id, ...data } = labelData;
-		await updateTaskLabelsRequest({
-			id,
-			tenantId,
-			datas: data as ITaskStatusCreate,
-			bearer_token: authToken
-		});
-		queryClient.invalidateQueries({ queryKey: ['labels'] });
-	}, [authToken, tenantId, queryClient]);
+  /**
+   * Invalidates queries and refreshes data
+   */
+  const refreshLabels = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['labels'] });
+    refetch();
+  }, [queryClient, refetch]);
 
-	// Create the label
-	const createLabel = useCallback(async (data: ITaskStatusCreate) => {
+  /**
+   * Delete a task label by ID
+   * @param id - The ID of the label to delete
+   */
+  const deleteLabel = useCallback(async (id: string) => {
+    if (!id) {
+      throw new Error('Label ID is required for deletion');
+    }
 
-		try {
-		  // Create the label request object with full logging
-		  const requestData = {
-			tenantId,
-			datas: { ...data, organizationId, organizationTeamId: activeTeamId },
-			bearer_token: authToken
-		  };
+    try {
+      await deleteTaskLabelRequest({
+        id,
+        tenantId,
+        bearer_token: authToken
+      });
+      refreshLabels();
+    } catch (error) {
+      console.error('Error deleting label:', error);
+      throw error;
+    }
+  }, [authToken, tenantId, refreshLabels]);
 
-		  // Make the request
-		  const response = await createLabelRequest(requestData);
-		  queryClient.invalidateQueries({ queryKey: ['labels'] });
-		  return response;
-		} catch (error) {
-		  console.error('[useTaskLabels] Create label error:', error);
-		  throw error;
-		}
-	  }, [authToken, tenantId, organizationId, activeTeamId, queryClient]);
+  /**
+   * Update an existing task label
+   * @param labelData - Label data with ID and properties to update
+   */
+  const updateLabel = useCallback(async (labelData: ITaskLabelItem) => {
+    if (!labelData?.id) {
+      throw new Error('Label ID is required for update');
+    }
 
-	useEffect(() => {
-		if (isSuccess) {
-			if (labels) {
-				setAllTaskLabels(labels.items || []);
-			}
-		}
-	}, [isLoading, isRefetching, isSuccess, labels]);
+    try {
+      const { id, ...data } = labelData;
+      await updateTaskLabelsRequest({
+        id,
+        tenantId,
+        datas: data as ITaskStatusCreate,
+        bearer_token: authToken
+      });
+      refreshLabels();
+    } catch (error) {
+      console.error('Error updating label:', error);
+      throw error;
+    }
+  }, [authToken, tenantId, refreshLabels]);
 
-	return {
-		labels,
-		isLoading,
-		deleteLabel,
-		updateLabel,
-		createLabel,
-		allTaskLabels
-	};
+  /**
+   * Create a new task label
+   * @param data - Label properties
+   * @returns The created label object
+   */
+  const createLabel = useCallback(async (data: ITaskStatusCreate) => {
+    if (!data || !tenantId || !organizationId || !activeTeamId) {
+      throw new Error('Missing required data for label creation');
+    }
+
+    try {
+      const requestData = {
+        tenantId,
+        datas: {
+          ...data,
+          organizationId,
+          organizationTeamId: activeTeamId
+        },
+        bearer_token: authToken
+      };
+
+      const response = await createLabelRequest(requestData);
+      refreshLabels();
+      return response;
+    } catch (error) {
+      console.error('Error creating label:', error);
+      throw error;
+    }
+  }, [authToken, tenantId, organizationId, activeTeamId, refreshLabels]);
+
+  // Update local state when query data changes
+  useEffect(() => {
+    if (isSuccess && labels?.items) {
+      setAllTaskLabels(labels.items);
+    }
+  }, [isSuccess, labels]);
+
+  // Memoize the returned data to prevent unnecessary re-renders
+  const returnData = useMemo(() => ({
+    labels,
+    isLoading: isLoading || isRefetching,
+    deleteLabel,
+    updateLabel,
+    createLabel,
+    allTaskLabels,
+    refreshLabels
+  }), [
+    labels,
+    isLoading,
+    isRefetching,
+    deleteLabel,
+    updateLabel,
+    createLabel,
+    allTaskLabels,
+    refreshLabels
+  ]);
+
+  return returnData;
 }

--- a/apps/mobile/app/services/hooks/features/useTaskLabels.ts
+++ b/apps/mobile/app/services/hooks/features/useTaskLabels.ts
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useStores } from '../../../models';
 import useFetchAllLabels from '../../client/queries/task/task-labels';
 import { createLabelRequest, deleteTaskLabelRequest, updateTaskLabelsRequest } from '../../client/requests/task-label';
-import { ITaskLabelItem } from '../../interfaces/ITaskLabel';
+import { ITaskLabelCreate, ITaskLabelItem } from '../../interfaces/ITaskLabel';
 import { ITaskStatusCreate } from '../../interfaces/ITaskStatus';
 
 /**
@@ -77,7 +77,7 @@ export function useTaskLabels() {
       await updateTaskLabelsRequest({
         id,
         tenantId,
-        datas: data as ITaskStatusCreate,
+        datas: data as ITaskLabelCreate,
         bearer_token: authToken
       });
       refreshLabels();
@@ -92,8 +92,8 @@ export function useTaskLabels() {
    * @param data - Label properties
    * @returns The created label object
    */
-  const createLabel = useCallback(async (data: ITaskStatusCreate) => {
-    if (!data || !tenantId || !organizationId || !activeTeamId) {
+  const createLabel = useCallback(async (data: ITaskLabelCreate) => {
+    if (!data || !tenantId || !organizationId) {
       throw new Error('Missing required data for label creation');
     }
 
@@ -103,7 +103,7 @@ export function useTaskLabels() {
         datas: {
           ...data,
           organizationId,
-          organizationTeamId: activeTeamId
+		  ...(activeTeamId ? { organizationTeamId: activeTeamId } : {})
         },
         bearer_token: authToken
       };

--- a/apps/mobile/app/services/hooks/features/useTaskLabels.ts
+++ b/apps/mobile/app/services/hooks/features/useTaskLabels.ts
@@ -4,7 +4,7 @@ import { useStores } from '../../../models';
 import useFetchAllLabels from '../../client/queries/task/task-labels';
 import { createLabelRequest, deleteTaskLabelRequest, updateTaskLabelsRequest } from '../../client/requests/task-label';
 import { ITaskLabelCreate, ITaskLabelItem } from '../../interfaces/ITaskLabel';
-import { ITaskStatusCreate } from '../../interfaces/ITaskStatus';
+// import { ITaskStatusCreate } from '../../interfaces/ITaskStatus';
 
 /**
  * Hook for managing task labels with CRUD operations


### PR DESCRIPTION
# Fix Task Labels Endpoint and Team Settings Navigation

## Description
This PR addresses two issues:
1. Fixed the endpoint for fetching task labels to match the web implementation
2. Enhanced team settings navigation to maintain the active tab when returning from child screens

The key change was updating the API endpoint for task labels from `/tags?data=...` to `/tags/level?...` and including the `organizationTeamId` parameter, which ensures that team-specific labels are correctly fetched and displayed in the mobile app.

Additionally, implemented tab persistence when navigating between settings and task-related screens, maintaining the same active tab when returning to the settings screen.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Previous screen record of the navigation issue
Before this fix, navigation back to teams setting wasn't working:

https://github.com/user-attachments/assets/350abf33-f4d2-4a81-b80b-fe6cfdecb373


## Current screen record of the navigation issue
After the fix, navigation back to teams setting now works perfectly:

https://github.com/user-attachments/assets/54ff797c-7a29-4991-a75a-d0e28a62c031




## Previous screen record of the fetch tasks labels issue
Before this fix, task labels created in the app were not visible in the label list:

https://github.com/user-attachments/assets/101f07b7-737f-4fe3-a2a4-f167aead419b



## Current screen record of  the fetch tasks labels issue
After the fix, labels created in the app now appear in the list:

https://github.com/user-attachments/assets/e4194b9b-e021-4cc4-84b4-543bfa2601c3


## Technical Details

### Task Labels Endpoint Fix
Updated the `getAllTaskLabelsRequest` function to use the same endpoint structure as the web implementation:

```javascript
export function getAllTaskLabelsRequest(
 { organizationId, tenantId }: { tenantId: string; organizationId: string },
 bearer_token: string
) {
 // Get activeTeamId from store
 let activeTeamId;
 try {
   const { teamStore } = require('../../../models').useStores();
   activeTeamId = teamStore.activeTeamId;
 } catch (error) {
   activeTeamId = null;
 }

 // Use the web-style endpoint with organizationTeamId parameter
 const endpoint = `/tags/level?tenantId=${tenantId}&organizationId=${organizationId}${activeTeamId ? `&organizationTeamId=${activeTeamId}` : ''}`;

 return serverFetch<PaginationResponse<ITaskLabelItem>>({
   path: endpoint,
   method: 'GET',
   bearer_token,
   tenantId
 });
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved navigation between settings and task-related screens, allowing screens to remember and restore the previously active tab.
  - Enhanced back navigation on task-related screens to return users to the correct tab in settings.

- **Improvements**
  - Refined keyboard and bottom sheet interactions for a smoother user experience.
  - Adjusted UI padding and gesture settings for better usability in task version screens.
  - More context-aware fetching of task labels based on the active team.
  - Simplified task version form for better performance and maintainability.
  - Improved state synchronization between navigation parameters and settings tabs.

- **Bug Fixes**
  - Enhanced error handling and logging when creating, updating, or deleting task labels.

- **Technical Enhancements**
  - Increased type safety and consistency across navigation and route parameters.
  - Centralized label data refreshing and optimized hook performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->