### PR TITLE
[FixBug] Newly created team’s task page hides sidebar and header when no tasks exist

### DIFF
--- a/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
+++ b/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
@@ -207,19 +207,21 @@ const TeamTask = () => {
 			}
 			childrenClassName="bg-white dark:bg-dark--theme"
 		>
-			<div className="flex flex-col p-4 pt-6 w-full min-h-full">
+			<div className="flex flex-col p-4 mt-6 w-full min-h-full">
 				<TaskTable columnVisibility={tableColumnsVisibility} currentItems={currentItems} />
 
-				<Paginate
-					total={total}
-					onPageChange={onPageChange}
-					pageCount={pageCount}
-					itemsPerPage={itemsPerPage}
-					itemOffset={itemOffset}
-					endOffset={endOffset}
-					setItemsPerPage={setItemsPerPage}
-					className="mt-auto"
-				/>
+				{tasks.length > 0 && (
+					<Paginate
+						total={total}
+						onPageChange={onPageChange}
+						pageCount={pageCount}
+						itemsPerPage={itemsPerPage}
+						itemOffset={itemOffset}
+						endOffset={endOffset}
+						setItemsPerPage={setItemsPerPage}
+						className="mt-auto"
+					/>
+				)}
 			</div>
 		</MainLayout>
 	);

--- a/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
+++ b/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
@@ -76,16 +76,6 @@ const TeamTask = () => {
 		return <TeamTasksPageSkeleton fullWidth={fullWidth} />;
 	}
 
-	if (tasks.length === 0) {
-		return (
-			<div className="flex flex-col p-4 pt-6 w-full min-h-full">
-				<div className="flex flex-col p-4 pt-6 w-full min-h-full">
-					<TaskTable columnVisibility={tableColumnsVisibility} currentItems={currentItems} />
-				</div>
-			</div>
-		);
-	}
-
 	return (
 		<MainLayout
 			mainHeaderSlot={


### PR DESCRIPTION
## Description

- Fix the team task page for newly created team without tasks

## Previous behavior


https://github.com/user-attachments/assets/276fab1d-d65c-4cab-8f7f-5d6255bc9f56



## Current behavior


https://github.com/user-attachments/assets/9341bc58-e447-46f9-bfaf-a4d72a29c5b5



## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Streamlined tasks page to always show the task table within the main layout.
- Bug Fixes
  - Pagination now appears only when tasks exist, avoiding empty pagination controls.
- Style
  - Adjusted top spacing for the content area (uses margin instead of padding) for more consistent layout.
- Refactor
  - Simplified rendering logic by removing the empty-state branch while preserving loading skeleton behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->