### PR TITLE
[Fix] Plus icon barely visible in Dark Mode on Timesheets view details button

### DIFF
--- a/apps/web/core/components/pages/timesheet/timesheet-card.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-card.tsx
@@ -63,7 +63,7 @@ export function TimesheetCard({ ...props }: ITimesheetCard) {
 					aria-label="View timesheet details"
 					onClick={onClick}
 				>
-					<PlusIcon />
+					<PlusIcon className='dark:text-[#6b7280] text-[#282048] '/>
 					<span>{t('pages.timesheet.TIMESHEET_VIEW_DETAILS')}</span>
 					<ArrowRightIcon className={cn('h-6 w-6', 'text-[#282048] dark:text-[#6b7280]')} />
 				</Button>

--- a/apps/web/core/components/timesheet/timesheet-icons.tsx
+++ b/apps/web/core/components/timesheet/timesheet-icons.tsx
@@ -153,9 +153,9 @@ export const DeleteSelectedIcon = ({ className }: { className?: string }) => <sv
  *
  * @returns {React.ReactElement} - The rendered plus icon component.
  */
-export const PlusIcon = () => <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M3.99609 8H11.9961" stroke="#282048" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-    <path d="M7.99609 12V4" stroke="#282048" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+export const PlusIcon = ({ className }: { className?: string }) => <svg  className={className} width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M3.99609 8H11.9961" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M7.99609 12V4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
 </svg>
 
 


### PR DESCRIPTION
## Description

- Fix Plus icon barely visible in Dark Mode on Timesheets view details button

## Current
<img width="2856" height="822" alt="Screen Shot 2025-11-12 at 23 28 26 pm" src="https://github.com/user-attachments/assets/61b83bfb-a693-4fc7-b1a2-08ce30d2310e" />

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined timesheet card button styling with enhanced dark/light text color treatment
  * Updated icon rendering to support improved color theming and customization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->