### PR TITLE
[BugFix] Task page showing stale task when switching teams

### DIFF
--- a/apps/web/core/components/teams/teams-dropdown.tsx
+++ b/apps/web/core/components/teams/teams-dropdown.tsx
@@ -63,19 +63,17 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 					/**
 					 * If user is on task page and switches the team,
 					 *
-					 * If the task is not in the new team, set the detailed task to null
+					 * If the task is not in the new team, set the detailed task to null and redirect to home page.
 					 */
-					const doesDetailedTaskExtisInNewTeam = item.data.tasks?.some(
-						(task) => task.id === detailedTask?.id
-					);
-					if (!doesDetailedTaskExtisInNewTeam) {
+					const taskBelongsToNewTeam = item.data.tasks?.some((task) => task.id === detailedTask?.id);
+					if (!taskBelongsToNewTeam) {
 						setDetailedTask(null);
 						router.push('/');
 					}
 				}
 			}
 		},
-		[setActiveTeam, stopTimer, t, setDetailedTask, path, router] // Removed timerStatus and activeTeam to prevent constant recreation
+		[setActiveTeam, stopTimer, t, setDetailedTask, path, router, detailedTask] // Removed timerStatus and activeTeam to prevent constant recreation
 	);
 
 	// Create items from teams - keep it simple to avoid circular dependencies


### PR DESCRIPTION
## Description

- When switching to a team that does not contain the currently displayed task, the task page now redirects to the home page. 

## Previous behavior


https://github.com/user-attachments/assets/e7aa7cda-9fa8-4acf-b20f-084352f08640

## Current behavior


https://github.com/user-attachments/assets/5972e888-c0fb-4cba-afd6-03b7865280f3


## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When switching teams while viewing a task, the app now verifies the task belongs to the selected team; if not, the task view is cleared and you’re redirected to the home page to avoid invalid task display.
  * Improved navigation consistency after changing teams from task pages.

* **Chores**
  * Updated internal handling to support the new navigation and state behavior during team changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->