### PR TITLE
[FixBug] Unable to switch back to a specific team after selecting “All Teams” view

### DIFF
--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task-times.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task-times.tsx
@@ -18,7 +18,10 @@ export default function UserTeamActiveTaskTimesBlock({
 	const [activeTask, setActiveTask] = useState<TTask | null | undefined>(null);
 
 	useEffect(() => {
-		getTaskById(activeTaskId || '')
+		if (!activeTaskId) {
+			return;
+		}
+		getTaskById(activeTaskId)
 			.then((response) => setActiveTask(response as TTask))
 			.catch((_) => console.log(_));
 

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-task-estimate.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-task-estimate.tsx
@@ -18,7 +18,10 @@ export default function UserTeamActiveTaskEstimateBlock({
 	const { getTaskById } = useTeamTasks();
 
 	useEffect(() => {
-		getTaskById(activeTaskId || '')
+		if (!activeTaskId) {
+			return;
+		}
+		getTaskById(activeTaskId)
 			.then((response) => setActiveTask(response as TTask))
 			.catch((_) => console.log(_));
 

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-card.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-card.tsx
@@ -88,7 +88,10 @@ function UserActiveTaskMenu({ member }: { member: TOrganizationTeamEmployee }) {
 	const { getTaskById } = useTeamTasks();
 
 	useEffect(() => {
-		getTaskById(member.activeTaskId || '')
+		if (!member.activeTaskId) {
+			return;
+		}
+		getTaskById(member.activeTaskId)
 			.then((response) => setActiveTask(response as TTask))
 			.catch((_) => console.log(_));
 

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task-times.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task-times.tsx
@@ -19,6 +19,9 @@ export default function UserTeamActiveTaskTimes({
 	const [activeTask, setActiveTask] = useState<TTask | null | undefined>(null);
 
 	useEffect(() => {
+		if (!member.activeTaskId) {
+			return;
+		}
 		getTaskById(member.activeTaskId || '')
 			.then((response) => setActiveTask(response as TTask))
 			.catch((_) => console.log(_));

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task-times.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task-times.tsx
@@ -22,7 +22,7 @@ export default function UserTeamActiveTaskTimes({
 		if (!member.activeTaskId) {
 			return;
 		}
-		getTaskById(member.activeTaskId || '')
+		getTaskById(member.activeTaskId)
 			.then((response) => setActiveTask(response as TTask))
 			.catch((_) => console.log(_));
 

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-task-estimate.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-task-estimate.tsx
@@ -16,7 +16,10 @@ export default function UserTeamActiveTaskEstimate({
 	const { getTaskById } = useTeamTasks();
 
 	useEffect(() => {
-		getTaskById(member.activeTaskId || '')
+		if (!member.activeTaskId) {
+			return;
+		}
+		getTaskById(member.activeTaskId)
 			.then((response) => setActiveTask(response as TTask))
 			.catch((_) => console.log(_));
 

--- a/apps/web/core/components/teams/team-item.tsx
+++ b/apps/web/core/components/teams/team-item.tsx
@@ -161,10 +161,8 @@ export function TeamItem({
 
 export function AllTeamItem({ title, count }: { title: string; count: number }) {
 	return (
-		<Link href="/all-teams">
-			<div
-				className={clsxm('flex justify-start items-center space-x-2 text-sm', 'mb-4 max-w-full cursor-pointer')}
-			>
+		<Link className="h-full flex items-center " href="/all-teams">
+			<div className={clsxm('flex justify-start items-center space-x-2 text-sm', ' max-w-full cursor-pointer')}>
 				<div>
 					<div
 						className={clsxm(

--- a/apps/web/core/components/teams/teams-dropdown.tsx
+++ b/apps/web/core/components/teams/teams-dropdown.tsx
@@ -5,7 +5,7 @@ import { useProfileValidation } from '@/core/hooks/users/use-profile-validation'
 import { clsxm } from '@/core/lib/utils';
 import { PlusIcon } from '@heroicons/react/24/solid';
 import { Button, Dropdown } from '@/core/components';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AllTeamItem, TeamItem, mapTeamItems } from './team-item';
 import { useTranslations } from 'next-intl';
 import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
@@ -101,6 +101,19 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 		[setActiveTeam, stopTimer, t, setDetailedTask, path, router, timerStatus] // Removed detailedTask and activeTeam to prevent constant recreation
 	);
 
+	useEffect(() => {
+		if (path.includes('/all-teams')) {
+			setTeamItem({
+				key: 'all-teams',
+				Label: () => (
+					<div className="h-[42px] flex items-center">
+						<AllTeamItem title={t('common.ALL_TEAMS')} count={userManagedTeams.length} />
+					</div>
+				)
+			});
+		}
+	}, [path]);
+
 	// Create items from teams - keep it simple to avoid circular dependencies
 	const items: TeamItem[] = useMemo(() => mapTeamItems(teams, onChangeActiveTeam), [teams, onChangeActiveTeam]);
 
@@ -149,14 +162,22 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 				)}
 				value={teamItem}
 				onChange={onChangeActiveTeam}
-				items={items}
+				items={[
+					...items,
+					...(userManagedTeams.length > 1
+						? [
+								{
+									key: 'all-teams',
+									Label: () => (
+										<AllTeamItem title={t('common.ALL_TEAMS')} count={userManagedTeams.length} />
+									)
+								}
+							]
+						: [])
+				]}
 				// loading={teamsFetching} // TODO: Enable loading in future when we implement better data fetching library like TanStack
 				publicTeam={publicTeam}
 			>
-				{userManagedTeams.length > 1 && (
-					<AllTeamItem title={t('common.ALL_TEAMS')} count={userManagedTeams.length} />
-				)}
-
 				{!publicTeam && (
 					<Tooltip
 						enabled={!user?.isEmailVerified}

--- a/apps/web/core/components/teams/teams-dropdown.tsx
+++ b/apps/web/core/components/teams/teams-dropdown.tsx
@@ -91,6 +91,11 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 						return; // Hook handles toast and redirect
 					}
 				}
+
+				// From all teams page
+				if (path.includes('/all-teams')) {
+					router.push('/');
+				}
 			}
 		},
 		[setActiveTeam, stopTimer, t, setDetailedTask, path, router, timerStatus] // Removed detailedTask and activeTeam to prevent constant recreation
@@ -98,8 +103,6 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 
 	// Create items from teams - keep it simple to avoid circular dependencies
 	const items: TeamItem[] = useMemo(() => mapTeamItems(teams, onChangeActiveTeam), [teams, onChangeActiveTeam]);
-
-	console.log(items);
 
 	const [teamItem, setTeamItem] = useState<TeamItem | null>(null);
 

--- a/apps/web/core/components/teams/teams-dropdown.tsx
+++ b/apps/web/core/components/teams/teams-dropdown.tsx
@@ -112,7 +112,7 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 				)
 			});
 		}
-	}, [path]);
+	}, [path, userManagedTeams.length, t]);
 
 	// Create items from teams - keep it simple to avoid circular dependencies
 	const items: TeamItem[] = useMemo(() => mapTeamItems(teams, onChangeActiveTeam), [teams, onChangeActiveTeam]);
@@ -164,7 +164,7 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 				onChange={onChangeActiveTeam}
 				items={[
 					...items,
-					...(userManagedTeams.length > 1
+					...(userManagedTeams.length > 1 || path.includes('/all-teams')
 						? [
 								{
 									key: 'all-teams',

--- a/apps/web/core/components/teams/teams-dropdown.tsx
+++ b/apps/web/core/components/teams/teams-dropdown.tsx
@@ -99,6 +99,8 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 	// Create items from teams - keep it simple to avoid circular dependencies
 	const items: TeamItem[] = useMemo(() => mapTeamItems(teams, onChangeActiveTeam), [teams, onChangeActiveTeam]);
 
+	console.log(items);
+
 	const [teamItem, setTeamItem] = useState<TeamItem | null>(null);
 
 	const { isOpen, closeModal, openModal } = useModal();


### PR DESCRIPTION
## Description

- User can switch back to a specific team from all team page
- Include 'All teams' option properly in the header teams dropdown

## Previous behavior


https://github.com/user-attachments/assets/cf4059bf-d137-4a2b-82f8-9e2f21e1d61f


## Current behavior


https://github.com/user-attachments/assets/6cfcf97d-d77e-4c72-bd24-23aedeab605f


 
## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Team dropdown now includes an “All Teams” option showing team count and auto-selects it when viewing All Teams; selecting a team from All Teams returns you to the home view.
* Bug Fixes
  * Avoided unnecessary/invalid task fetches when no active task ID is present, reducing errors and UI flicker.
* Style
  * Team items now have a full-height clickable area and refined spacing for a cleaner, more consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->