### PR TITLE
[Fix] Fix task input value on task creation

### DIFF
--- a/apps/web/core/components/tasks/task-input.tsx
+++ b/apps/web/core/components/tasks/task-input.tsx
@@ -135,10 +135,7 @@ export function TaskInput(props: Props) {
 	);
 
 	useEffect(() => {
-		// Don't reset query during task creation to maintain the creation UI
-		if (!datas.isCreatingTask) {
-			setQuery(taskName === inputTask?.title ? '' : taskName);
-		}
+		setQuery(taskName === inputTask?.title ? '' : taskName);
 	}, [taskName, inputTask, setQuery, datas.isCreatingTask]);
 
 	useEffect(() => {


### PR DESCRIPTION
## Description

- Fix the task input value on task creation : The full title entered by the user is now saved and persisted without being cut off.

## Previous behavior


https://github.com/user-attachments/assets/90e63c54-31a1-4144-b9cb-09bc84fc1b00



## Current behavior


https://github.com/user-attachments/assets/64231977-b15e-4f56-822b-fac9c652e02c



## ✅ Checklist

Please confirm you did the following before asking for review:

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced