### PR TITLE
[Refactor] Separate jotai state updates from react query

### DIFF
--- a/apps/web/core/hooks/common/use-has-mounted.ts
+++ b/apps/web/core/hooks/common/use-has-mounted.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export const useHasMounted = () => {
 	const [mounted, setMounted] = useState<boolean>(false);
@@ -10,4 +10,36 @@ export const useHasMounted = () => {
 	}, []);
 
 	return { mounted };
+};
+
+/**
+ * Custom hook that executes a callback on dependency changes with conditional first render execution.
+ * The condition is evaluated dynamically on each render.
+ *
+ * @param callback - The function to execute when dependencies change
+ * @param dependencies - Array of dependencies to watch for changes
+ * @param shouldSkipFirstRender - Whether to skip the first render
+ */
+export const useConditionalUpdateEffect = (
+	callback: () => void | (() => void),
+	dependencies: React.DependencyList,
+	shouldSkipFirstRender: boolean | (() => boolean)
+) => {
+	const isFirstRender = useRef(true);
+
+	useEffect(() => {
+		const skipFirst = typeof shouldSkipFirstRender === 'function' ? shouldSkipFirstRender() : shouldSkipFirstRender;
+
+		if (skipFirst && isFirstRender.current) {
+			isFirstRender.current = false;
+			return;
+		}
+
+		// If we're not skipping first render, we still need to track it for subsequent calls
+		if (isFirstRender.current) {
+			isFirstRender.current = false;
+		}
+
+		return callback();
+	}, dependencies);
 };

--- a/apps/web/core/hooks/roles/use-role-permissions.ts
+++ b/apps/web/core/hooks/roles/use-role-permissions.ts
@@ -17,7 +17,8 @@ export const useRolePermissions = (roleId?: string) => {
 	const rolePermissionsQuery = useQuery({
 		queryKey: queryKeys.roles.permissions(roleId!),
 		queryFn: () => {
-			return rolePermissionService.getRolePermission(roleId!);
+			if (!roleId) return null;
+			return rolePermissionService.getRolePermission(roleId);
 		},
 		enabled: !!roleId
 	});

--- a/apps/web/core/hooks/roles/use-role-permissions.ts
+++ b/apps/web/core/hooks/roles/use-role-permissions.ts
@@ -17,9 +17,9 @@ export const useRolePermissions = (roleId?: string) => {
 	const rolePermissionsQuery = useQuery({
 		queryKey: queryKeys.roles.permissions(roleId!),
 		queryFn: () => {
-			if (!roleId) return null;
-			return rolePermissionService.getRolePermission(roleId);
-		}
+			return rolePermissionService.getRolePermission(roleId!);
+		},
+		enabled: !!roleId
 	});
 
 	// Mutation for updating role permissions

--- a/apps/web/core/hooks/roles/use-role-permissions.ts
+++ b/apps/web/core/hooks/roles/use-role-permissions.ts
@@ -59,7 +59,7 @@ export const useRolePermissions = (roleId?: string) => {
 			}
 		},
 		[rolePermissionsQuery.data],
-		Boolean(rolePermissions) || !rolePermissionsQuery.isFetching
+		Boolean(rolePermissions?.length)
 	);
 
 	// For backward compatibility

--- a/apps/web/core/hooks/roles/use-role-permissions.ts
+++ b/apps/web/core/hooks/roles/use-role-permissions.ts
@@ -6,6 +6,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { rolePermissionService } from '@/core/services/client/api/roles/role-permission.service';
 import { TRolePermission } from '@/core/types/schemas/role/role-permission-schema';
 import { queryKeys } from '@/core/query/keys';
+import { useConditionalUpdateEffect } from '../common';
 
 export const useRolePermissions = (roleId?: string) => {
 	const [rolePermissions, setRolePermissions] = useAtom(rolePermissionsState);
@@ -17,18 +18,7 @@ export const useRolePermissions = (roleId?: string) => {
 		queryKey: queryKeys.roles.permissions(roleId!),
 		queryFn: () => {
 			if (!roleId) return null;
-			return rolePermissionService.getRolePermission(roleId).then((response) => {
-				if (response?.items?.length) {
-					const tempRolePermissions = response.items;
-					const formatedItems: { [key: string]: TRolePermission } = {};
-
-					tempRolePermissions.forEach((item: TRolePermission) => {
-						formatedItems[item.permission] = item;
-					});
-					setRolePermissionsFormated(formatedItems);
-					setRolePermissions(tempRolePermissions);
-				}
-			});
+			return rolePermissionService.getRolePermission(roleId);
 		}
 	});
 
@@ -54,6 +44,23 @@ export const useRolePermissions = (roleId?: string) => {
 			}
 		}
 	});
+
+	useConditionalUpdateEffect(
+		() => {
+			if (rolePermissionsQuery.data?.items?.length) {
+				const tempRolePermissions = rolePermissionsQuery.data.items;
+				const formatedItems: { [key: string]: TRolePermission } = {};
+
+				tempRolePermissions.forEach((item: TRolePermission) => {
+					formatedItems[item.permission] = item;
+				});
+				setRolePermissionsFormated(formatedItems);
+				setRolePermissions(tempRolePermissions);
+			}
+		},
+		[rolePermissionsQuery.data],
+		Boolean(rolePermissions) || !rolePermissionsQuery.isFetching
+	);
 
 	// For backward compatibility
 	const getRolePermissions = useCallback(

--- a/apps/web/core/hooks/roles/use-roles.ts
+++ b/apps/web/core/hooks/roles/use-roles.ts
@@ -45,7 +45,7 @@ export const useRoles = () => {
 			}
 		},
 		[rolesQuery.data],
-		Boolean(roles) || !rolesQuery.isFetching
+		Boolean(roles?.length)
 	);
 
 	return {

--- a/apps/web/core/hooks/roles/use-roles.ts
+++ b/apps/web/core/hooks/roles/use-roles.ts
@@ -11,10 +11,12 @@ export const useRoles = () => {
 
 	const rolesQuery = useQuery({
 		queryKey: queryKeys.roles.all,
-		queryFn: () =>
-			roleService.getRoles().then((response) => {
+		queryFn: async () => {
+			const response = await roleService.getRoles();
+			if (response) {
 				return response;
-			})
+			}
+		}
 	});
 
 	const createRoleMutation = useMutation({

--- a/apps/web/core/hooks/tags/use-tags.ts
+++ b/apps/web/core/hooks/tags/use-tags.ts
@@ -4,6 +4,7 @@ import { tagsState } from '@/core/stores/tags/tags';
 import { tagService } from '@/core/services/client/api';
 import { queryKeys } from '@/core/query/keys';
 import { useConditionalUpdateEffect } from '../common';
+import { useCallback } from 'react';
 
 export const useTags = () => {
 	const [tags, setTags] = useAtom(tagsState);
@@ -13,26 +14,23 @@ export const useTags = () => {
 		queryKey: queryKeys.tags.all,
 		queryFn: tagService.getTags
 	});
-
+	const invalidateTagsData = useCallback(
+		() => queryClient.invalidateQueries({ queryKey: queryKeys.tags.all }),
+		[queryClient]
+	);
 	const createTagMutation = useMutation({
 		mutationFn: tagService.createTag,
-		onSuccess: (tag) => {
-			queryClient.invalidateQueries({ queryKey: queryKeys.tags.all });
-		}
+		onSuccess: invalidateTagsData
 	});
 
 	const updateTagMutation = useMutation({
 		mutationFn: tagService.updateTag,
-		onSuccess: (tag) => {
-			queryClient.invalidateQueries({ queryKey: queryKeys.tags.all });
-		}
+		onSuccess: invalidateTagsData
 	});
 
 	const deleteTagMutation = useMutation({
 		mutationFn: tagService.deleteTag,
-		onSuccess: (_, id) => {
-			queryClient.invalidateQueries({ queryKey: queryKeys.tags.all });
-		}
+		onSuccess: invalidateTagsData
 	});
 
 	useConditionalUpdateEffect(
@@ -48,7 +46,7 @@ export const useTags = () => {
 	return {
 		tags,
 		loading: tagsQuery.isLoading,
-		getTags: () => queryClient.invalidateQueries({ queryKey: queryKeys.tags.all }),
+		getTags: invalidateTagsData,
 
 		createTag: createTagMutation.mutate,
 		createTagLoading: createTagMutation.isPending,

--- a/apps/web/core/hooks/tags/use-tags.ts
+++ b/apps/web/core/hooks/tags/use-tags.ts
@@ -45,7 +45,7 @@ export const useTags = () => {
 			}
 		},
 		[tagsQuery.data],
-		Boolean(tags) || !tagsQuery.isFetching
+		Boolean(tags?.length)
 	);
 
 	return {

--- a/apps/web/core/hooks/tags/use-tags.ts
+++ b/apps/web/core/hooks/tags/use-tags.ts
@@ -11,10 +11,7 @@ export const useTags = () => {
 
 	const tagsQuery = useQuery({
 		queryKey: queryKeys.tags.all,
-		queryFn: () =>
-			tagService.getTags().then((response) => {
-				return response;
-			})
+		queryFn: tagService.getTags
 	});
 
 	const createTagMutation = useMutation({

--- a/apps/web/core/hooks/tasks/use-issue-types.ts
+++ b/apps/web/core/hooks/tasks/use-issue-types.ts
@@ -60,7 +60,7 @@ export function useIssueType() {
 			}
 		},
 		[issueTypesQuery.data],
-		Boolean(issueTypes)
+		Boolean(issueTypes?.length)
 	);
 
 	// Mutations

--- a/apps/web/core/hooks/tasks/use-issue-types.ts
+++ b/apps/web/core/hooks/tasks/use-issue-types.ts
@@ -1,6 +1,6 @@
 'use client';
 import { userState, issueTypesListState, activeTeamIdState } from '@/core/stores';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useFirstLoad } from '../common/use-first-load';
@@ -9,7 +9,7 @@ import { IIssueTypesCreate } from '@/core/types/interfaces/task/issue-type';
 import { queryKeys } from '@/core/query/keys';
 import { useAuthenticateUser } from '../auth';
 import { useOrganizationTeams } from '../organizations';
-import isEqual from 'lodash/isEqual';
+import { useConditionalUpdateEffect } from '../common';
 
 export function useIssueType() {
 	const [user] = useAtom(userState);
@@ -21,7 +21,7 @@ export function useIssueType() {
 	const [issueTypes, setIssueTypes] = useAtom(issueTypesListState);
 	const { firstLoadData: firstLoadIssueTypeData } = useFirstLoad();
 
-	// PERFORMANCE OPTIMIZATION: Memoize derived values to avoid recalculation on every render
+	//  Memoize derived values to avoid recalculation on every render
 	const organizationId = useMemo(
 		() => authUser?.employee?.organizationId || user?.employee?.organizationId,
 		[authUser?.employee?.organizationId, user?.employee?.organizationId]
@@ -34,8 +34,7 @@ export function useIssueType() {
 
 	const teamId = useMemo(() => activeTeam?.id || activeTeamId, [activeTeam?.id, activeTeamId]);
 
-	// useQuery for fetching issue types
-	// PERFORMANCE OPTIMIZATION: Removed setState from queryFn to follow React Query best practices
+	//  Removed setState from queryFn to follow React Query best practices
 	const issueTypesQuery = useQuery({
 		queryKey: queryKeys.issueTypes.byTeam(teamId),
 		queryFn: async () => {
@@ -52,18 +51,17 @@ export function useIssueType() {
 		gcTime: 1000 * 60 * 15 // Keep in cache for 15 minutes
 	});
 
-	// PERFORMANCE OPTIMIZATION: Sync React Query data with Jotai state using useEffect
+	//  Sync React Query data with Jotai state using useEffect
 	// This replaces the setState in queryFn and follows React Query best practices
-	// DEEP EQUAL COMPARISON: Important for application context to avoid unnecessary updates
-	useEffect(() => {
-		if (issueTypesQuery.data?.items) {
-			// Deep comparison to prevent unnecessary state updates
-			// This is important for the application context as requested
-			if (!isEqual(issueTypesQuery.data.items, issueTypes)) {
+	useConditionalUpdateEffect(
+		() => {
+			if (issueTypesQuery.data) {
 				setIssueTypes(issueTypesQuery.data.items);
 			}
-		}
-	}, [issueTypesQuery.data?.items, issueTypes, setIssueTypes]);
+		},
+		[issueTypesQuery.data],
+		Boolean(issueTypes)
+	);
 
 	// Mutations
 	const createIssueTypeMutation = useMutation({

--- a/apps/web/core/hooks/tasks/use-task-labels.ts
+++ b/apps/web/core/hooks/tasks/use-task-labels.ts
@@ -37,7 +37,8 @@ export function useTaskLabels() {
 			}
 			const res = await taskLabelService.getTaskLabelsList(tenantId, organizationId, teamId);
 			return res.data;
-		}
+		},
+		enabled: !!tenantId && !!organizationId && !!teamId
 	});
 
 	// Mutations

--- a/apps/web/core/hooks/tasks/use-task-labels.ts
+++ b/apps/web/core/hooks/tasks/use-task-labels.ts
@@ -89,7 +89,7 @@ export function useTaskLabels() {
 			}
 		},
 		[taskLabelsQuery.data],
-		Boolean(taskLabels)
+		Boolean(taskLabels?.length)
 	);
 
 	const loadTaskLabels = useCallback(async () => {

--- a/apps/web/core/hooks/tasks/use-task-labels.ts
+++ b/apps/web/core/hooks/tasks/use-task-labels.ts
@@ -11,6 +11,7 @@ import { ITagCreate } from '@/core/types/interfaces/tag/tag';
 import { queryKeys } from '@/core/query/keys';
 import { useAuthenticateUser } from '../auth';
 import { useOrganizationTeams } from '../organizations';
+import { useConditionalUpdateEffect } from '../common';
 
 export function useTaskLabels() {
 	const [user] = useAtom(userState);
@@ -35,10 +36,7 @@ export function useTaskLabels() {
 				throw new Error('Required parameters missing: tenantId, organizationId, and teamId are required');
 			}
 			const res = await taskLabelService.getTaskLabelsList(tenantId, organizationId, teamId);
-
-			setTaskLabels(res.data.items);
-
-			return res;
+			return res.data;
 		}
 	});
 
@@ -83,6 +81,16 @@ export function useTaskLabels() {
 				});
 		}
 	});
+
+	useConditionalUpdateEffect(
+		() => {
+			if (taskLabelsQuery.data) {
+				setTaskLabels(taskLabelsQuery.data.items);
+			}
+		},
+		[taskLabelsQuery.data],
+		Boolean(taskLabels)
+	);
 
 	const loadTaskLabels = useCallback(async () => {
 		return taskLabelsQuery.data;

--- a/apps/web/core/hooks/tasks/use-task-priorities.ts
+++ b/apps/web/core/hooks/tasks/use-task-priorities.ts
@@ -38,7 +38,8 @@ export function useTaskPriorities() {
 
 			const res = await taskPriorityService.getTaskPrioritiesList(tenantId, organizationId, teamId);
 			return res;
-		}
+		},
+		enabled: !!tenantId && !!organizationId && !!teamId
 	});
 
 	// Mutations

--- a/apps/web/core/hooks/tasks/use-task-priorities.ts
+++ b/apps/web/core/hooks/tasks/use-task-priorities.ts
@@ -32,20 +32,18 @@ export function useTaskPriorities() {
 		[authUser, user]
 	);
 	const teamId = useMemo(() => activeTeam?.id || getActiveTeamIdCookie() || activeTeamId, [activeTeam, activeTeamId]);
-
+	const isEnabled = useMemo(() => !!tenantId && !!organizationId && !!teamId, [tenantId, organizationId, teamId]);
 	// useQuery for fetching task priorities
 	const taskPrioritiesQuery = useQuery({
 		queryKey: queryKeys.taskPriorities.byTeam(teamId),
 		queryFn: async () => {
-			const isEnabled = !!tenantId && !!organizationId && !!teamId;
 			if (!isEnabled) {
 				throw new Error('Required parameters missing: tenantId, organizationId, and teamId are required');
 			}
 
-			const res = await taskPriorityService.getTaskPrioritiesList(tenantId, organizationId, teamId);
-			return res;
+			return await taskPriorityService.getTaskPrioritiesList(tenantId, organizationId, teamId);
 		},
-		enabled: !!tenantId && !!organizationId && !!teamId
+		enabled: isEnabled
 	});
 
 	const invalidateTaskPrioritiesData = useCallback(

--- a/apps/web/core/hooks/tasks/use-task-priorities.ts
+++ b/apps/web/core/hooks/tasks/use-task-priorities.ts
@@ -11,6 +11,7 @@ import { ITaskPrioritiesCreate } from '@/core/types/interfaces/task/task-priorit
 import { queryKeys } from '@/core/query/keys';
 import { useAuthenticateUser } from '../auth';
 import { useOrganizationTeams } from '../organizations';
+import { useConditionalUpdateEffect } from '../common';
 
 export function useTaskPriorities() {
 	const [user] = useAtom(userState);
@@ -36,9 +37,6 @@ export function useTaskPriorities() {
 			}
 
 			const res = await taskPriorityService.getTaskPrioritiesList(tenantId, organizationId, teamId);
-
-			setTaskPriorities(res.items);
-
 			return res;
 		}
 	});
@@ -84,6 +82,16 @@ export function useTaskPriorities() {
 				});
 		}
 	});
