### PR TITLE
[Refactor] Migrate activity report api calls to react query

### DIFF
--- a/apps/web/core/hooks/activities/use-report-activity.ts
+++ b/apps/web/core/hooks/activities/use-report-activity.ts
@@ -295,21 +295,21 @@ export function useReportActivity({ types }: { types?: 'TEAM-DASHBOARD' | 'APPS-
 		(customProps?: Partial<UseReportActivityProps>) => {
 			return fetchReport(timeLogReportDailyChartQuery, setRapportChartActivity, customProps);
 		},
-		[fetchReport, timeLogReportDailyChartQuery, setRapportChartActivity]
+		[fetchReport, setRapportChartActivity]
 	);
 
 	const fetchDailyReport = useCallback(
 		(customProps?: Partial<UseReportActivityProps>) => {
 			return fetchReport(timeLogReportDailyQuery, setRapportDailyActivity, customProps);
 		},
-		[fetchReport, timeLogReportDailyQuery, setRapportDailyActivity]
+		[fetchReport, setRapportDailyActivity]
 	);
 
 	const fetchActivityReport = useCallback(
 		(customProps?: Partial<UseReportActivityProps>) => {
 			return fetchReport(activityReportQuery, setActivityReport, customProps);
 		},
-		[fetchReport, activityReportQuery, setActivityReport]
+		[fetchReport, setActivityReport]
 	);
 
 	const fetchStatisticsCounts = useCallback(
@@ -335,7 +335,7 @@ export function useReportActivity({ types }: { types?: 'TEAM-DASHBOARD' | 'APPS-
 				setStatisticsCounts(null);
 			}
 		},
-		[user, getMergedProps, timesheetStatisticsCountsQuery, setStatisticsCounts]
+		[user, getMergedProps, setStatisticsCounts]
 	);
 
 	// Update handlers

--- a/apps/web/core/hooks/activities/use-time-daily-activity.ts
+++ b/apps/web/core/hooks/activities/use-time-daily-activity.ts
@@ -51,15 +51,15 @@ export function useTimeDailyActivity(type?: string) {
 
 	// React Query for daily activities data with dynamic title
 	const dailyActivitiesQuery = useQuery({
-		queryKey: queryKeys.activities.daily(
-			baseParams?.tenantId,
-			baseParams?.organizationId,
-			baseParams?.employeeId,
-			baseParams?.todayStart?.toISOString(),
-			baseParams?.todayEnd?.toISOString(),
-			baseParams?.type,
+		queryKey: queryKeys.activities.daily({
+			tenantId: baseParams?.tenantId,
+			organizationId: baseParams?.organizationId,
+			employeeId: baseParams?.employeeId,
+			todayStart: baseParams?.todayStart?.toISOString(),
+			todayEnd: baseParams?.todayEnd?.toISOString(),
+			type: baseParams?.type,
 			currentTitle
-		),
+		}),
 		queryFn: async () => {
 			if (!baseParams) {
 				throw new Error('Daily activities parameters are required');

--- a/apps/web/core/query/keys/index.ts
+++ b/apps/web/core/query/keys/index.ts
@@ -205,27 +205,10 @@ export const queryKeys = {
 				...(defaultRange ? [defaultRange] : []),
 				...(unitOfTime ? [unitOfTime] : [])
 			] as const,
-		daily: (
-			tenantId: string | undefined | null,
-			organizationId: string | undefined | null,
-			employeeId: string | undefined | null,
-			startDate: string | undefined | null,
-			endDate: string | undefined | null,
-			type?: string | undefined | null,
-			title?: string | undefined | null
-		) =>
-			[
-				'activities',
-				'daily',
-				...(tenantId ? [tenantId] : []),
-				...(organizationId ? [organizationId] : []),
-				...(employeeId ? [employeeId] : []),
-				...(startDate ? [startDate] : []),
-				...(endDate ? [endDate] : []),
-				...(type ? [type] : []),
-				...(title ? [title] : [])
-			] as const,
-		report: (params: Record<string, any>) => ['activities', 'report', params] as const
+		dailyChart: (params: Record<string, any>) => ['activities', 'daily-activity-report-chart', params] as const,
+		daily: (params: Record<string, any>) => ['activities', 'daily-activity-report', params] as const,
+		statisticsCounts: (params: Record<string, any>) => ['activities', 'statistics-counts', params] as const,
+		activityReport: (params: Record<string, any>) => ['activities', 'activity-report', params] as const
 	},
 
 	// Keys related to task statuses

--- a/apps/web/core/services/client/api/activities/activity.service.ts
+++ b/apps/web/core/services/client/api/activities/activity.service.ts
@@ -2,9 +2,7 @@ import { GAUZY_API_BASE_SERVER_URL } from '@/core/constants/config/constants';
 import { APIService } from '../../api.service';
 import qs from 'qs';
 import { getDefaultTimezone } from '@/core/lib/helpers/date-and-time';
-
-import { IActivityReport } from '@/core/types/interfaces/activity/activity-report';
-import { ETimeLogType } from '@/core/types/generics/enums/timer';
+import { IActivitiesReportRequest, IActivityReport } from '@/core/types/interfaces/activity/activity-report';
 import { validateApiResponse, ZodValidationError } from '@/core/types/schemas';
 import { activitySchema, TActivity } from '@/core/types/schemas/activities/activity.schema';
 
@@ -169,19 +167,7 @@ class ActivityService extends APIService {
 		employeeIds = [],
 		source = [],
 		logType = []
-	}: {
-		activityLevel?: { start: number; end: number };
-		organizationId: string;
-		tenantId: string;
-		startDate: string | Date;
-		endDate: string | Date;
-		timeZone?: string;
-		groupBy?: string;
-		projectIds?: string[];
-		employeeIds?: string[];
-		source?: string[];
-		logType?: ETimeLogType[];
-	}) => {
+	}: IActivitiesReportRequest) => {
 		const queryString = qs.stringify(
 			{
 				activityLevel,

--- a/apps/web/core/types/interfaces/activity/activity-report.ts
+++ b/apps/web/core/types/interfaces/activity/activity-report.ts
@@ -228,6 +228,20 @@ export interface ITimeLogReportDailyChartProps {
 	userId?: string;
 }
 
+export interface IActivitiesReportRequest {
+	activityLevel?: { start: number; end: number };
+	organizationId: string;
+	tenantId: string;
+	startDate: string | Date;
+	endDate: string | Date;
+	timeZone?: string;
+	groupBy?: string;
+	projectIds?: string[];
+	employeeIds?: string[];
+	source?: string[];
+	logType?: ETimeLogType[];
+}
+
 export interface ITimeLogReportDaily {
 	activity: number;
 	date: string; // '2024-07-19'


### PR DESCRIPTION
## Description

- Migrate all activity reports API calls to use react query
- Update query keys for all activity report calls for better caching 
- Update all relevant components

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new interface for activity report requests, supporting more flexible filtering and grouping options.

- **Refactor**
  - Enhanced activity report data fetching with React Query for improved caching, retry, and synchronization.
  - Standardized activity report query keys with more granular and consistent parameter handling.
  - Updated method signatures and parameter structures for clarity and reusability.
  - Simplified query key construction for daily activity fetching.

- **Chores**
  - Consolidated and cleaned up import statements for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->