### PR TITLE
fix: Skeleton for user team activity on loading in UserTeamCard component

### DIFF
--- a/apps/web/core/components/pages/teams/team/team-members-views/user-team-card/index.tsx
+++ b/apps/web/core/components/pages/teams/team/team-members-views/user-team-card/index.tsx
@@ -22,7 +22,7 @@ import { TaskEstimateInfo } from './task-estimate';
 import { TaskInfo } from './task-info';
 import { UserInfo } from './user-info';
 import { UserTeamCardMenu } from './user-team-card-menu';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useMemo, useState } from 'react';
 import { LazyUserTeamActivity } from '@/core/components/optimized-components';
 import { CollapseUpIcon, ExpandIcon } from '@/core/components/svgs/expand';
 import { activityTypeState } from '@/core/stores/timer/activity-type';
@@ -47,6 +47,7 @@ import { TActivityFilter } from '@/core/types/schemas';
 import { cn } from '@/core/lib/helpers';
 import { ITEMS_LENGTH_TO_VIRTUALIZED } from '@/core/constants/config/constants';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { UserTeamActivitySkeleton } from '@/core/components/common/skeleton/profile-component-skeletons';
 
 type IUserTeamCard = {
 	active?: boolean;
@@ -347,7 +348,11 @@ export function UserTeamCard({
 						<Loader className="animate-spin" />
 					</div>
 				) : null}
-				<LazyUserTeamActivity showActivity={showActivity} member={member} />
+				{showActivity && (
+					<Suspense fallback={<UserTeamActivitySkeleton />}>
+						<LazyUserTeamActivity showActivity={showActivity} member={member} />
+					</Suspense>
+				)}
 			</EverCard>
 			<EverCard
 				shadow="bigger"


### PR DESCRIPTION
# Fix Skeleton for user team activity on loading in UserTeamCard component

[[ETP-80]-[Bug]-Web Activity Tab is open with skeleton after login](https://evertech.atlassian.net/browse/ETP-80)


## Screenshots

### Previous screenshots

https://github.com/user-attachments/assets/11202d29-93db-43e0-8b1f-81fd2ee7b618

### Current screenshots

https://github.com/user-attachments/assets/00bdee12-e59f-4d84-bccf-ef901a98d4d2

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

Please confirm you did the following before asking for review:

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced


[ETP-80]: https://evertech.atlassian.net/browse/ETP-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team member activity now loads on demand, showing a lightweight skeleton while content is fetched.
  * Activity content displays only when expanded/toggled, reducing clutter and improving clarity.
  * Consistent loading experience across all relevant cards.

* **Performance**
  * Faster initial page load and reduced resource usage by deferring activity rendering until needed.

* **UX Improvements**
  * Smoother perception during loading with skeleton placeholders.
  * Eliminates unnecessary activity rendering when not viewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->