+
+	useConditionalUpdateEffect(
+		() => {
+			if (taskPrioritiesQuery.data) {
+				setTaskPriorities(taskPrioritiesQuery.data.items);
+			}
+		},
+		[taskPrioritiesQuery.data],
+		Boolean(taskPriorities)
+	);
 
 	const loadTaskPriorities = useCallback(async () => {
 		return taskPrioritiesQuery.data;

--- a/apps/web/core/hooks/tasks/use-task-priorities.ts
+++ b/apps/web/core/hooks/tasks/use-task-priorities.ts
@@ -90,7 +90,7 @@ export function useTaskPriorities() {
 			}
 		},
 		[taskPrioritiesQuery.data],
-		Boolean(taskPriorities)
+		Boolean(taskPriorities?.length)
 	);
 
 	const loadTaskPriorities = useCallback(async () => {

--- a/apps/web/core/hooks/tasks/use-task-related-issue-type.ts
+++ b/apps/web/core/hooks/tasks/use-task-related-issue-type.ts
@@ -88,12 +88,12 @@ export function useTaskRelatedIssueType() {
 			}
 		},
 		[taskRelatedIssueTypesQuery.data],
-		Boolean(taskRelatedIssueType)
+		Boolean(taskRelatedIssueType?.length)
 	);
 
 	const loadTaskRelatedIssueTypeData = useCallback(async () => {
 		return taskRelatedIssueTypesQuery.data;
-	}, [user?.tenantId, user?.employee?.organizationId, activeTeamId]);
+	}, [taskRelatedIssueTypesQuery.data]);
 
 	const handleFirstLoad = useCallback(async () => {
 		await loadTaskRelatedIssueTypeData();

--- a/apps/web/core/hooks/tasks/use-task-related-issue-type.ts
+++ b/apps/web/core/hooks/tasks/use-task-related-issue-type.ts
@@ -37,7 +37,8 @@ export function useTaskRelatedIssueType() {
 			}
 			const res = await taskRelatedIssueTypeService.getTaskRelatedIssueTypeList(tenantId, organizationId, teamId);
 			return res.data;
-		}
+		},
+		enabled: !!tenantId && !!organizationId && !!teamId
 	});
 
 	const createTaskRelatedIssueTypeMutation = useMutation({

--- a/apps/web/core/hooks/tasks/use-task-sizes.ts
+++ b/apps/web/core/hooks/tasks/use-task-sizes.ts
@@ -10,6 +10,7 @@ import { taskSizeService } from '@/core/services/client/api/tasks/task-size.serv
 import { ITaskSizesCreate } from '@/core/types/interfaces/task/task-size';
 import { queryKeys } from '@/core/query/keys';
 import { useOrganizationTeams } from '../organizations';
+import { useConditionalUpdateEffect } from '../common';
 
 export function useTaskSizes() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
@@ -69,13 +70,20 @@ export function useTaskSizes() {
 		}
 	});
 
