### PR TITLE
Refactor: [Web] get team invitation handling to support role filtering and use single request

### DIFF
--- a/apps/web/app/api/invite/route.ts
+++ b/apps/web/app/api/invite/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: Request) {
 		return NextResponse.json({ error: 'Unauthorized' });
 	}
 
-	// WORKAROUND: Use combined request to get all invitations (EMPLOYEE + non-EMPLOYEE)
+	// Get all team invitations (all roles)
 	const { data } = await getAllTeamInvitationsRequest(
 		{
 			tenantId,

--- a/apps/web/app/api/roles/options/route.ts
+++ b/apps/web/app/api/roles/options/route.ts
@@ -69,7 +69,7 @@ export async function POST(req: Request) {
 		access_token
 	);
 
-	// WORKAROUND: Use combined request to get all invitations (EMPLOYEE + non-EMPLOYEE)
+	// Get all team invitations (all roles)
 	const { data } = await getAllTeamInvitationsRequest(
 		{
 			tenantId,

--- a/apps/web/core/services/client/api/organizations/teams/invites/invite.service.ts
+++ b/apps/web/core/services/client/api/organizations/teams/invites/invite.service.ts
@@ -88,19 +88,17 @@ class InviteService extends APIService {
 	};
 
 	/**
-	 * WORKAROUND: Get all team invitations by combining EMPLOYEE and non-EMPLOYEE requests
+	 * Get team invitations with optional role filtering
 	 *
-	 * This is needed due to a bug in Gauzy API where:
-	 * - No role filter = automatically applies `role: { name: Not(RolesEnum.EMPLOYEE) }`
-	 * - This excludes EMPLOYEE invitations by default
-	 *
-	 * TODO: Remove this workaround once Gauzy API is fixed
+	 * Now that the Gauzy API bug is fixed, we can:
+	 * - Get all invitations by not specifying roles (returns all roles by default)
+	 * - Filter by specific roles by passing a roles array
 	 */
 	getTeamInvitations = async (requestParams: IGetInvitationRequest): Promise<PaginationResponse<TInvite>> => {
 		try {
-			const { teamId, ...remainingParams } = requestParams;
+			const { teamId, roles, ...remainingParams } = requestParams;
 
-			const baseQuery: Record<string, string> = {
+			const baseQuery: Record<string, any> = {
 				'where[tenantId]': this.tenantId,
 				'where[organizationId]': this.organizationId,
 				'where[status]': EInviteStatus.INVITED
@@ -110,40 +108,33 @@ class InviteService extends APIService {
 				baseQuery['where[teams][id][0]'] = teamId;
 			}
 
-			// Add remaining params (excluding role as we handle it specially)
+			// Add role filter if roles are specified˝˝
+			if (roles && roles.length > 0) {
+				if (roles.length === 1) {
+					// Single role filter
+					baseQuery['where[role][name]'] = roles[0];
+				} else {
+					// Multiple roles filter - use array format
+					roles.forEach((role, index) => {
+						baseQuery[`where[role][name][${index}]`] = role;
+					});
+				}
+			}
+
+			// Add remaining params
 			(Object.keys(remainingParams) as (keyof typeof remainingParams)[]).forEach((key) => {
-				if (remainingParams[key] && key !== 'role') {
+				if (remainingParams[key]) {
 					baseQuery[`where[${key}]`] = remainingParams[key] as string;
 				}
 			});
 
-			// Execute both requests in parallel for better performance
-			const [employeeResponse, nonEmployeeResponse] = await Promise.all([
-				// Request 1: Get EMPLOYEE invitations explicitly
-				this.get<PaginationResponse<TInvite>>(
-					`/invite?${qs.stringify({ ...baseQuery, 'where[role][name]': 'EMPLOYEE' })}`,
-					{ tenantId: this.tenantId }
-				),
-				// Request 2: Get non-EMPLOYEE invitations (no role filter = gets MANAGER, ADMIN, etc.)
-				this.get<PaginationResponse<TInvite>>(`/invite?${qs.stringify(baseQuery)}`, { tenantId: this.tenantId })
-			]);
+			// Single request to get invitations
+			const response = await this.get<PaginationResponse<TInvite>>(`/invite?${qs.stringify(baseQuery)}`, {
+				tenantId: this.tenantId
+			});
 
-			// Combine results and deduplicate by invitation ID
-			const allInvitations = [...(employeeResponse.data.items || []), ...(nonEmployeeResponse.data.items || [])];
-
-			// Remove duplicates based on invitation ID (safety measure)
-			const uniqueInvitations = allInvitations.filter(
-				(invitation, index, array) => array.findIndex((inv) => inv.id === invitation.id) === index
-			);
-
-			const combinedResult = {
-				...employeeResponse.data,
-				items: uniqueInvitations,
-				total: uniqueInvitations.length
-			};
-
-			// Validate the combined response data using Zod schema
-			return validatePaginationResponse(inviteSchema, combinedResult, 'getTeamInvitations API response');
+			// Validate the response data using Zod schema
+			return validatePaginationResponse(inviteSchema, response.data, 'getTeamInvitations API response');
 		} catch (error) {
 			if (error instanceof ZodValidationError) {
 				this.logger.error(

--- a/apps/web/core/types/interfaces/user/invite.ts
+++ b/apps/web/core/types/interfaces/user/invite.ts
@@ -81,7 +81,7 @@ export interface TeamInvitationsQueryParams {
 }
 
 export interface IGetInvitationRequest {
-	role?: string;
+	roles?: string[];
 	teamId?: string;
 	status?: EInviteStatus;
 }


### PR DESCRIPTION
# Refactor Get team invitation API handling to support role filtering and use single request

Previously we made 2 parallel requests to get all team invitations due to a Gauzy API bug that excluded EMPLOYEE roles by default. The backend bug is now fixed.

## Solution
- Updated `ITeamInvitationsRequest` to accept `roles?: ERoleName[]` instead of `role?: ERoleName`
- Modified `getTeamInvitationsRequest()` to handle role arrays
- Simplified `getAllTeamInvitationsRequest()` to use single API call
- Updated client-side `getTeamInvitations()` to use single request
- Removed dual request workaround logic

## Benefits
- Better performance (1 request instead of 2)
- Cleaner code without workaround logic
- Support for filtering multiple specific roles

No breaking changes. All existing functionality preserved.