### PR TITLE
[FixBug] Home page | Active Task block | Project dropdown (empty state)

### DIFF
--- a/apps/web/core/components/pages/task/details-section/blocks/task-secondary-info.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-secondary-info.tsx
@@ -454,12 +454,12 @@ export function ProjectDropDown(props: ITaskProjectDropdownProps) {
 							<EverCard
 								shadow="bigger"
 								className={clsxm(
-									'p-0 md:p-0 shadow-xl card dark:shadow-lg card-white dark:bg-[#1c1f26] dark:border dark:border-transparent flex flex-col gap-2.5 h-[13rem] max-h-[13rem] overflow-x-auto rounded-none overflow-hidden',
+									'p-0 md:p-4 shadow-xl card dark:shadow-lg card-white dark:bg-[#1c1f26] dark:border dark:border-transparent flex flex-col gap-2.5 min-h-[6rem]  h-[13rem]  max-h-[13rem] overflow-x-auto rounded-none overflow-hidden',
 									styles?.listCard
 								)}
 							>
-								<ScrollArea className="w-full h-full">
-									<div className="flex flex-col gap-2.5 w-full p-4">
+								<ScrollArea className="w-full !h-full ">
+									<div className="flex flex-col gap-2.5 h-[11rem]  w-full">
 										{validProjects?.map((item) => {
 											return (
 												<DropdownMenuItem
@@ -489,7 +489,7 @@ export function ProjectDropDown(props: ITaskProjectDropdownProps) {
 												</DropdownMenuItem>
 											);
 										})}
-										<div className="mt-2">
+										<div className="mt-auto">
 											{!controlled && (
 												<Button
 													className=" px-2 py-1 w-full !justify-start !gap-2  !min-w-min h-[2rem] rounded-lg text-xs dark:text-white dark:border-gray-800"

--- a/apps/web/core/components/pages/task/details-section/blocks/task-secondary-info.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-secondary-info.tsx
@@ -41,6 +41,7 @@ import { EIssueType } from '@/core/types/generics/enums/task';
 import { TOrganizationProject, TTaskVersion } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useTaskLabelsValue } from '@/core/hooks/tasks/use-task-labels-value';
+import { cn } from '@/core/lib/helpers';
 
 type StatusType = 'version' | 'epic' | 'status' | 'label' | 'size' | 'priority';
 
@@ -384,47 +385,60 @@ export function ProjectDropDown(props: ITaskProjectDropdownProps) {
 		<>
 			<div
 				className={clsxm(
-					'relative text-xs font-medium border text-[0.625rem] w-fit h-fit max-w-[7.6875rem] rounded-[8px]',
+					'relative text-xs font-medium border text-[0.625rem] w-fit h-fit max-w-[10rem] min-w-[6rem] !rounded-[8px]',
 					styles?.container
 				)}
 			>
 				<DropdownMenu>
-					<div>
-						<DropdownMenuTrigger asChild>
+					<div className="w-full">
+						<DropdownMenuTrigger className="w-full" asChild>
 							<button
 								className={clsxm(
 									`cursor-pointer outline-none min-w-fit w-full flex dark:text-white
 										items-center justify-between h-fit p-1
 										border-solid border-color-[#F2F2F2]
-										dark:bg-[#1B1D22] dark:border dark:border-gray-800 rounded-lg`,
+										dark:bg-[#1B1D22] dark:border dark:border-gray-800 gap-[.4rem] rounded-lg`,
 									styles?.value
 								)}
 								aria-label={selected ? `Current project: ${selected.name}` : 'Select a project'}
 							>
-								{selected ? (
-									<div className="flex gap-1 items-center mx-1 w-fit">
-										{selected.imageUrl && (
-											<Image
-												className="w-4 h-4 rounded-full"
-												src={selected.imageUrl}
-												alt={selected.name || ''}
-												width={25}
-												height={25}
-											/>
-										)}
-										<span className="overflow-hidden whitespace-nowrap max-w-20 text-ellipsis">
-											{updateLoading ? <SpinnerLoader size={10} /> : selected?.name || 'Project'}
-										</span>
-									</div>
-								) : (
-									<CircleIcon className="w-4 h-4" />
-								)}
-								<ChevronDownIcon
-									className={clsxm(
-										'w-5 h-5 transition duration-150 ease-in-out group-hover:text-opacity-80 text-default dark:text-white'
+								<div className="flex gap-1 items-center w-fit">
+									{selected?.imageUrl ? (
+										<Image
+											className="w-4 h-4 rounded-full"
+											src={selected.imageUrl}
+											alt={selected.name || ''}
+											width={25}
+											height={25}
+										/>
+									) : (
+										<CircleIcon
+											className={clsxm(
+												'w-4 h-4',
+												!selected && '!text-[#64748b] dark:text-white/70'
+											)}
+										/>
 									)}
-									aria-hidden="true"
-								/>
+									<span
+										className={cn(
+											'overflow-hidden whitespace-nowrap max-w-20 text-ellipsis',
+											!selected && '!text-[#64748b] dark:text-white/70'
+										)}
+									>
+										{selected?.name || 'Project'}
+									</span>
+								</div>
+
+								{updateLoading ? (
+									<SpinnerLoader size={10} />
+								) : (
+									<ChevronDownIcon
+										className={clsxm(
+											'w-5 h-5 transition duration-150 ease-in-out group-hover:text-opacity-80 text-default dark:text-white'
+										)}
+										aria-hidden="true"
+									/>
+								)}
 							</button>
 						</DropdownMenuTrigger>
 

--- a/apps/web/core/components/pages/task/details-section/blocks/task-secondary-info.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-secondary-info.tsx
@@ -425,7 +425,7 @@ export function ProjectDropDown(props: ITaskProjectDropdownProps) {
 											!selected && '!text-[#64748b] dark:text-white/70'
 										)}
 									>
-										{selected?.name || 'Project'}
+										{selected?.name || t('pages.projects.projectTitle.SINGULAR')}
 									</span>
 								</div>
 


### PR DESCRIPTION
## Description

- Fix the empty state of the project dropdown to follow the style like other dropdowns.
- [Jira](https://evertech.atlassian.net/browse/ETP-75?atlOrigin=eyJpIjoiNmMwNWY3NjY0Yjc5NDcwMDkzNmI5MjdhODlkZGRiMDQiLCJwIjoiaiJ9)

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced


## Previous behavior


https://github.com/user-attachments/assets/f55b2961-f385-4226-a512-7dd93584b9ef


## Current Behavior


https://github.com/user-attachments/assets/9c1d928d-45ee-4ff0-ad10-090af1557ca2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right-side loading indicator in the project dropdown.
  * New projects created via quick-create are auto-selected and update the task when applicable.

* **Style**
  * Full-width dropdown trigger with improved spacing and rounded corners.
  * Expanded dropdown panel sizing, min-height, and improved scrolling for clearer visibility.
  * Clearer empty-state visuals with image/icon and truncated project names.
  * Bottom “Remove” action anchored to the footer.

* **Refactor**
  * Layout reflow for more reliable width/height/scroll behavior; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->