+	useConditionalUpdateEffect(
+		() => {
+			if (taskSizesQuery.data) {
+				setTaskSizes(taskSizesQuery.data.items);
+			}
+		},
+		[taskSizesQuery.data],
+		Boolean(taskSizes)
+	);
+
 	const loadTaskSizes = useCallback(async () => {
 		try {
 			const res = taskSizesQuery.data;
-
-			if (res?.items) {
-				setTaskSizes(res?.items || []);
-			}
+			return res;
 		} catch (error) {
 			console.error('Failed to load task sizes:', error);
 		}

--- a/apps/web/core/hooks/tasks/use-task-sizes.ts
+++ b/apps/web/core/hooks/tasks/use-task-sizes.ts
@@ -77,7 +77,7 @@ export function useTaskSizes() {
 			}
 		},
 		[taskSizesQuery.data],
-		Boolean(taskSizes)
+		Boolean(taskSizes?.length)
 	);
 
 	const loadTaskSizes = useCallback(async () => {

--- a/apps/web/core/hooks/tasks/use-task-status.ts
+++ b/apps/web/core/hooks/tasks/use-task-status.ts
@@ -110,7 +110,7 @@ export function useTaskStatus() {
 			}
 		},
 		[taskStatusesQuery.data],
-		Boolean(taskStatuses)
+		Boolean(taskStatuses?.length)
 	);
 
 	const loadTaskStatuses = useCallback(async () => {

--- a/apps/web/core/hooks/tasks/use-task-status.ts
+++ b/apps/web/core/hooks/tasks/use-task-status.ts
@@ -7,7 +7,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useFirstLoad } from '../common/use-first-load';
 import { getActiveTeamIdCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
 import { taskStatusService } from '@/core/services/client/api/tasks/task-status.service';
-import { useCallbackRef, useSyncRef } from '../common';
+import { useCallbackRef, useConditionalUpdateEffect, useSyncRef } from '../common';
 import { TStatus, TStatusItem, useMapToTaskStatusValues } from '@/core/components/tasks/task-status';
 import { ITaskStatusCreate } from '@/core/types/interfaces/task/task-status/task-status';
 import { queryKeys } from '@/core/query/keys';
@@ -37,7 +37,8 @@ export function useTaskStatus() {
 				throw new Error('Required parameters missing: organizationId, teamId, and tenantId are required');
 			}
 			return taskStatusService.getTaskStatuses(tenantId, organizationId, teamId);
-		}
+		},
+		enabled: Boolean(organizationId) && Boolean(teamId) && Boolean(tenantId)
 	});
 
 	// Mutations using useQuery pattern
