### PR TITLE
[Refactor] Migrate team tasks api calls to use react query

### DIFF
--- a/apps/web/core/components/activities/user-team-card-activity.tsx
+++ b/apps/web/core/components/activities/user-team-card-activity.tsx
@@ -80,42 +80,6 @@ const UserTeamActivity = ({ showActivity, member }: { showActivity: boolean; mem
 						</Tab.Group>
 					</div>
 				</div>
-				<div className="flex-1 w-full overflow-hidden">
-					<Tab.Group>
-						<Tab.List className="w-full flex space-x-1 rounded-xl bg-gray-200 dark:bg-[#FFFFFF14] p-2">
-							{Object.values(ActivityFilters).map((filter: string) => (
-								<Tab
-									key={filter}
-									className={({ selected }) =>
-										clsxm(
-											'w-full rounded-lg py-2.5 text-sm font-medium leading-5',
-											'focus:outline-none focus:ring-2',
-											selected
-												? 'bg-white dark:bg-dark text-blue-700 shadow'
-												: 'hover:bg-white/[0.50]'
-										)
-									}
-								>
-									{filter}
-								</Tab>
-							))}
-						</Tab.List>
-						<Tab.Panels className="w-full mt-2">
-							<Tab.Panel className="w-full overflow-hidden">
-								<UserWorkedTaskTab member={member} />
-							</Tab.Panel>
-							<Tab.Panel className="w-full">
-								<ScreenshootTeamTab />
-							</Tab.Panel>
-							<Tab.Panel className="w-full">
-								<AppsTab />
-							</Tab.Panel>
-							<Tab.Panel className="w-full">
-								<VisitedSitesTab />
-							</Tab.Panel>
-						</Tab.Panels>
-					</Tab.Group>
-				</div>
 			</div>
 		</Transition>
 	);

--- a/apps/web/core/components/activities/user-worked-task.tsx
+++ b/apps/web/core/components/activities/user-worked-task.tsx
@@ -14,22 +14,22 @@ const UserWorkedTaskTab = ({ member }: { member?: any }) => {
 	const t = useTranslations();
 
 	const tasks = hook.tasksFiltered;
-	const canSeeActivity = profile.userProfile?.id === user?.id || user?.role?.name?.toUpperCase() == 'MANAGER';
+	const canSeeActivity = profile?.userProfile?.id === user?.id || user?.role?.name?.toUpperCase() == 'MANAGER';
 	const otherTasks = tasks.filter((t) =>
-		profile.member?.running == true ? t.id !== profile.activeUserTeamTask?.id : t
+		profile?.member?.running == true ? t.id !== profile?.activeUserTeamTask?.id : t
 	);
 
 	return (
 		<div>
-			{profile.activeUserTeamTask && canSeeActivity && (
+			{profile?.activeUserTeamTask && canSeeActivity && (
 				<TaskCard
 					active
-					task={profile.activeUserTeamTask}
-					isAuthUser={profile.isAuthUser}
+					task={profile?.activeUserTeamTask}
+					isAuthUser={profile?.isAuthUser}
 					activeAuthTask={true}
 					profile={profile}
 					taskBadgeClassName={`	${
-						profile.activeUserTeamTask?.issueType === 'Bug'
+						profile?.activeUserTeamTask?.issueType === 'Bug'
 							? '!px-[0.3312rem] py-[0.2875rem]'
 							: '!px-[0.375rem] py-[0.375rem]'
 					} rounded-sm`}
@@ -53,7 +53,7 @@ const UserWorkedTaskTab = ({ member }: { member?: any }) => {
 							<li key={task.id}>
 								<TaskCard
 									task={task}
-									isAuthUser={profile.isAuthUser}
+									isAuthUser={profile?.isAuthUser}
 									activeAuthTask={false}
 									viewType={hook.tab === 'unassigned' ? 'unassign' : 'default'}
 									profile={profile}

--- a/apps/web/core/components/pages/profile/screenshots/screenshot-details.tsx
+++ b/apps/web/core/components/pages/profile/screenshots/screenshot-details.tsx
@@ -58,7 +58,7 @@ const ScreenshotDetailsModal = ({
 	const getTask = useCallback(
 		async (taskId: string) => {
 			const task = await getTaskById(taskId);
-			task?.data && setTask(task?.data);
+			task && setTask(task as ITask);
 		},
 		[getTaskById]
 	);

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task-times.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task-times.tsx
@@ -19,7 +19,7 @@ export default function UserTeamActiveTaskTimesBlock({
 
 	useEffect(() => {
 		getTaskById(activeTaskId || '')
-			.then((response) => setActiveTask(response.data))
+			.then((response) => setActiveTask(response as ITask))
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task.tsx
@@ -19,7 +19,7 @@ export default function UserTeamActiveBlockTaskInfo({
 
 	useEffect(() => {
 		getTaskById(activeTaskId || '')
-			.then((response) => setActiveTask(response.data))
+			.then((response) => setActiveTask(response as ITask))
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task.tsx
@@ -18,12 +18,13 @@ export default function UserTeamActiveBlockTaskInfo({
 	const { getTaskById } = useTeamTasks();
 
 	useEffect(() => {
-		getTaskById(activeTaskId || '')
-			.then((response) => setActiveTask(response as ITask))
-			.catch((_) => console.log(_));
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+		if (!activeTaskId) {
+			return;
+		}
+		getTaskById(activeTaskId)
+			.then((task) => setActiveTask(task as ITask))
+			.catch(console.error);
+	}, [activeTaskId, getTaskById]);
 
 	return (
 		<>

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-task-estimate.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-task-estimate.tsx
@@ -19,7 +19,7 @@ export default function UserTeamActiveTaskEstimateBlock({
 
 	useEffect(() => {
 		getTaskById(activeTaskId || '')
-			.then((response) => setActiveTask(response.data))
+			.then((response) => setActiveTask(response as ITask))
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-card.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-card.tsx
@@ -89,7 +89,7 @@ function UserActiveTaskMenu({ member }: { member: TOrganizationTeamEmployee }) {
 
 	useEffect(() => {
 		getTaskById(member.activeTaskId || '')
-			.then((response) => setActiveTask(response.data))
+			.then((response) => setActiveTask(response as ITask))
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task-times.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task-times.tsx
@@ -20,7 +20,7 @@ export default function UserTeamActiveTaskTimes({
 
 	useEffect(() => {
 		getTaskById(member.activeTaskId || '')
-			.then((response) => setActiveTask(response.data))
+			.then((response) => setActiveTask(response as ITask))
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task.tsx
@@ -17,7 +17,7 @@ export default function UserTeamActiveTaskInfo({
 
 	useEffect(() => {
 		getTaskById(member.activeTaskId || '')
-			.then((response) => setActiveTask(response.data))
+			.then((response) => setActiveTask(response as ITask))
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task.tsx
@@ -16,12 +16,14 @@ export default function UserTeamActiveTaskInfo({
 	const { getTaskById } = useTeamTasks();
 
 	useEffect(() => {
-		getTaskById(member.activeTaskId || '')
-			.then((response) => setActiveTask(response as ITask))
-			.catch((_) => console.log(_));
+		if (member.activeTaskId) {
+			getTaskById(member.activeTaskId)
+				.then((response) => setActiveTask(response as ITask))
+				.catch((_) => console.log(_));
+		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [member.activeTaskId, getTaskById]);
 
 	return (
 		<>

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-task-estimate.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-task-estimate.tsx
@@ -17,7 +17,7 @@ export default function UserTeamActiveTaskEstimate({
 
 	useEffect(() => {
 		getTaskById(member.activeTaskId || '')
-			.then((response) => setActiveTask(response.data))
+			.then((response) => setActiveTask(response as ITask))
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/team/team-members-views/user-team-card/index.tsx
+++ b/apps/web/core/components/pages/teams/team/team-members-views/user-team-card/index.tsx
@@ -146,7 +146,7 @@ export function UserTeamCard({
 		},
 		[setActivity]
 	);
-	const canSeeActivity = profile.userProfile?.id === user?.id || isManagerConnectedUser != -1;
+	const canSeeActivity = profile?.userProfile?.id === user?.id || isManagerConnectedUser != -1;
 
 	return (
 		<div
@@ -156,7 +156,7 @@ export function UserTeamCard({
 			onDragEnter={onDragEnter}
 			onDragEnd={onDragEnd}
 			onDragOver={onDragOver}
-			ref={profile.loadTaskStatsIObserverRef}
+			ref={profile?.loadTaskStatsIObserverRef}
 		>
 			<EverCard
 				shadow="bigger"
@@ -268,7 +268,7 @@ export function UserTeamCard({
 					<div className="absolute right-2">{menu}</div>
 				</div>
 				{userDetailAccordion == memberInfo.memberUser?.id &&
-				memberInfo.memberUser.id == profile.userProfile?.id &&
+				memberInfo.memberUser.id == profile?.userProfile?.id &&
 				!showActivity ? (
 					<div className="overflow-y-auto h-96">
 						{canSeeActivity && (

--- a/apps/web/core/components/tasks/task-default-status.tsx
+++ b/apps/web/core/components/tasks/task-default-status.tsx
@@ -68,7 +68,8 @@ export const taskStatus: TStatus<ETaskStatusName> = {
 		icon: <TickCircleIcon className="w-full max-w-[17px]" />,
 		bgColor: '#D4EFDF'
 	},
-	custom: {}
+	custom: {},
+	cancelled: {}
 };
 
 export const taskPriorities: TStatus = {

--- a/apps/web/core/components/tasks/task-input-kanban.tsx
+++ b/apps/web/core/components/tasks/task-input-kanban.tsx
@@ -26,6 +26,7 @@ import { EverCard } from '../common/ever-card';
 import { Tooltip } from '../duplicated-components/tooltip';
 import { Nullable } from '@/core/types/generics/utils';
 import { ETaskSizeName, ETaskPriority, EIssueType } from '@/core/types/generics/enums/task';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 
 type Props = {
 	task?: Nullable<ITask>;
@@ -85,7 +86,7 @@ export function TaskInputKanban(props: Props) {
 	}, [timerStatus]);
 
 	const onTaskCreated = useCallback(
-		(task: ITask | undefined) => $onTaskCreated.current && $onTaskCreated.current(task),
+		(task: TTask | undefined) => $onTaskCreated.current && $onTaskCreated.current(task as any),
 		[$onTaskCreated]
 	);
 

--- a/apps/web/core/components/tasks/task-input.tsx
+++ b/apps/web/core/components/tasks/task-input.tsx
@@ -39,6 +39,7 @@ import { ITask } from '@/core/types/interfaces/task/task';
 import { IIssueType } from '@/core/types/interfaces/task/issue-type';
 import { EIssueType, ETaskSizeName, ETaskStatusName, ETaskPriority } from '@/core/types/generics/enums/task';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 
 type Props = {
 	task?: Nullable<ITask>;
@@ -104,7 +105,7 @@ export function TaskInput(props: Props) {
 	}, [timerStatus]);
 
 	const onTaskCreated = useCallback(
-		(task: ITask | undefined) => $onTaskCreated.current && $onTaskCreated.current(task),
+		(task: TTask | undefined) => $onTaskCreated.current && $onTaskCreated.current(task as any),
 		[$onTaskCreated]
 	);
 

--- a/apps/web/core/components/tasks/task-priorities-form.tsx
+++ b/apps/web/core/components/tasks/task-priorities-form.tsx
@@ -215,7 +215,7 @@ export const TaskPrioritiesForm = ({ formOnly = false, onCreated }: StatusForm) 
 											taskPriorities.map((priority) => (
 												<StatusesListCard
 													statusTitle={
-														priority.name ? priority.name?.split('-').join(' ') : ''
+														priority?.name ? priority?.name?.split('-').join(' ') : ''
 													}
 													bgColor={priority?.color || ''}
 													statusIcon={priority?.fullIconUrl || ''}
@@ -224,9 +224,9 @@ export const TaskPrioritiesForm = ({ formOnly = false, onCreated }: StatusForm) 
 														setEdit(priority);
 													}}
 													onDelete={() => {
-														deleteTaskPriorities(priority.id);
+														deleteTaskPriorities(priority?.id);
 													}}
-													key={priority.id}
+													key={priority?.id}
 												/>
 											))
 										) : (

--- a/apps/web/core/components/tasks/task-priorities-form.tsx
+++ b/apps/web/core/components/tasks/task-priorities-form.tsx
@@ -217,8 +217,8 @@ export const TaskPrioritiesForm = ({ formOnly = false, onCreated }: StatusForm) 
 													statusTitle={
 														priority.name ? priority.name?.split('-').join(' ') : ''
 													}
-													bgColor={priority.color || ''}
-													statusIcon={priority.fullIconUrl || ''}
+													bgColor={priority?.color || ''}
+													statusIcon={priority?.fullIconUrl || ''}
 													onEdit={() => {
 														setCreateNew(false);
 														setEdit(priority);

--- a/apps/web/core/components/tasks/task-status.tsx
+++ b/apps/web/core/components/tasks/task-status.tsx
@@ -159,7 +159,7 @@ export function useActiveTaskStatus<T extends ITaskStatusField>(
 		}
 
 		taskUpdateQueue.task((task) => {
-			return handleStatusUpdate(status, updatedField || field, taskStatusId, task.current, true).finally(() => {
+			return handleStatusUpdate(status, updatedField || field, taskStatusId, task.current, true)?.finally(() => {
 				props.onChangeLoading && props.onChangeLoading(false);
 			});
 		}, $task);
@@ -443,7 +443,7 @@ export function EpicPropertiesDropdown({
 
 export function useTaskPrioritiesValue() {
 	const { taskPriorities } = useTaskPriorities();
-	return useMapToTaskStatusValues(taskPriorities, false);
+	return useMapToTaskStatusValues(taskPriorities as TTaskStatus[], false);
 }
 
 /**
@@ -537,7 +537,7 @@ export function TaskPriorityStatus({
 
 export function useTaskSizesValue() {
 	const { taskSizes } = useTaskSizes();
-	return useMapToTaskStatusValues(taskSizes, false);
+	return useMapToTaskStatusValues(taskSizes as TTaskStatus[], false);
 }
 
 /**

--- a/apps/web/core/hooks/organizations/teams/use-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-tasks.ts
@@ -226,7 +226,7 @@ export function useTeamTasks() {
 			try {
 				const res = await getTaskByIdQuery.refetch();
 				setDetailedTask((res?.data as ITask) || null);
-				return res.data;
+				return res?.data;
 			} catch (error) {
 				console.error('Error fetching task by ID:', error);
 				return null;
@@ -235,22 +235,25 @@ export function useTeamTasks() {
 		[setDetailedTask, tasksRef]
 	);
 
-	const getTasksByEmployeeId = useCallback(async (employeeId: string, organizationTeamId: string) => {
-		try {
-			if (!employeeId || !organizationTeamId) {
-				throw new Error('Required parameters missing : employeeId or organizationTeamId');
+	const getTasksByEmployeeId = useCallback(
+		async (employeeId: string, organizationTeamId: string) => {
+			try {
+				if (!employeeId || !organizationTeamId) {
+					throw new Error('Required parameters missing : employeeId or organizationTeamId');
+				}
+
+				setSelectedEmployeeId(employeeId);
+				setSelectedOrganizationTeamId(organizationTeamId);
+
+				const res = await getTasksByEmployeeIdQuery.refetch();
+				return res.data;
+			} catch (error) {
+				console.error('Error fetching tasks by employee ID:', error);
+				return [];
 			}
-
-			setSelectedEmployeeId(employeeId);
-			setSelectedOrganizationTeamId(organizationTeamId);
-
-			const res = await getTasksByEmployeeIdQuery.refetch();
-			return res.data;
-		} catch (error) {
-			console.error('Error fetching tasks by employee ID:', error);
-			return [];
-		}
-	}, []);
+		},
+		[getTasksByEmployeeIdQuery]
+	);
 
 	const loadTeamTasksData = useCallback(
 		async (deepCheck?: boolean) => {

--- a/apps/web/core/hooks/tasks/use-task-filter.ts
+++ b/apps/web/core/hooks/tasks/use-task-filter.ts
@@ -42,8 +42,8 @@ export function useTaskFilter(profile: I_UserProfilePage) {
 		[activeTeamManagers, user?.id]
 	);
 	const canSeeActivity = useMemo(
-		() => profile.userProfile?.id === user?.id || isManagerConnectedUser != -1,
-		[isManagerConnectedUser, profile.userProfile?.id, user?.id]
+		() => profile?.userProfile?.id === user?.id || isManagerConnectedUser != -1,
+		[isManagerConnectedUser, profile?.userProfile?.id, user?.id]
 	);
 	const path = usePathname();
 

--- a/apps/web/core/hooks/tasks/use-task-input.ts
+++ b/apps/web/core/hooks/tasks/use-task-input.ts
@@ -10,6 +10,7 @@ import { useAuthenticateUser } from '../auth';
 import { ITask } from '@/core/types/interfaces/task/task';
 import { Nullable } from '@/core/types/generics/utils';
 import { TTag } from '@/core/types/schemas';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 
 export const h_filter = (status: ETaskStatusName, filters: 'closed' | 'open') => {
 	switch (filters) {
@@ -158,9 +159,9 @@ export function useTaskInput({
 			setQuery('');
 			localStorage.setItem('lastTaskIssue', taskIssue || 'Bug');
 			setTaskIssue('');
-			const items = res.data?.items || [];
-			const created = items.find((t: ITask) => t.title === query.trim());
-			if (created && autoActiveTask) setActiveTask(created);
+			const items = res?.items || [];
+			const created = items.find((t: TTask) => t.title === query.trim());
+			if (created && autoActiveTask) setActiveTask(created as any);
 
 			return created;
 		});

--- a/apps/web/core/query/keys/index.ts
+++ b/apps/web/core/query/keys/index.ts
@@ -231,8 +231,8 @@ export const queryKeys = {
 	tasks: {
 		all: ['tasks'] as const,
 		detail: (taskId: string | undefined | null) => ['tasks', ...(taskId ? [taskId] : [])] as const,
-		byEmployee: (employeeId: string | undefined | null) =>
-			['tasks', 'by-employee', ...(employeeId ? [employeeId] : [])] as const,
+		byEmployee: (employeeId: string | undefined | null, teamId: string | undefined | null) =>
+			['tasks', 'by-employee', ...(employeeId ? [employeeId] : []), ...(teamId ? [teamId] : [])] as const,
 		byTeam: (teamId: string | undefined | null) => ['tasks', 'by-team', ...(teamId ? [teamId] : [])] as const,
 		byTeamAndProject: (teamId: string | undefined | null, projectId: string | undefined | null) =>
 			['tasks', 'by-team', ...(teamId ? [teamId] : []), 'project', ...(projectId ? [projectId] : [])] as const,

--- a/apps/web/core/services/client/api/organizations/teams/team-employee.service.ts
+++ b/apps/web/core/services/client/api/organizations/teams/team-employee.service.ts
@@ -10,6 +10,7 @@ import {
 	TOrganizationTeamEmployee,
 	TOrganizationTeamEmployeeUpdate
 } from '@/core/types/schemas';
+import { updateActiveTaskSchema } from '@/core/types/schemas/task/task.schema';
 
 class OrganizationTeamEmployeeService extends APIService {
 	deleteOrganizationEmployeeTeam = async ({
@@ -79,10 +80,7 @@ class OrganizationTeamEmployeeService extends APIService {
 		}
 	};
 
-	updateOrganizationTeamEmployeeActiveTask = async (
-		id: string,
-		data: Partial<TOrganizationTeamEmployeeUpdate>
-	): Promise<TOrganizationTeamEmployee> => {
+	updateOrganizationTeamEmployeeActiveTask = async (id: string, data: Partial<TOrganizationTeamEmployeeUpdate>) => {
 		try {
 			const response = await this.put<TOrganizationTeamEmployee>(
 				`/organization-team-employee/${id}/active-task`,
@@ -91,7 +89,7 @@ class OrganizationTeamEmployeeService extends APIService {
 
 			// Validate API response using utility function
 			return validateApiResponse(
-				organizationTeamEmployeeSchema,
+				updateActiveTaskSchema,
 				response.data,
 				'updateOrganizationTeamEmployeeActiveTask API response'
 			);

--- a/apps/web/core/services/client/api/tasks/task.service.ts
+++ b/apps/web/core/services/client/api/tasks/task.service.ts
@@ -7,143 +7,363 @@ import {
 import { APIService, getFallbackAPI } from '../../api.service';
 import qs from 'qs';
 import { GAUZY_API_BASE_SERVER_URL } from '@/core/constants/config/constants';
-import { ICreateTask } from '@/core/types/interfaces/task/task';
 import { DeleteResponse, PaginationResponse } from '@/core/types/interfaces/common/data-response';
 import { ITask } from '@/core/types/interfaces/task/task';
+import taskSchema, { createTaskSchema, TCreateTask, TTask } from '@/core/types/schemas/task/task.schema';
+import { validateApiResponse, validatePaginationResponse, ZodValidationError } from '@/core/types/schemas';
 
+/**
+ * Enhanced Task Service with Zod validation
+ *
+ * This service extends the base APIService to add schema validation
+ * for all API responses, ensuring data integrity and type safety.
+ */
 class TaskService extends APIService {
-	getTaskById = async (taskId: string) => {
-		const organizationId = getOrganizationIdCookie();
-		const tenantId = getTenantIdCookie();
-
-		const relations = [
-			'tags',
-			'teams',
-			'members',
-			'members.user',
-			'createdByUser',
-			'linkedIssues',
-			'linkedIssues.taskTo',
-			'linkedIssues.taskFrom',
-			'parent',
-			'children'
-		];
-
-		const obj = {
-			'where[organizationId]': organizationId,
-			'where[tenantId]': tenantId,
-			'join[alias]': 'task',
-			'join[leftJoinAndSelect][members]': 'task.members',
-			'join[leftJoinAndSelect][user]': 'members.user',
-			includeRootEpic: 'true'
-		} as Record<string, string>;
-
-		relations.forEach((rl, i) => {
-			obj[`relations[${i}]`] = rl;
-		});
-
-		const query = qs.stringify(obj);
-
-		const endpoint = GAUZY_API_BASE_SERVER_URL.value ? `/tasks/${taskId}?${query}` : `/tasks/${taskId}`;
-
-		return this.get<ITask>(endpoint);
-	};
-
-	getTasks = async (organizationId: string, tenantId: string, projectId: string, teamId: string) => {
-		const relations = [
-			'tags',
-			'teams',
-			'members',
-			'members.user',
-			'createdByUser',
-			'linkedIssues',
-			'linkedIssues.taskTo',
-			'linkedIssues.taskFrom',
-			'parent',
-			'children'
-		];
-
-		const obj = {
-			'where[organizationId]': organizationId,
-			'where[tenantId]': tenantId,
-			'where[projectId]': projectId,
-			'join[alias]': 'task',
-			'join[leftJoinAndSelect][members]': 'task.members',
-			'join[leftJoinAndSelect][user]': 'members.user',
-			'where[teams][0]': teamId
-		} as Record<string, string>;
-
-		relations.forEach((rl, i) => {
-			obj[`relations[${i}]`] = rl;
-		});
-
-		const query = qs.stringify(obj);
-		const endpoint = `/tasks/team?${query}`;
-
-		return this.get<PaginationResponse<ITask>>(endpoint, { tenantId });
-	};
-
-	deleteTask = async (taskId: string) => {
-		return this.delete<DeleteResponse>(`/tasks/${taskId}`);
-	};
-
-	updateTask = async (taskId: string, body: Partial<ITask>) => {
-		if (GAUZY_API_BASE_SERVER_URL.value) {
-			const tenantId = getTenantIdCookie();
+	/**
+	 * Fetches a single task by its ID with validation
+	 *
+	 * @param {string} taskId - Task identifier
+	 * @returns {Promise<TTask>} - Validated task data
+	 * @throws ValidationError if response data doesn't match schema
+	 */
+	getTaskById = async (taskId: string): Promise<TTask> => {
+		try {
 			const organizationId = getOrganizationIdCookie();
-			const teamId = getActiveTeamIdCookie();
-			const projectId = getActiveProjectIdCookie();
-
-			const nBody = { ...body };
-			delete nBody.selectedTeam;
-			delete nBody.rootEpic;
-
-			await this.put(`/tasks/${taskId}`, nBody);
-
-			return this.getTasks(organizationId, tenantId, projectId, teamId);
-		}
-
-		return this.put<PaginationResponse<ITask>>(`/tasks/${taskId}`, body);
-	};
-
-	createTask = async (body: Partial<ICreateTask> & { title: string }) => {
-		if (GAUZY_API_BASE_SERVER_URL.value) {
-			const organizationId = getOrganizationIdCookie();
-			const teamId = getActiveTeamIdCookie();
 			const tenantId = getTenantIdCookie();
-			const projectId = getActiveProjectIdCookie();
-			const title = body.title.trim() || '';
 
-			const datas: ICreateTask = {
-				description: '',
-				teams: [
+			const relations = [
+				'tags',
+				'teams',
+				'members',
+				'members.user',
+				'createdByUser',
+				'linkedIssues',
+				'linkedIssues.taskTo',
+				'linkedIssues.taskFrom',
+				'parent',
+				'children'
+			];
+
+			const obj = {
+				'where[organizationId]': organizationId,
+				'where[tenantId]': tenantId,
+				'join[alias]': 'task',
+				'join[leftJoinAndSelect][members]': 'task.members',
+				'join[leftJoinAndSelect][user]': 'members.user',
+				includeRootEpic: 'true'
+			} as Record<string, string>;
+
+			relations.forEach((rl, i) => {
+				obj[`relations[${i}]`] = rl;
+			});
+
+			const query = qs.stringify(obj);
+
+			const endpoint = GAUZY_API_BASE_SERVER_URL.value ? `/tasks/${taskId}?${query}` : `/tasks/${taskId}`;
+
+			const response = await this.get<ITask>(endpoint);
+
+			// Validate the response data using Zod schema
+			return validateApiResponse(taskSchema, response.data, 'getTaskById API response');
+		} catch (error) {
+			if (error instanceof ZodValidationError) {
+				this.logger.error(
+					'Task by ID validation failed:',
 					{
-						id: teamId
-					}
-				],
-				tags: [],
-				organizationId,
-				tenantId,
-				projectId,
-				estimate: 0,
-				...body,
-				title // this must be called after ...body
-			};
-
-			await this.post('/tasks', datas, { tenantId });
-
-			return this.getTasks(organizationId, tenantId, projectId, teamId);
+						message: error.message,
+						issues: error.issues,
+						taskId
+					},
+					'TaskService'
+				);
+			}
+			throw error;
 		}
-		const api = await getFallbackAPI();
-		return api.post<PaginationResponse<ITask>>('/tasks/team', body);
 	};
 
-	deleteEmployeeFromTasks = async (employeeId: string, organizationTeamId: string) => {
-		return this.delete<DeleteResponse>(`/tasks/employee/${employeeId}?organizationTeamId=${organizationTeamId}`);
+	/**
+	 * Fetches a paginated list of tasks with validation
+	 *
+	 * @param {string} organizationId - Organization identifier
+	 * @param {string} tenantId - Tenant identifier
+	 * @param {string} projectId - Project identifier
+	 * @param {string} teamId - Team identifier
+	 * @returns {Promise<PaginationResponse<TTask>>} - Validated paginated tasks data
+	 * @throws ValidationError if response data doesn't match schema
+	 */
+	getTasks = async (
+		organizationId: string,
+		tenantId: string,
+		projectId: string,
+		teamId: string
+	): Promise<PaginationResponse<TTask>> => {
+		try {
+			const relations = [
+				'tags',
+				'teams',
+				'members',
+				'members.user',
+				'createdByUser',
+				'linkedIssues',
+				'linkedIssues.taskTo',
+				'linkedIssues.taskFrom',
+				'parent',
+				'children'
+			];
+
+			const obj = {
+				'where[organizationId]': organizationId,
+				'where[tenantId]': tenantId,
+				'where[projectId]': projectId,
+				'join[alias]': 'task',
+				'join[leftJoinAndSelect][members]': 'task.members',
+				'join[leftJoinAndSelect][user]': 'members.user',
+				'where[teams][0]': teamId
+			} as Record<string, string>;
+
+			relations.forEach((rl, i) => {
+				obj[`relations[${i}]`] = rl;
+			});
+
+			const query = qs.stringify(obj);
+			const endpoint = `/tasks/team?${query}`;
+
+			const response = await this.get<PaginationResponse<ITask>>(endpoint, { tenantId });
+
+			// Validate the response data using Zod schema
+			return validatePaginationResponse(taskSchema, response.data, 'getTasks API response');
+		} catch (error) {
+			if (error instanceof ZodValidationError) {
+				this.logger.error(
+					'Tasks validation failed:',
+					{
+						message: error.message,
+						issues: error.issues,
+						organizationId,
+						tenantId,
+						projectId,
+						teamId
+					},
+					'TaskService'
+				);
+			}
+			throw error;
+		}
 	};
 
-	getTasksByEmployeeId = async (employeeId: string, organizationTeamId: string) => {
-		return this.get<ITask[]>(`/tasks/employee/${employeeId}?organizationTeamId=${organizationTeamId}`);
+	/**
+	 * Deletes a task by its ID with validation
+	 *
+	 * @param {string} taskId - Task identifier
+	 * @returns {Promise<DeleteResponse>} - Delete operation response
+	 */
+	deleteTask = async (taskId: string): Promise<DeleteResponse> => {
+		try {
+			const response = await this.delete<DeleteResponse>(`/tasks/${taskId}`);
+
+			// Note: Delete operations typically return a simple response, not the deleted entity
+			// So we don't validate against task schema here
+			return response.data;
+		} catch (error) {
+			if (error instanceof ZodValidationError) {
+				this.logger.error(
+					'Task deletion validation failed:',
+					{
+						message: error.message,
+						issues: error.issues,
+						taskId
+					},
+					'TaskService'
+				);
+			}
+			throw error;
+		}
+	};
+
+	/**
+	 * Updates an existing task with validation
+	 *
+	 * @param {string} taskId - Task identifier
+	 * @param {Partial<TTask>} body - Partial task update data
+	 * @returns {Promise<PaginationResponse<TTask>>} - Updated tasks list or single task response
+	 * @throws ValidationError if input or response data doesn't match schema
+	 */
+	updateTask = async (taskId: string, body: Partial<TTask>): Promise<PaginationResponse<TTask>> => {
+		try {
+			// Validate input data before sending (partial validation)
+			const validatedInput = validateApiResponse(
+				taskSchema.partial(),
+				body,
+				'updateTask input data'
+			) as Partial<TTask>;
+
+			if (GAUZY_API_BASE_SERVER_URL.value) {
+				const tenantId = getTenantIdCookie();
+				const organizationId = getOrganizationIdCookie();
+				const teamId = getActiveTeamIdCookie();
+				const projectId = getActiveProjectIdCookie();
+
+				const nBody = { ...validatedInput };
+				delete nBody.selectedTeam;
+				delete nBody.rootEpic;
+
+				await this.put(`/tasks/${taskId}`, nBody);
+
+				return this.getTasks(organizationId, tenantId, projectId, teamId);
+			}
+
+			const response = await this.put<PaginationResponse<ITask>>(`/tasks/${taskId}`, validatedInput);
+
+			// Validate the response data
+			return validatePaginationResponse(taskSchema, response.data, 'updateTask API response');
+		} catch (error) {
+			if (error instanceof ZodValidationError) {
+				this.logger.error(
+					'Task update validation failed:',
+					{
+						message: error.message,
+						issues: error.issues,
+						taskId
+					},
+					'TaskService'
+				);
+			}
+			throw error;
+		}
+	};
+
+	/**
+	 * Creates a new task with validation
+	 *
+	 * @param {Partial<TCreateTask> & { title: string }} body - New task data
+	 * @returns {Promise<PaginationResponse<TTask>>} - Created task or updated tasks list
+	 * @throws ValidationError if input or response data doesn't match schema
+	 */
+	createTask = async (body: Partial<TCreateTask> & { title: string }): Promise<PaginationResponse<TTask>> => {
+		try {
+			if (GAUZY_API_BASE_SERVER_URL.value) {
+				const organizationId = getOrganizationIdCookie();
+				const teamId = getActiveTeamIdCookie();
+				const tenantId = getTenantIdCookie();
+				const projectId = getActiveProjectIdCookie();
+				const title = body.title.trim() || '';
+
+				const datas: TCreateTask = {
+					description: '',
+					teams: [
+						{
+							id: teamId
+						}
+					],
+					tags: [],
+					organizationId,
+					tenantId,
+					projectId,
+					estimate: 0,
+					...body,
+					title // this must be called after ...body
+				};
+
+				// Validate input data before sending
+				const validatedInput = validateApiResponse(
+					createTaskSchema,
+					datas,
+					'createTask input data'
+				) as TCreateTask;
+
+				await this.post('/tasks', validatedInput, { tenantId });
+
+				return this.getTasks(organizationId, tenantId, projectId, teamId);
+			}
+
+			const api = await getFallbackAPI();
+			const response = await api.post<PaginationResponse<ITask>>('/tasks/team', body);
+
+			// Validate the response data
+			return validatePaginationResponse(taskSchema, response.data, 'createTask API response');
+		} catch (error) {
+			if (error instanceof ZodValidationError) {
+				this.logger.error(
+					'Task creation validation failed:',
+					{
+						message: error.message,
+						issues: error.issues
+					},
+					'TaskService'
+				);
+			}
+			throw error;
+		}
+	};
+
+	/**
+	 * Deletes an employee from tasks with validation
+	 *
+	 * @param {string} employeeId - Employee identifier
+	 * @param {string} organizationTeamId - Organization team identifier
+	 * @returns {Promise<DeleteResponse>} - Delete operation response
+	 */
+	deleteEmployeeFromTasks = async (employeeId: string, organizationTeamId: string): Promise<DeleteResponse> => {
+		try {
+			const response = await this.delete<DeleteResponse>(
+				`/tasks/employee/${employeeId}?organizationTeamId=${organizationTeamId}`
+			);
+			return response.data;
+		} catch (error) {
+			if (error instanceof ZodValidationError) {
+				this.logger.error(
+					'Delete employee from tasks validation failed:',
+					{
+						message: error.message,
+						issues: error.issues,
+						employeeId,
+						organizationTeamId
+					},
+					'TaskService'
+				);
+			}
+			throw error;
+		}
+	};
+
+	/**
+	 * Fetches tasks by employee ID with validation
+	 *
+	 * @param {string} employeeId - Employee identifier
+	 * @param {string} organizationTeamId - Organization team identifier
+	 * @returns {Promise<TTask[]>} - Validated array of tasks
+	 * @throws ValidationError if response data doesn't match schema
+	 */
+	getTasksByEmployeeId = async (employeeId: string, organizationTeamId: string): Promise<TTask[]> => {
+		try {
+			const organizationId = getOrganizationIdCookie();
+			const obj = {
+				'where[organizationTeamId]': organizationTeamId,
+				'where[organizationId]': organizationId
+			} as Record<string, string>;
+			const query = qs.stringify(obj);
+
+			const response = await this.get<ITask[]>(`/tasks/employee/${employeeId}?${query}`);
+
+			// Validate the response data using Zod schema
+			return response.data.map((task: any) =>
+				validateApiResponse(taskSchema, task, 'getTasksByEmployeeId API response')
+			);
+		} catch (error) {
+			if (error instanceof ZodValidationError) {
+				this.logger.error(
+					'Tasks by employee ID validation failed:',
+					{
+						message: error.message,
+						issues: error.issues,
+						employeeId,
+						organizationTeamId
+					},
+					'TaskService'
+				);
+			}
+			throw error;
+		}
 	};
 }
 

--- a/apps/web/core/types/generics/enums/task.ts
+++ b/apps/web/core/types/generics/enums/task.ts
@@ -48,7 +48,8 @@ export enum ETaskStatusName {
 	CUSTOM = 'custom',
 	READY_FOR_REVIEW = 'ready-for-review',
 	IN_REVIEW_STATUS = 'in-review',
-	DONE = 'done'
+	DONE = 'done',
+	CANCELLED = 'cancelled'
 }
 export enum ETaskSizeName {
 	X_LARGE = 'X-Large',

--- a/apps/web/core/types/schemas/tag/tag.schema.ts
+++ b/apps/web/core/types/schemas/tag/tag.schema.ts
@@ -32,7 +32,7 @@ export const tagSchema = z
 		tagTypeName: z.string().optional().nullable(),
 		fix_relational_custom_fields: z.any().optional().nullable(),
 		customFields: z.any().optional().nullable(),
-		fullIconUrl: z.record(z.any()).optional().nullable(),
+		fullIconUrl: z.any().optional().nullable(),
 		// Counter fields
 		candidate_counter: z.number().optional(),
 		employee_counter: z.number().optional(),

--- a/apps/web/core/types/schemas/task/task.schema.ts
+++ b/apps/web/core/types/schemas/task/task.schema.ts
@@ -6,26 +6,11 @@ import { taskStatusNameSchema, taskTypeSchema } from '../common/enums.schema';
 import { taskPrioritySchema } from './task-priority.schema';
 import { taskSizeSchema } from './task-size.schema';
 import { taskStatusSchema } from './task-status.schema';
+import { organizationTeamSchema } from '../team/organization-team.schema';
 
 export const basePerTenantAndOrganizationEntitySchema = baseEntitySchema.extend({
 	tenantId: idSchema.optional(),
 	organizationId: idSchema.optional()
-});
-
-// schema for IOrganizationTeam
-export const organizationTeamSchema = basePerTenantAndOrganizationEntitySchema.extend({
-	name: z.string(),
-	prefix: z.string().optional(),
-	emoji: z.string().optional(),
-	teamSize: z.string().optional(),
-	logo: z.string().optional(),
-	imageId: z.string().optional(),
-	color: z.string().optional(),
-	public: z.boolean().nullable(),
-	profile_link: z.string().optional(),
-	tags: z.array(tagSchema).optional().nullable(),
-	members: z.array(employeeSchema).optional().nullable(),
-	managers: z.array(employeeSchema).optional().nullable()
 });
 
 // schema for ITaskSize
@@ -79,25 +64,25 @@ export const baseTaskPropertiesSchema = basePerTenantAndOrganizationEntitySchema
 	title: z.string(),
 	number: z.number().optional(),
 	public: z.boolean().nullable(),
-	prefix: z.string().optional(),
+	prefix: z.string().optional().nullable(),
 	description: z.string().optional(),
-	status: taskStatusNameSchema.optional(),
-	priority: taskPrioritySchema.optional(),
-	size: taskSizeSchema.optional(),
-	issueType: taskTypeSchema.optional(),
-	startDate: z.date().optional(),
-	resolvedAt: z.date().optional(),
-	dueDate: z.date().optional(),
+	status: z.any().optional(),
+	priority: z.any().optional().nullable(),
+	size: z.any().optional().nullable(),
+	issueType: z.any().optional(),
+	startDate: z.any().optional(),
+	resolvedAt: z.any().optional(),
+	dueDate: z.any().optional(),
 	estimate: z.number().optional(),
 	isDraft: z.boolean().optional(),
 	isScreeningTask: z.boolean().optional(),
-	version: z.string().optional()
+	version: z.string().optional().nullable()
 });
 
 // schema for ITaskAssociations
 export const taskAssociationsSchema = z.object({
 	tags: z.array(tagSchema).optional(),
-	projectId: idSchema.optional(),
+	projectId: z.string().optional().nullable(),
 	members: z.array(employeeSchema).optional(),
 	teams: z.array(organizationTeamSchema).optional()
 });
@@ -105,36 +90,36 @@ const baseTaskSchema = z.object({
 	title: z.string(),
 	number: z.number().optional(),
 	public: z.boolean().nullable(),
-	prefix: z.string().optional(),
+	prefix: z.string().optional().nullable(),
 	description: z.string().optional(),
-	status: taskStatusNameSchema.optional(),
-	priority: taskPrioritySchema.optional(),
-	size: taskSizeSchema.optional(),
-	issueType: taskTypeSchema.optional(),
-	startDate: z.date().optional(),
-	resolvedAt: z.date().optional(),
-	dueDate: z.date().optional(),
+	status: z.any().optional(),
+	priority: z.any().optional().nullable(),
+	size: z.any().optional().nullable(),
+	issueType: z.any().optional().nullable(),
+	startDate: z.any().optional().nullable(),
+	resolvedAt: z.any().optional().nullable(),
+	dueDate: z.any().optional().nullable(),
 	estimate: z.number().optional(),
 	isDraft: z.boolean().optional(),
 	isScreeningTask: z.boolean().optional(),
-	version: z.string().optional(),
+	version: z.string().optional().nullable(),
 	tags: z.array(tagSchema).optional().nullable(),
-	projectId: idSchema.optional(),
-	members: z.array(employeeSchema).optional(),
+	projectId: z.string().optional().nullable(),
+	members: z.array(z.any()).optional(),
 	teams: z.array(organizationTeamSchema).optional(),
 
-	parentId: idSchema.optional(),
+	parentId: z.string().optional().nullable(),
 	children: z.array(z.any()).optional().nullable(),
 	rootEpic: z.any().optional().nullable(),
 	// Relations with the entities of status, size, priority and type
 	taskStatus: taskStatusSchema.optional(),
-	taskStatusId: idSchema.optional(),
+	taskStatusId: z.string().optional().nullable(),
 	taskSize: taskSizeEntitySchema.optional(),
-	taskSizeId: idSchema.optional(),
+	taskSizeId: z.string().optional().nullable(),
 	taskPriority: taskPriorityEntitySchema.optional(),
-	taskPriorityId: idSchema.optional(),
+	taskPriorityId: z.string().optional().nullable(),
 	taskType: issueTypeEntitySchema.optional(),
-	taskTypeId: idSchema.optional(),
+	taskTypeId: z.string().optional().nullable(),
 
 	// Additional properties specific to tasks
 	taskNumber: z.string().optional(),
@@ -148,28 +133,28 @@ const baseTaskSchema = z.object({
 // schema for ITask
 export const taskSchema = baseTaskPropertiesSchema
 	.merge(baseTaskSchema)
-	.merge(taskAssociationsSchema)
+	// .merge(taskAssociationsSchema)
 	.extend({
 		// Relations with other tasks
 		parent: baseTaskSchema.optional().nullable(),
-		parentId: idSchema.optional(),
+		parentId: z.string().optional().nullable(),
 		children: z.array(baseTaskSchema).optional().nullable(),
 		rootEpic: baseTaskSchema.optional().nullable(),
 
 		// Relations with the entities of status, size, priority and type
 		taskStatus: taskStatusSchema.optional(),
-		taskStatusId: idSchema.optional(),
+		taskStatusId: z.string().optional().nullable(),
 		taskSize: taskSizeEntitySchema.optional(),
-		taskSizeId: idSchema.optional(),
+		taskSizeId: z.string().optional().nullable(),
 		taskPriority: taskPriorityEntitySchema.optional(),
-		taskPriorityId: idSchema.optional(),
+		taskPriorityId: z.string().optional().nullable(),
 		taskType: issueTypeEntitySchema.optional(),
-		taskTypeId: idSchema.optional(),
+		taskTypeId: z.string().optional().nullable(),
 
 		// Additional properties specific to tasks
 		taskNumber: z.string().optional(),
 		totalWorkedTime: z.number().optional(),
-		selectedTeam: organizationTeamSchema.optional(),
+		// selectedTeam: organizationTeamSchema.optional(),
 		linkedIssues: z.array(taskLinkedIssueSchema).optional(),
 		label: z.string().optional(),
 		estimateHours: z.number().optional(),
@@ -210,6 +195,12 @@ export const createTaskSchema = z.object({
 	organizationId: z.string(),
 	tenantId: z.string(),
 	projectId: z.string().nullable().optional()
+});
+
+export const updateActiveTaskSchema = z.object({
+	affected: z.number(),
+	generatedMaps: z.array(z.any()),
+	raw: z.array(z.any())
 });
 
 // ===== TYPES TYPESCRIPT EXPORTED =====


### PR DESCRIPTION
## Description

- Migrate use team tasks to use React query
- Add zod validation to use team tasks api calls

## ✅ Checklist

Please confirm you did the following before asking for review:

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a "cancelled" task status across the application.

- **Bug Fixes**
  - Improved error safety and type handling in task-related components to prevent runtime errors.
  - Enhanced safe property access for optional or nullable fields in task and activity components.

- **Refactor**
  - Standardized data fetching and mutation logic for team tasks using React Query for better performance and reliability.
  - Updated task service to use schema validation for all API responses and inputs, improving data integrity.
  - Optimized rendering performance in activity components using memoization.
  - Simplified task state handling by directly using task objects without unnecessary data property checks.

- **Chores**
  - Relaxed type constraints in task and tag schemas for broader compatibility.
  - Cleaned up redundant UI code and improved code consistency in several components.
  - Improved type annotations for task input components and query keys for enhanced type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->