### PR TITLE
[Refactor] Migrate board and image assets api calls to use react query

### DIFF
--- a/apps/web/core/components/features/projects/add-or-edit-project/container.tsx
+++ b/apps/web/core/components/features/projects/add-or-edit-project/container.tsx
@@ -1,6 +1,6 @@
 import { Children, cloneElement, isValidElement, PropsWithChildren, ReactElement } from 'react';
 import { TModalMode } from '.';
-import { IImageAsset } from '@/core/types/interfaces/common/image-asset';
+import { TImageAsset } from '@/core/types/schemas';
 import { TCreateProjectRequest, TOrganizationProject } from '@/core/types/schemas';
 
 interface IAddOrEditContainerProps extends PropsWithChildren {
@@ -14,7 +14,7 @@ interface IAddOrEditContainerProps extends PropsWithChildren {
 
 export type TStepData = Partial<
 	TCreateProjectRequest & {
-		projectImage?: IImageAsset;
+		projectImage?: TImageAsset;
 		members?: { memberId: string; roleId: string; id: string }[];
 		id?: string;
 	}

--- a/apps/web/core/hooks/board/use-board.ts
+++ b/apps/web/core/hooks/board/use-board.ts
@@ -40,17 +40,20 @@ export const useBoard = () => {
 		window.localStorage.setItem('board-files', JSON.stringify(files));
 	}, []);
 
-	const onLiveCollaborationQuery = async () =>
-		queryClient.fetchQuery({
-			queryKey: queryKeys.board.liveCollaboration,
-			queryFn: async () => {
-				return await exportToBackend(
-					excalidrawAPI?.getSceneElements() || [],
-					excalidrawAPI?.getAppState() || ({} as AppState),
-					excalidrawAPI?.getFiles() || {}
-				);
-			}
-		});
+	const onLiveCollaborationQuery = useCallback(
+		async () =>
+			queryClient.fetchQuery({
+				queryKey: queryKeys.board.liveCollaboration,
+				queryFn: async () => {
+					return await exportToBackend(
+						excalidrawAPI?.getSceneElements() || [],
+						excalidrawAPI?.getAppState() || ({} as AppState),
+						excalidrawAPI?.getFiles() || {}
+					);
+				}
+			}),
+		[queryClient, excalidrawAPI]
+	);
 
 	const onLiveCollaboration = useCallback(async () => {
 		if (excalidrawAPI) {
@@ -62,7 +65,7 @@ export const useBoard = () => {
 				window.open(uri.toString(), '_blank', 'noreferrer');
 			}
 		}
-	}, [excalidrawAPI]);
+	}, [onLiveCollaborationQuery]);
 
 	return { setExcalidrawAPI, excalidrawAPI, saveChanges, onLiveCollaboration };
 };

--- a/apps/web/core/hooks/board/use-board.ts
+++ b/apps/web/core/hooks/board/use-board.ts
@@ -1,13 +1,16 @@
 import { exportToBackend } from '@/core/lib/helpers/export-to-backend';