@@ -97,12 +98,25 @@ export function useTaskStatus() {
 		}
 	});
 
+	/**
+	 * This helper function prevents:
+	 *
+	 * - Setting state unnecessarily on mount.
+	 */
+	useConditionalUpdateEffect(
+		() => {
+			if (taskStatusesQuery.data) {
+				setTaskStatuses(taskStatusesQuery.data.items);
+			}
+		},
+		[taskStatusesQuery.data],
+		Boolean(taskStatuses)
+	);
+
 	const loadTaskStatuses = useCallback(async () => {
 		try {
 			const res = taskStatusesQuery.data;
-			if (res) {
-				setTaskStatuses(res.items);
-			}
+			return res;
 		} catch (error) {
 			console.error('Failed to load task statuses:', error);
 		}

--- a/apps/web/core/hooks/tasks/use-task-version.ts
+++ b/apps/web/core/hooks/tasks/use-task-version.ts
@@ -90,7 +90,7 @@ export function useTaskVersion() {
 			}
 		},
 		[taskVersionsQuery.data],
-		Boolean(taskVersion)
+		Boolean(taskVersion?.length)
 	);
 
 	const loadTaskVersionData = useCallback(() => {


### PR DESCRIPTION
## Description
- Add a custom useEffect hooks that execute conditionally for the first render
- Separate state update from react-query for:
  - Task labels
  - Task status
  - Task priorities
  - Task issues type
  - Tag
  - Task size

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new mechanism that conditionally updates app data only when relevant changes occur, improving performance and responsiveness.
- **Refactor**
	- Streamlined state management for roles, tags, task labels, priorities, issue types, related issue types, sizes, statuses, and versions to ensure more efficient and predictable updates.
	- Centralized query invalidation logic and improved memoization across multiple hooks.
- **Bug Fixes**
	- Reduced unnecessary data updates and improved consistency across various parts of the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->