### PR TITLE
[FixBug] Infinite API calls to currency endpoint in Project Creation form (Financial Settings step)

### DIFF
--- a/apps/web/core/components/features/projects/add-or-edit-project/steps/financial-settings-form.tsx
+++ b/apps/web/core/components/features/projects/add-or-edit-project/steps/financial-settings-form.tsx
@@ -1,18 +1,19 @@
 import { Button } from '@/core/components';
-import { FormEvent, useCallback, useEffect, useState } from 'react';
+import { FormEvent, useCallback, useState } from 'react';
 import { Select } from './basic-information-form';
 import { IStepElementProps } from '../container';
 import { EProjectBudgetType, EProjectBilling } from '@/core/types/generics/enums/project';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/core/lib/helpers';
-import { useCurrencies } from '@/core/hooks/common/use-currencies';
 import { InputField } from '@/core/components/duplicated-components/_input';
 import { getInitialValue } from '@/core/lib/helpers/create-project';
 import { ECurrencies } from '@/core/types/generics/enums/currency';
+import { useAtomValue } from 'jotai';
+import { currenciesState } from '@/core/stores';
 
 export default function FinancialSettingsForm(props: IStepElementProps) {
 	const { goToNext, goToPrevious, currentData } = props;
-	const { currencies, getCurrencies } = useCurrencies();
+	const currencies = useAtomValue(currenciesState);
 	const [currency, setCurrency] = useState<string>(() => getInitialValue(currentData, 'currency', undefined));
 	const [billingType, setBillingType] = useState<EProjectBilling>(() =>
 		getInitialValue(currentData, 'billing', EProjectBilling.FLAT_FEE)
@@ -40,10 +41,6 @@ export default function FinancialSettingsForm(props: IStepElementProps) {
 			billing: billingType
 		});
 	};
