### PR TITLE
fix: set default value of withteam to true in useAuthenticationTeam hook

### DIFF
--- a/apps/mobile/app/services/hooks/features/use-authentication-team.ts
+++ b/apps/mobile/app/services/hooks/features/use-authentication-team.ts
@@ -24,7 +24,7 @@ export function useAuthenticationTeam() {
 		screen: 1,
 		animation: false
 	});
-	const [withteam, setWithTeam] = useState<boolean>(false);
+	const [withteam, setWithTeam] = useState<boolean>(true);
 	const [attemptsCount, setAttemptsCount] = useState(0);
 
 	const {


### PR DESCRIPTION
# 🚀 Change Mobile App Default Screen to Login Instead of Team Creation

_Set login screen as default entry point for unauthenticated users in mobile app._

## Description

This PR changes the default screen behavior for unauthenticated users in the mobile application.

- **Problem**: When users open the mobile app without being logged in, they see the "Create New Team" screen by default, which is confusing for existing users who want to log in.
- **Solution**: Changed the default screen to show the login flow (email → security code → workspace selection) instead of team creation.
- **Why**: This provides a better user experience for existing users while still allowing new users to create teams via the "Back" button.

## What Was Changed

### Major Changes

- Modified `useAuthenticationTeam` hook to set `withteam` state to `true` by default instead of `false`
- This changes the initial screen from "Create New Team" to "Login" for unauthenticated users

### Minor Changes

- No UI components were modified - only the default state logic
- All existing navigation flows remain intact
- Team creation is still accessible via the "Back" button in the login flow

## How to Test This PR

1. Run the mobile app with `cd apps/mobile && yarn start`
2. Ensure you are logged out of the app
3. Open the app and verify:
   - Default screen shows "Enter Email" (login flow) instead of "Create New Team"
   - You can enter an email and proceed with the login flow
   - Clicking "Back" button takes you to the team creation screen
   - Team creation flow still works normally
   - Login flow works normally and authenticates users

## Screenshots 

### Previous screenshots

The app previously showed "Create New Team" form with team name input field as the first screen for unauthenticated users.

https://github.com/user-attachments/assets/630878e6-f914-4756-a303-06f73813867b


### Current screenshots

The app now shows "Enter Email" login form as the first screen for unauthenticated users, with team creation accessible via "Back" button.

https://github.com/user-attachments/assets/280e7c8b-9dcf-44bf-af83-1be8eca5513a


## Related Issues

- Addresses user experience issue where existing users had to navigate to login from team creation screen

## Type of Change

- [x] Bug fix (fixes a UX problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

- This is a minimal change affecting only one line of code in the authentication hook
- All existing functionality is preserved - only the default state is changed
- The change improves UX for existing users while maintaining access to team creation
- No breaking changes or additional dependencies introduced