+import { queryKeys } from '@/core/query/keys';
 import { ExcalidrawElement } from '@excalidraw/excalidraw/dist/types/excalidraw/element/types';
 import { AppState, BinaryFiles } from '@excalidraw/excalidraw/dist/types/excalidraw/types';
 import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/dist/types/excalidraw/types';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRef, useState, useEffect, useCallback } from 'react';
 
 export const useBoard = () => {
 	const loaded = useRef(false);
 	// const { user } = useAuthenticateUser();
 	const [excalidrawAPI, setExcalidrawAPI] = useState<ExcalidrawImperativeAPI | null>(null);
+	const queryClient = useQueryClient();
 
 	useEffect(() => {
 		if (!excalidrawAPI || loaded.current) {
@@ -37,19 +40,27 @@ export const useBoard = () => {
 		window.localStorage.setItem('board-files', JSON.stringify(files));
 	}, []);
 
+	const onLiveCollaborationQuery = async () =>
+		queryClient.fetchQuery({
+			queryKey: queryKeys.board.liveCollaboration,
+			queryFn: async () => {
+				return await exportToBackend(
+					excalidrawAPI?.getSceneElements() || [],
+					excalidrawAPI?.getAppState() || ({} as AppState),
+					excalidrawAPI?.getFiles() || {}
+				);
+			}
+		});
+
 	const onLiveCollaboration = useCallback(async () => {
 		if (excalidrawAPI) {
-			await exportToBackend(
-				excalidrawAPI.getSceneElements(),
-				excalidrawAPI.getAppState(),
-				excalidrawAPI.getFiles()
-			).then((res) => {
-				if (res.url) {
-					const uri = new URL(res.url);
-					uri.searchParams.set('live', 'true');
-					window.open(uri.toString(), '_blank', 'noreferrer');
-				}
-			});
+			const response = await onLiveCollaborationQuery();
+
+			if (response.url) {
+				const uri = new URL(response.url);
+				uri.searchParams.set('live', 'true');
+				window.open(uri.toString(), '_blank', 'noreferrer');
+			}
 		}
 	}, [excalidrawAPI]);
 

--- a/apps/web/core/hooks/common/index.ts
+++ b/apps/web/core/hooks/common/index.ts
@@ -26,3 +26,4 @@ export * from './use-sortable-data';
 export * from './use-sync-ref';
 export * from './use-timezone-settings';
 export * from './use-element-height';
+export * from './use-image-assets';

--- a/apps/web/core/query/keys/index.ts
+++ b/apps/web/core/query/keys/index.ts
@@ -444,5 +444,9 @@ export const queryKeys = {
 		all: ['email-verification'] as const,
 		verifyToken: (email: string | undefined | null, token: string | undefined | null) =>
 			['email-verification', 'verify-token', ...(email ? [email] : []), ...(token ? [token] : [])] as const
+	},
+
+	board: {
+		liveCollaboration: ['live-collaboration'] as const
 	}
 };

--- a/apps/web/core/services/client/api/common/image-assets.service.ts
+++ b/apps/web/core/services/client/api/common/image-assets.service.ts
@@ -1,0 +1,63 @@
+import { getAccessTokenCookie } from '@/core/lib/helpers/cookies';
+import { APIService } from '../../api.service';
+import { GAUZY_API_BASE_SERVER_URL } from '@/core/constants/config/constants';
+import { validateApiResponse, imageAssetSchema, ZodValidationError } from '@/core/types/schemas';
+import { TImageAsset } from '@/core/types/schemas/common/image-asset.schema';
+
+/**
+ * Enhanced Image Assets Service with Zod validation
+ *
+ * This service extends the base APIService to add schema validation
+ * for all API responses, ensuring data integrity and type safety.
+ */
+class ImageAssetsService extends APIService {
+	/**
+	 * Upload an image asset with validation
+	 *
+	 * @param file - The file to upload
+	 * @param folder - The folder to upload to
+	 * @param tenantId - The tenant ID
+	 * @param organizationId - The organization ID
+	 * @returns Promise<TImageAsset> - Validated image asset data
+	 * @throws ValidationError if response data doesn't match schema
+	 */
+	uploadImageAsset = async (
+		file: File,
+		folder: string,
+		tenantId: string,
+		organizationId: string
+	): Promise<TImageAsset> => {
+		const bearer_token = getAccessTokenCookie();
+		const formData = new FormData();
+		formData.append('file', file);
+		formData.append('tenantId', tenantId);
+		formData.append('organizationId', organizationId);
+
+		const response = await this.post<TImageAsset>(`/image-assets/upload/${folder}`, formData, {
+			headers: {
+				'tenant-id': tenantId,
+				Authorization: `Bearer ${bearer_token}`
+			}
+		});
+
+		try {
+			// Validate the response data using Zod schema
+			return validateApiResponse(imageAssetSchema, response.data, 'uploadImageAsset API response');
+		} catch (error) {
+			if (error instanceof ZodValidationError) {
+				this.logger.error(
+					'Image asset validation failed:',
+					{
+						message: error.message,
+						issues: error.issues
+					},
+					'ImageAssetsService'
+				);
+				this.logger.debug('Actual API response data:', response.data, 'ImageAssetsService');
+			}
+			throw error;
+		}
+	};
+}
+
+export const imageAssetsService = new ImageAssetsService(GAUZY_API_BASE_SERVER_URL.value);

--- a/apps/web/core/services/client/api/common/index.ts
+++ b/apps/web/core/services/client/api/common/index.ts
@@ -1,0 +1,1 @@
+export * from './image-assets.service';

--- a/apps/web/core/services/client/api/index.ts
+++ b/apps/web/core/services/client/api/index.ts
@@ -1,6 +1,7 @@
 export * from './tasks';
 export * from './organizations/teams/invites';
 
+export * from './common';
 export * from './languages';
 
 export * from './daily-plans';

--- a/apps/web/core/types/interfaces/common/image-asset.ts
+++ b/apps/web/core/types/interfaces/common/image-asset.ts
@@ -1,6 +1,7 @@
 import { IBasePerTenantAndOrganizationEntityModel } from '../common/base-interfaces';
 import { FileStorageProvider } from './file-storage-provider';
 import { ID } from './base-interfaces';
+import { TImageAsset } from '../../schemas';
 
 export interface IImageAsset extends IBasePerTenantAndOrganizationEntityModel {
 	name: string;
@@ -17,10 +18,10 @@ export interface IImageAsset extends IBasePerTenantAndOrganizationEntityModel {
 }
 
 export interface IRelationalImageAsset {
-	image?: IImageAsset | null;
+	image?: TImageAsset | null;
 	imageId?: ID | null;
 }
 
-export interface ICreateImageAssets extends Pick<IImageAsset, 'tenantId' | 'organizationId'> {
+export interface ICreateImageAssets extends Pick<TImageAsset, 'tenantId' | 'organizationId'> {
 	file: File;
 }

--- a/apps/web/core/types/interfaces/project/organization-project.ts
+++ b/apps/web/core/types/interfaces/project/organization-project.ts
@@ -84,7 +84,7 @@ export interface ICreateProjectRequest {
 	description?: string;
 	color?: string;
 	tags?: TTag[];
-	imageUrl?: string;
+	imageUrl?: string | null;
 	imageId?: string;
 	budget?: number;
 	budgetType?: EProjectBudgetType;

--- a/apps/web/core/types/interfaces/team/organization-team.ts
+++ b/apps/web/core/types/interfaces/team/organization-team.ts
@@ -1,6 +1,6 @@
-import { TOrganizationTeamEmployee } from '../../schemas';
+import { TImageAsset, TOrganizationTeamEmployee } from '../../schemas';
 import { IBasePerTenantAndOrganizationEntityModel, ID, ITaggable } from '../common/base-interfaces';
-import { IImageAsset, IRelationalImageAsset } from '../common/image-asset';
+import { IRelationalImageAsset } from '../common/image-asset';
 import { IOrganizationProject } from '../project/organization-project';
 import { ITask } from '../task/task';
 
@@ -49,7 +49,7 @@ export interface IOrganizationTeamCreate {
 	requirePlanToTrack?: boolean;
 	public?: boolean;
 	imageId?: string | null;
-	image?: IImageAsset | null;
+	image?: TImageAsset | null;
 	projects?: IOrganizationProject[];
 }
 export type IOrganizationTeamUpdate = IOrganizationTeamCreate & { id: string };

--- a/apps/web/core/types/schemas/common/image-asset.schema.ts
+++ b/apps/web/core/types/schemas/common/image-asset.schema.ts
@@ -34,3 +34,7 @@ export const createImageAssetsSchema = z.object({
 	organizationId: z.string(),
 	file: z.any() // File object
 });
+
+// Export TypeScript types
+export type TImageAsset = z.infer<typeof imageAssetSchema>;
+export type TCreateImageAssets = z.infer<typeof createImageAssetsSchema>;


### PR DESCRIPTION
## Description

- Create image asset API service
- Add zod validation for image asset service
- Migrate image asset to use react query
- Migrate board API call to use react query

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated service for uploading image assets with improved validation and error handling.
  - Added centralized query key management for live collaboration features.
- **Enhancements**
  - Refactored image asset upload hook to use React Query for better state and lifecycle management.
  - Improved live collaboration data fetching with React Query integration.
- **Bug Fixes**
  - Updated type definitions to ensure consistency and type safety for image asset and project-related data.
  - Allowed explicit null values for project image URLs.
- **Chores**
  - Streamlined exports for image asset services and hooks for easier access across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->