-
-	useEffect(() => {
-		getCurrencies();
-	}, [getCurrencies]);
 
 	const handlePrevious = useCallback(() => {
 		goToPrevious?.({

--- a/apps/web/core/components/layouts/app/init-state.tsx
+++ b/apps/web/core/components/layouts/app/init-state.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/core/hooks/tasks';
 import { useTimeLogs } from '@/core/hooks/activities/time-logs/use-time-logs';
 import { useGetCurrentOrganization } from '@/core/hooks/auth/use-current-organization';
+import { useCurrencies } from '@/core/hooks/common/use-currencies';
 
 export function AppState() {
 	const { data: user } = useUserQuery();
@@ -53,6 +54,7 @@ function InitState() {
 	const { firstLoadRolesData } = useRoles();
 	const { firstLoadTaskStatusesData, loadTaskStatuses: loadTaskStatusesData } = useTaskStatus();
 	const { firstLoadMyRolePermissionsData } = useRolePermissions();
+	const { firstLoadCurrenciesData } = useCurrencies();
 
 	// Load workspaces data on app initialization
 	const { firstLoadWorkspacesData } = useWorkspaces();
@@ -104,6 +106,7 @@ function InitState() {
 		firstLoadDataEmployee();
 		firstLoadRolesData();
 		firstLoadMyRolePermissionsData();
+		firstLoadCurrenciesData();
 		// --------------
 
 		getTimerStatus();

--- a/apps/web/core/hooks/common/use-currencies.ts
+++ b/apps/web/core/hooks/common/use-currencies.ts
@@ -7,6 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/core/query/keys';
 import { getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/cookies';
 import { UseCurrenciesReturn } from '@/core/types/interfaces/common/currency';
+import { useFirstLoad } from './use-first-load';
 
 /**
  * Custom hook for managing application currencies with React Query integration
@@ -59,6 +60,7 @@ import { UseCurrenciesReturn } from '@/core/types/interfaces/common/currency';
  */
 export const useCurrencies = (): UseCurrenciesReturn => {
 	const [currencies, setCurrencies] = useAtom(currenciesState);
+	const { firstLoadData: firstLoadCurrenciesData } = useFirstLoad();
 
 	/**
 	 * React Query for currencies data with optimized caching strategy
@@ -97,10 +99,16 @@ export const useCurrencies = (): UseCurrenciesReturn => {
 		await currenciesQuery.refetch();
 	}, [currenciesQuery]);
 
+	const handleFirstLoad = useCallback(async () => {
+		await getCurrencies();
+		firstLoadCurrenciesData();
+	}, [firstLoadCurrenciesData, getCurrencies]);
+
 	return {
 		currencies,
 		loading: currenciesQuery.isLoading,
 		getCurrencies,
+		firstLoadCurrenciesData: handleFirstLoad,
 		error: currenciesQuery.error,
 		isError: currenciesQuery.isError,
 		refetch: currenciesQuery.refetch

--- a/apps/web/core/hooks/common/use-currencies.ts
+++ b/apps/web/core/hooks/common/use-currencies.ts
@@ -60,7 +60,7 @@ import { useFirstLoad } from './use-first-load';
  */
 export const useCurrencies = (): UseCurrenciesReturn => {
 	const [currencies, setCurrencies] = useAtom(currenciesState);
-	const { firstLoadData: firstLoadCurrenciesData } = useFirstLoad();
+	const { firstLoadData } = useFirstLoad();
 
 	/**
 	 * React Query for currencies data with optimized caching strategy
@@ -100,9 +100,12 @@ export const useCurrencies = (): UseCurrenciesReturn => {
 	}, [currenciesQuery]);
 
 	const handleFirstLoad = useCallback(async () => {
-		await getCurrencies();
-		firstLoadCurrenciesData();
-	}, [firstLoadCurrenciesData, getCurrencies]);
+		// Only fetch if we don't have data and not currently fetching
+		if (!currenciesQuery.data && currenciesQuery.fetchStatus !== 'fetching') {
+			await currenciesQuery.refetch();
+		}
+		firstLoadData();
+	}, [firstLoadData, currenciesQuery]);
 
 	return {
 		currencies,

--- a/apps/web/core/types/interfaces/common/currency.ts
+++ b/apps/web/core/types/interfaces/common/currency.ts
@@ -20,7 +20,7 @@ export interface UseCurrenciesReturn {
 	/** Function to manually fetch currencies data */
 	getCurrencies: () => Promise<void>;
 	/** First load data function for backward compatibility */
-	firstLoadCurrenciesData: () => void;
+	firstLoadCurrenciesData: () => Promise<void>;
 	/** Error object from React Query if the request failed */
 	error: Error | null;
 	/** Boolean indicating if there's an error */

--- a/apps/web/core/types/interfaces/common/currency.ts
+++ b/apps/web/core/types/interfaces/common/currency.ts
@@ -19,6 +19,8 @@ export interface UseCurrenciesReturn {
 	loading: boolean;
 	/** Function to manually fetch currencies data */
 	getCurrencies: () => Promise<void>;
+	/** First load data function for backward compatibility */
+	firstLoadCurrenciesData: () => void;
 	/** Error object from React Query if the request failed */
 	error: Error | null;
 	/** Boolean indicating if there's an error */


### PR DESCRIPTION
## Description

- Fix the Financial Settings step in the project creation form
- [JIRA Ticket](https://evertech.atlassian.net/browse/ETP-103

## Previous behavior


https://github.com/user-attachments/assets/d6d5bfb2-cfd9-442b-b011-fde69165decd


## Current Behavior


https://github.com/user-attachments/assets/e15c2735-35c4-45f2-96e6-4d8d595bf564



## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Financial Settings form now reads currencies from shared app state, removing the on-mount fetch for a more consistent experience.
- Chores
  - App initialization preloads currencies during startup, ensuring currency data is available on first render across the app.
  - Currency hook exposes a new firstLoadCurrenciesData method; related interface updated to include this method.
- Tests
  - None.
- Documentation
  - None.
- Style
  - None.
- Revert
  - None.
- Bug Fixes
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->