### PR TITLE
[FixBug] Infinite loop: assignTask + log functions firing repeatedly when Assign Task popup is open (Profile Page | Unassigned Tab)

### DIFF
--- a/apps/web/core/components/common/image-overlapper.tsx
+++ b/apps/web/core/components/common/image-overlapper.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import Skeleton from 'react-loading-skeleton';
 import { ScrollArea } from '@/core/components/common/scroll-bar';
 import { useModal, useTeamTasks } from '@/core/hooks';
-import { Modal, Divider } from '@/core/components';
+import { Modal, Divider, SpinnerLoader } from '@/core/components';
 import { useTranslations } from 'next-intl';
 import { TaskAssignButton } from '@/core/components/tasks/task-assign-button';
 import { clsxm } from '@/core/lib/utils';
@@ -71,7 +71,7 @@ export default function ImageOverlapper({
 	const [assignedMembers, setAssignedMembers] = useState<TEmployee[]>([...(item?.members || [])]);
 	const [unassignedMembers, setUnassignedMembers] = useState<TEmployee[]>([]);
 	const [showInfo, setShowInfo] = useState<boolean>(false);
-	const { updateTask } = useTeamTasks();
+	const { updateTask, updateLoading } = useTeamTasks();
 
 	const t = useTranslations();
 
@@ -113,6 +113,7 @@ export default function ImageOverlapper({
 	);
 
 	const onConfirm = useCallback(async () => {
+		if (updateLoading) return;
 		try {
 			await updateTask({
 				...item,
@@ -123,7 +124,7 @@ export default function ImageOverlapper({
 		} catch (error) {
 			console.error('Error updating task members:', error);
 		}
-	}, [closeModal, updateTask, item, assignedMembers]);
+	}, [closeModal, updateTask, item, assignedMembers, updateLoading]);
 
 	const hasMembers = item?.members?.length > 0;
 
@@ -217,12 +218,13 @@ export default function ImageOverlapper({
 								<TaskAvatars task={{ members: assignedMembers }} limit={3} />
 								<div className="flex px-4 h-fit">
 									<button
-										className="flex flex-row gap-1 justify-center items-center px-4 py-2 w-28 min-w-0 h-12 text-sm text-white rounded-xl bg-primary dark:bg-primary-light disabled:bg-primary-light disabled:opacity-40"
+										className="flex flex-row gap-3 justify-center items-center px-2 py-2 w-28 min-w-0 h-12 text-sm text-white rounded-xl bg-primary dark:bg-primary-light disabled:bg-primary-light disabled:opacity-40"
+										disabled={updateLoading}
 										onClick={() => {
 											onConfirm();
 										}}
 									>
-										<IconsCheck fill="#ffffff" />
+										{updateLoading ? <SpinnerLoader size={20} /> : <IconsCheck fill="#ffffff" />}
 										{t('common.CONFIRM')}
 									</button>
 								</div>

--- a/apps/web/core/components/teams/team-member.tsx
+++ b/apps/web/core/components/teams/team-member.tsx
@@ -1,50 +1,24 @@
 import { useTeamMemberCard } from '@/core/hooks';
-import { useEffect } from 'react';
-import { IEmployee } from '@/core/types/interfaces/organization/employee';
+import { useCallback } from 'react';
 import { IconsCheck } from '@/core/components/icons';
 import { UserInfo } from '../pages/teams/team/team-members-views/user-team-card/user-info';
 
-export default function TeamMember({
-	member,
-	item,
-	onCheckMember,
-	membersList,
-	validate
-}: {
-	member: any;
-	item: any;
-	onCheckMember: any;
-	membersList: any;
-	validate: any;
-}) {
+export default function TeamMember({ member, onClick, assigned }: { member: any; onClick: any; assigned: boolean }) {
 	const memberInfo = useTeamMemberCard(member);
-	const { assignTask } = useTeamMemberCard(member);
-	const checkAssign = membersList.assignedMembers.some((el: IEmployee) => el.id === member.employeeId);
-	const checkUnassign = membersList.unassignedMembers.some((el: IEmployee) => el.id === member.employeeId);
 
-	useEffect(() => {
-		if (validate) {
-			if (checkAssign) {
-				assignTask(item);
-			} else if (checkUnassign) {
-				memberInfo.unassignTask(item);
-			}
-		}
-	}, [validate, checkAssign, checkUnassign, item, assignTask, memberInfo]);
-
-	const assignMember = () => {
-		onCheckMember(member.employee);
-	};
+	const toggleMember = useCallback(() => {
+		onClick(member.employee);
+	}, [onClick, member]);
 
 	return (
 		<div
 			onClick={() => {
-				assignMember();
+				toggleMember();
 			}}
 			className="w-100 cursor-pointer flex items-center"
 		>
 			<UserInfo memberInfo={memberInfo} className="2xl:w-[20.625rem] w-100 pointer-events-none" />
-			{checkAssign ? <IconsCheck fill="#3826a6" /> : <></>}
+			{assigned ? <IconsCheck fill="#3826a6" /> : <></>}
 		</div>
 	);
 }

--- a/apps/web/core/hooks/organizations/teams/use-team-member-card.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-member-card.ts
@@ -196,10 +196,11 @@ export function useTeamMemberCard(member: TOrganizationTeamEmployee | undefined)
 			if (!member?.employeeId) {
 				return Promise.resolve();
 			}
+			console.log(task.members, member);
 			setAssignTaskLoading(true);
 			return updateTask({
 				...task,
-				members: [...(task.members || []), (member ? member.employee : {}) as any]
+				members: [...(task.members || []), (member ? member : {}) as any]
 			}).then(() => {
 				if (isAuthUser && !activeTeamTask) {
 					setActiveTask(task);

--- a/apps/web/core/types/schemas/organization/employee.schema.ts
+++ b/apps/web/core/types/schemas/organization/employee.schema.ts
@@ -83,7 +83,7 @@ export const employeeSchema = z
 				id: uuIdSchema,
 				fullName: z.string(),
 				email: z.string(),
-				phone: z.string(),
+				phone: z.string().nullable().optional(),
 				avatar: z.string().nullable().optional()
 			})
 			.passthrough()


### PR DESCRIPTION
## Description

- Opening the Assign Task popup does not trigger `assignTask` automatically.
- No repeated calls to `assignTask` or logging while the popup is idle.
- Confirming the assignment triggers a single API call and a single log event.
- [JIRA Ticket](https://evertech.atlassian.net/browse/ETP-91?atlOrigin=eyJpIjoiNThhOTNiZjRmZGY5NGJhM2JhNDljNzY4NmIxMzc4NjMiLCJwIjoiaiJ9)


## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced