### PR TITLE
[FixBug] Child/Related Issue selector popup hides tasks at end of list

### DIFF
--- a/apps/web/core/components/tasks/task-input.tsx
+++ b/apps/web/core/components/tasks/task-input.tsx
@@ -615,10 +615,10 @@ function TaskCard({
 			<EverCard
 				shadow="custom"
 				className={clsxm(
-					'rounded-xl md:px-4 md:py-4 overflow-hidden',
+					'rounded-xl md:px-4 md:py-4',
 					!cardWithoutShadow && ['shadow-xl card'],
 					fullWidth ? ['w-full'] : ['md:w-[500px]'],
-					fullHeight ? 'h-full' : 'max-h-96'
+					fullHeight && 'h-full'
 				)}
 			>
 				<div className="flex flex-col gap-4">
@@ -749,9 +749,9 @@ function TaskCard({
 					</div>
 				</div>
 
-				<Divider className="mt-4" />
+				<Divider className="my-4" />
 				{/* Task list */}
-				<ul className={assignTaskPopup ? 'overflow-y-auto py-6 max-h-[40vh]' : 'overflow-y-auto py-6 max-h-56'}>
+				<ul className={assignTaskPopup ? 'overflow-y-auto py-6 max-h-[40vh]' : 'overflow-y-auto py-6 max-h-60'}>
 					{forParentChildRelationship && (
 						<LazyRender items={data || []}>
 							{(task, i) => {


### PR DESCRIPTION
## Description

- Fix Child/ Related task popup | task lists
- [JIRA Ticket](git checkout -b ETP-106-fix-bug-child-related-issue-selector-popup-hides-tasks-at-end-of-list)


## Previous behavior


https://github.com/user-attachments/assets/0354db7f-eba8-47c2-9eb8-940c54501a73



## Current Behavior


https://github.com/user-attachments/assets/81a646e1-43f0-4a18-aadb-cc63535295a6



## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced