### PR TITLE
[Fix Bug] Personal settings page | Infinite api calls when the user did not set the timezone

### DIFF
--- a/apps/web/core/components/pages/settings/personal/personal-setting-form.tsx
+++ b/apps/web/core/components/pages/settings/personal/personal-setting-form.tsx
@@ -1,18 +1,7 @@
-import { useLanguage, useSettings } from '@/core/hooks';
-import { userState } from '@/core/stores';
 import { Button, Text, ThemeToggler } from '@/core/components';
-import { useTheme } from 'next-themes';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useTranslations } from 'next-intl';
-import { useAtom } from 'jotai';
-import validator from 'validator';
-import { EmailResetModal } from '../../../features/users/email-reset-modal';
-import { LanguageDropDown } from '../../../common/language-dropdown';
-import { TimezoneDropDown } from '../../../settings/timezone-dropdown';
-import { useRouter } from 'next/navigation';
 import InternationalPhoneInput from '@/core/components/common/international-phone-Input';
 import { InputField } from '@/core/components/duplicated-components/_input';
+import { useLanguage, useSettings } from '@/core/hooks';
 import {
 	getActiveLanguageIdCookie,
 	getActiveTimezoneIdCookie,
@@ -20,6 +9,17 @@ import {
 	setActiveTimezoneCookie,
 	userTimezone
 } from '@/core/lib/helpers/index';
+import { userState } from '@/core/stores';
+import { useAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
+import { useTheme } from 'next-themes';
+import { useRouter } from 'next/navigation';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import validator from 'validator';
+import { LanguageDropDown } from '../../../common/language-dropdown';
+import { EmailResetModal } from '../../../features/users/email-reset-modal';
+import { TimezoneDropDown } from '../../../settings/timezone-dropdown';
 
 interface IValidation {
 	email: boolean;


### PR DESCRIPTION
## Description

- Fix infinite API calls on personal settings page when the user has not set the timezone

## Previous behavior

https://github.com/user-attachments/assets/9cfdb8ab-994d-4250-9987-da51d24b2b00

## Current behavior

https://github.com/user-attachments/assets/a0588418-e1a8-4cd3-88fd-b3745919ead9


## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-time timezone auto-detect with a DETECT button and form fields initialized from user data/cookies.
  * Language changes now persist and propagate when updated.

* **Bug Fixes**
  * Prevents redundant timezone saves and avoids updates for missing user data.
  * Validates email before applying contact changes and shows email-reset flow when needed.

* **Improvements**
  * Smoother full-name/contact edit flows; single submit applies multiple updates.
  * UI reorganized into clearer sections and small UX cleanups.

* **Refactor**
  * Handlers and state updates streamlined for reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->