### PR TITLE
[FixBug] Prevent unexpected 403s for API calls with sensitive relations

### DIFF
--- a/apps/web/app/[locale]/(main)/reports/weekly-limit/page.tsx
+++ b/apps/web/app/[locale]/(main)/reports/weekly-limit/page.tsx
@@ -28,7 +28,7 @@ import {
 	LazyTimeReportTableByMember,
 	LazyPaginate
 } from '@/core/components/optimized-components/reports';
-import { activeTeamState, isTrackingEnabledState } from '@/core/stores';
+import { activeTeamState, isTrackingEnabledState, myPermissionsState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
@@ -41,6 +41,7 @@ function WeeklyLimitReport() {
 	const tenantId = getTenantIdCookie();
 	const [groupBy, setGroupBy] = useState<TGroupByOption[]>(['date']);
 	const t = useTranslations();
+	const myPermissions = useAtomValue(myPermissionsState);
 	const breadcrumbPath = useMemo(
 		() => [
 			{ title: t('common.REPORTS'), href: '/' },
@@ -81,7 +82,10 @@ function WeeklyLimitReport() {
 	// Get the organization
 	useEffect(() => {
 		if (organizationId && tenantId) {
-			getUserOrganizationsRequest({ tenantId, userId: user?.id ?? '' }, accessToken ?? '').then((org) => {
+			getUserOrganizationsRequest(
+				{ tenantId, userId: user?.id ?? '', userPermissions: myPermissions },
+				accessToken ?? ''
+			).then((org) => {
 				setOrganization(org.data.items[0].organization);
 			});
 		}

--- a/apps/web/core/hooks/roles/use-role-permissions.ts
+++ b/apps/web/core/hooks/roles/use-role-permissions.ts
@@ -75,8 +75,8 @@ export const useRolePermissions = (roleId?: string) => {
 
 	useConditionalUpdateEffect(
 		() => {
-			if (myRolePermissionsQuery.data?.items?.length) {
-				setMyRolePermissions(myRolePermissionsQuery.data.items);
+			if (myRolePermissionsQuery.data?.length) {
+				setMyRolePermissions(myRolePermissionsQuery.data);
 			}
 		},
 		[myRolePermissionsQuery.data],

--- a/apps/web/core/services/client/api/roles/role-permission.service.ts
+++ b/apps/web/core/services/client/api/roles/role-permission.service.ts
@@ -4,6 +4,7 @@ import { GAUZY_API_BASE_SERVER_URL } from '@/core/constants/config/constants';
 import { PaginationResponse } from '@/core/types/interfaces/common/data-response';
 import { validateApiResponse, validatePaginationResponse, ZodValidationError } from '@/core/types/schemas';
 import { rolePermissionSchema, TRolePermission } from '@/core/types/schemas/role/role-permission-schema';
+import { z } from 'zod';
 
 /**
  * Enhanced Role Permission Service with Zod validation
@@ -93,7 +94,11 @@ class RolePermissionService extends APIService {
 			const response = await this.get<PaginationResponse<TRolePermission>>('/role-permissions/me');
 
 			// Validate the response data using Zod schema
-			return validatePaginationResponse(rolePermissionSchema, response.data, 'getMyRolePermissions API response');
+			return validateApiResponse(
+				z.array(rolePermissionSchema),
+				response.data,
+				'getMyRolePermissions API response'
+			);
 		} catch (error) {
 			if (error instanceof ZodValidationError) {
 				this.logger.error(

--- a/apps/web/core/services/client/api/timesheets/time-log.service.ts
+++ b/apps/web/core/services/client/api/timesheets/time-log.service.ts
@@ -31,7 +31,9 @@ import {
 class TimeLogService extends APIService {
 	getTimeLimitsReport = async (params: TGetTimeLimitReport): Promise<TTimeLimitReportList[]> => {
 		const query = qs.stringify({
-			...params
+			...params,
+			tenantId: this.tenantId,
+			organizationId: this.organizationId
 		});
 
 		try {

--- a/apps/web/core/services/client/api/users/user.service.ts
+++ b/apps/web/core/services/client/api/users/user.service.ts
@@ -61,7 +61,7 @@ class UserService extends APIService {
 	getAuthenticatedUserData = async (): Promise<TUser> => {
 		try {
 			// Define the relations to be included in the request
-			const relations = ['role', 'tenant'];
+			const relations = ['role', 'tenant', 'role.rolePermissions'];
 
 			// Construct the query string with 'qs', including the includeEmployee parameter
 			const query = qs.stringify({

--- a/apps/web/core/services/client/api/users/user.service.ts
+++ b/apps/web/core/services/client/api/users/user.service.ts
@@ -61,7 +61,7 @@ class UserService extends APIService {
 	getAuthenticatedUserData = async (): Promise<TUser> => {
 		try {
 			// Define the relations to be included in the request
-			const relations = ['role', 'tenant', 'role.rolePermissions'];
+			const relations = ['role', 'tenant', 'role'];
 
 			// Construct the query string with 'qs', including the includeEmployee parameter
 			const query = qs.stringify({

--- a/apps/web/core/services/client/api/users/user.service.ts
+++ b/apps/web/core/services/client/api/users/user.service.ts
@@ -61,7 +61,7 @@ class UserService extends APIService {
 	getAuthenticatedUserData = async (): Promise<TUser> => {
 		try {
 			// Define the relations to be included in the request
-			const relations = ['role', 'tenant', 'role'];
+			const relations = ['role', 'tenant'];
 
 			// Construct the query string with 'qs', including the includeEmployee parameter
 			const query = qs.stringify({

--- a/apps/web/core/services/server/requests/organization.ts
+++ b/apps/web/core/services/server/requests/organization.ts
@@ -28,7 +28,7 @@ export function getUserOrganizationsRequest(
 	}: {
 		tenantId: string;
 		userId: string;
-		userPermissions: string[];
+		userPermissions?: string[];
 	},
 	bearerToken: string
 ) {
@@ -38,8 +38,6 @@ export function getUserOrganizationsRequest(
 	// Create a new instance of URLSearchParams for query string construction
 	const query = new URLSearchParams();
 
-	console.log(userPermissions);
-
 	// Add user and tenant IDs to the query
 	query.append('where[userId]', userId);
 	query.append('where[tenantId]', tenantId);
@@ -48,7 +46,7 @@ export function getUserOrganizationsRequest(
 	const relations: string[] = [
 		'organization',
 		'organization.contact',
-		...(userPermissions.includes('ALL_ORG_VIEW')
+		...(userPermissions?.includes('ALL_ORG_VIEW')
 			? ['organization.featureOrganizations', 'organization.featureOrganizations.feature']
 			: [])
 	];

--- a/apps/web/core/services/server/requests/organization.ts
+++ b/apps/web/core/services/server/requests/organization.ts
@@ -23,10 +23,12 @@ export function createOrganizationRequest(datas: IOrganizationCreate, bearerToke
 export function getUserOrganizationsRequest(
 	{
 		tenantId,
-		userId
+		userId,
+		userPermissions
 	}: {
 		tenantId: string;
 		userId: string;
+		userPermissions: string[];
 	},
 	bearerToken: string
 ) {
@@ -36,6 +38,8 @@ export function getUserOrganizationsRequest(
 	// Create a new instance of URLSearchParams for query string construction
 	const query = new URLSearchParams();
 
+	console.log(userPermissions);
+
 	// Add user and tenant IDs to the query
 	query.append('where[userId]', userId);
 	query.append('where[tenantId]', tenantId);
@@ -44,8 +48,9 @@ export function getUserOrganizationsRequest(
 	const relations: string[] = [
 		'organization',
 		'organization.contact',
-		'organization.featureOrganizations',
-		'organization.featureOrganizations.feature'
+		...(userPermissions.includes('ALL_ORG_VIEW')
+			? ['organization.featureOrganizations', 'organization.featureOrganizations.feature']
+			: [])
 	];
 	// Append each relation to the query string
 	relations.forEach((relation, index) => {

--- a/apps/web/core/stores/auth/role-permissions.ts
+++ b/apps/web/core/stores/auth/role-permissions.ts
@@ -10,5 +10,6 @@ export const rolePermissionsFormatedState = atom<{
 
 export const myPermissionsState = atom<string[]>((get) => {
 	const myRolePermissions = get(myRolePermissionsState);
-	return myRolePermissions.map((item) => item.permission);
+	const enabled = myRolePermissions.filter((p) => p.enabled && p.permission);
+	return Array.from(new Set(enabled.map((p) => p.permission)));
 });

--- a/apps/web/core/stores/auth/role-permissions.ts
+++ b/apps/web/core/stores/auth/role-permissions.ts
@@ -8,7 +8,7 @@ export const rolePermissionsFormatedState = atom<{
 	[key: string]: TRolePermission;
 }>({});
 
-export const myPermissions = atom<string[]>((get) => {
+export const myPermissionsState = atom<string[]>((get) => {
 	const myRolePermissions = get(myRolePermissionsState);
 	return myRolePermissions.map((item) => item.permission);
 });

--- a/apps/web/core/types/schemas/role/role-permission-schema.ts
+++ b/apps/web/core/types/schemas/role/role-permission-schema.ts
@@ -6,11 +6,11 @@ import { roleSchema } from '@/core/types/schemas/role/role.schema';
 
 export const rolePermissionSchema = z
 	.object({
-		role: roleSchema,
+		role: roleSchema.optional(),
 		roleId: uuIdSchema,
 		permission: z.string(),
 		enabled: z.boolean(),
-		description: z.string()
+		description: z.string().nullable().optional()
 	})
 	.merge(basePerTenantEntityModelSchema)
 	.strict();


### PR DESCRIPTION
## Description

- Allow only ADMIN to get sensitive relations on weekly limit page
- Fix bad request error on weekly limit page

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Weekly limit report now respects user permissions for accurate visibility.
  - Organization data loading includes user permission context to ensure complete feature visibility.
  - Time limit reports are correctly scoped to the selected tenant and organization, improving accuracy.
  - Role permissions loading adjusted to handle non-paginated responses, reducing display inconsistencies.

- Refactor
  - Permission state and validation refined to deduplicate and only expose enabled permissions, improving consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->