### PR TITLE
[Fix] View button text not visible in Dark Mode (appears only on hover)

### DIFF
--- a/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
+++ b/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
@@ -108,7 +108,7 @@ const TeamTask = () => {
 										<Menu.Button>
 											<Button
 												type="button"
-												className=" border-gray-200 !border hover:bg-slate-100 dark:border text-sm min-w-fit text-black h-[2.2rem] hover:dark:bg-transparent"
+												className=" border-gray-200 !border hover:bg-slate-100 dark:border  dark:border-gray-400   text-sm min-w-fit text-black dark:text-white h-[2.2rem]  dark:bg-transparent"
 												variant="outline"
 											>
 												<Settings2 size={15} /> <span>{t('common.VIEW')}</span>
@@ -137,7 +137,7 @@ const TeamTask = () => {
 																	}))
 																}
 																className={cn(
-																	`${active && 'bg-primary/10'} rounded gap-2 group flex w-full items-center px-2 py-2 text-xs`
+																	`${active && 'bg-primary/10'} rounded gap-2 group flex w-full dark:text-white items-center px-2 py-2 text-xs`
 																)}
 															>
 																<div className="flex justify-center items-center w-5 h-full">


### PR DESCRIPTION
## Description

- Fix View button text not visible in Dark Mode (appears only on hover)

## Current

<img width="2976" height="654" alt="Screen Shot 2025-11-12 at 23 47 29 pm" src="https://github.com/user-attachments/assets/79bb8430-24c4-4867-bd06-4cf260bd868e" />

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [ ] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark-mode styling for UI components throughout the application. Refined text colors and optimized border styling ensure improved visibility and visual consistency when dark mode is active. These visual updates provide users with a better, more comfortable viewing experience while maintaining design coherence and reducing eye strain in low-light environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->