### PR TITLE
[Web]-Refactor: Update styling for task filters and date range components

### DIFF
--- a/apps/web/core/components/pages/profile/task-filters.tsx
+++ b/apps/web/core/components/pages/profile/task-filters.tsx
@@ -62,7 +62,7 @@ export function TaskFilter({ className, hook, profile }: IClassName & Props) {
 				leave="transition duration-75 ease-out"
 				leaveFrom="transform scale-100 opacity-100"
 				leaveTo="transform scale-95 opacity-0 ease-out"
-				className="w-full"
+				className="mt-5 w-full"
 				ref={hook.tab !== 'dailyplan' ? hook.outclickFilterCard.targetEl : null}
 			>
 				{hook.filterType !== undefined && <Divider className="mt-1" />}
@@ -219,11 +219,11 @@ export function TaskStatusFilter({ hook, employeeId }: { hook: I_TaskFilter; emp
 	const { date, setDate, data } = useDateRange(dailyPlanTab);
 	return (
 		<div className="flex flex-col items-center pt-2 mt-4 space-x-2 md:justify-between md:flex-row">
-			<div className="flex flex-wrap flex-1 justify-center space-x-3 md:justify-start">
+			<div className="flex flex-wrap flex-1 justify-center mb-2 space-x-3 h-9 md:justify-start">
 				<TaskStatusDropdown
 					key={key + 1}
 					onValueChange={(_, values) => hook.onChangeStatusFilter('status', values || [])}
-					className="min-w-fit lg:max-w-[170px] mt-4 mb-2 lg:mt-0"
+					className="min-w-fit lg:max-w-[170px] mt-4 mb-2 lg:mb-0 lg:mt-0 h-7"
 					multiple={true}
 					isMultiple={false}
 				/>
@@ -231,7 +231,7 @@ export function TaskStatusFilter({ hook, employeeId }: { hook: I_TaskFilter; emp
 				<TaskPropertiesDropdown
 					key={key + 2}
 					onValueChange={(_, values) => hook.onChangeStatusFilter('priority', values || [])}
-					className="min-w-fit lg:max-w-[170px] mt-4 mb-2 lg:mt-0"
+					className="min-w-fit lg:max-w-[170px] mt-4 mb-2 lg:mb-0 lg:mt-0 h-7"
 					multiple={true}
 					isMultiple={false}
 				/>
@@ -239,7 +239,7 @@ export function TaskStatusFilter({ hook, employeeId }: { hook: I_TaskFilter; emp
 				<TaskSizesDropdown
 					key={key + 3}
 					onValueChange={(_, values) => hook.onChangeStatusFilter('size', values || [])}
-					className="min-w-fit lg:max-w-[170px] mt-4 mb-2 lg:mt-0"
+					className="min-w-fit lg:max-w-[170px] mt-4 mb-2 lg:mb-0 lg:mt-0 h-7"
 					multiple={true}
 					isMultiple={false}
 				/>
@@ -247,7 +247,7 @@ export function TaskStatusFilter({ hook, employeeId }: { hook: I_TaskFilter; emp
 				<TaskLabelsDropdown
 					key={key + 4}
 					onValueChange={(_, values) => hook.onChangeStatusFilter('label', values || [])}
-					className="min-w-fit lg:max-w-[170px] mt-4 mb-2 lg:mt-0 bg-[#F2F2F2] rounded-xl"
+					className="min-w-fit lg:max-w-[170px] mt-4 mb-2 lg:mb-0 lg:mt-0 h-7 !rounded-[8px] text-dark dark:text-white bg-[#F2F2F2] dark:bg-dark--theme-light"
 					multiple={true}
 					isMultiple={false}
 				/>
@@ -259,6 +259,8 @@ export function TaskStatusFilter({ hook, employeeId }: { hook: I_TaskFilter; emp
 						date={date}
 						onSelect={(range: DateRange | undefined) => setDate(range)}
 						label="Planned date"
+						className="min-w-fit lg:max-w-[170px] mt-4 mb-2 lg:mb-0 lg:mt-0 h-7"
+						contentClassName="h-7"
 					/>
 				)}
 				<VerticalSeparator />

--- a/apps/web/core/components/tasks/task-date-range.tsx
+++ b/apps/web/core/components/tasks/task-date-range.tsx
@@ -16,8 +16,16 @@ interface ITaskDatePickerWithRange {
 	onSelect?: (range: DateRange | undefined) => void;
 	label?: string;
 	data?: TDailyPlan[];
+	contentClassName?: string;
 }
-export function TaskDatePickerWithRange({ className, date, onSelect, label, data }: ITaskDatePickerWithRange) {
+export function TaskDatePickerWithRange({
+	className,
+	contentClassName,
+	date,
+	onSelect,
+	label,
+	data
+}: ITaskDatePickerWithRange) {
 	const isDateDisabled = (dateToCheck: Date) => {
 		if (!data || !Array.isArray(data)) return true;
 
@@ -40,8 +48,9 @@ export function TaskDatePickerWithRange({ className, date, onSelect, label, data
 						id="date"
 						variant={'outline'}
 						className={cn(
-							'w-[230px] justify-start text-left font-normal dark:bg-dark--theme-light rounded-xl  mt-4 mb-2 lg:mt-0 h-9',
-							!date && 'text-muted-foreground'
+							'w-[230px] justify-start text-left font-normal dark:bg-dark--theme-light rounded-xl  mt-4 mb-2 lg:mt-0 h-8',
+							!date && 'text-muted-foreground',
+							contentClassName
 						)}
 					>
 						<CalendarDays className="mr-2 w-4 h-4" />


### PR DESCRIPTION
# Update styling for task filters and date range components

- Adjusted class names in TaskFilter and TaskStatusFilter components for improved layout and consistency.
- Modified height properties for dropdowns and date picker to enhance visual alignment.
- Ensured proper spacing and margins for better user experience across task filtering UI.


## How to Test This PR

<img width="3024" height="1646" alt="screenshot-localhost-3030-2025-07-28-21-06-13" src="https://github.com/user-attachments/assets/e309749d-ef6c-483e-8e9e-85984494c212" />


1. Run the app with `yarn web:dev`
2. Open the browser at `http://localhost:3030/profile/[memberId]`
3. Click on the filter and search Button

## Screenshots (if needed)


### Previous screenshots


<img width="1512" height="899" alt="Screenshot 2025-07-28 at 21 07 35" src="https://github.com/user-attachments/assets/681c05a4-5340-4075-84d5-d73f77c2a508" />

<img width="1512" height="899" alt="Screenshot 2025-07-28 at 21 07 24" src="https://github.com/user-attachments/assets/d759e941-8b78-485d-8974-2f1161643dad" />

### Current screenshots

<img width="3024" height="1646" alt="screenshot-localhost-3030-2025-07-28-21-07-50" src="https://github.com/user-attachments/assets/6701bbf2-fd6f-45cd-9b1e-ae5faf64153a" />

<img width="3024" height="1646" alt="screenshot-localhost-3030-2025-07-28-21-08-11" src="https://github.com/user-attachments/assets/78ffa741-6b8c-41a0-aadc-3a5c9c1713e6" />


## Related Issues

Please list related issues, tasks or discussions:

Example:
>
> - Closes #12343434344
> - Related to #567834232

## Type of Change

- [ ] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

Please confirm you did the following before asking for review:

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

