### PR TITLE
Fix Daily Plan Auto-Assignment for Manager Scenarios

### DIFF
--- a/apps/web/core/components/features/daily-plan/active-task-handler-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/active-task-handler-modal.tsx
@@ -35,6 +35,7 @@ export function ActiveTaskHandlerModal({
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const { setActiveTask } = useTeamTasks();
+	// Use default useDailyPlan() so it targets the current user's own plans (todayPlan)
 	const { addTaskToPlan } = useDailyPlan();
 
 	const [selectedOption, setSelectedOption] = useState<number>();
@@ -61,7 +62,16 @@ export function ActiveTaskHandlerModal({
 				action: async () => {
 					try {
 						if (todayPlan && todayPlan.id && activeTeamTask) {
-							await addTaskToPlan({ taskId: activeTeamTask.id }, todayPlan.id);
+							await addTaskToPlan(
+								{
+									// Always use the plan owner for auto-assignment
+									// todayPlan comes from `useTimerView` which uses `useTimer` (current user's myDailyPlans)
+									// so this is effectively a "self-plan" scenario
+									employeeId: todayPlan.employeeId ?? undefined,
+									taskId: activeTeamTask.id
+								},
+								todayPlan.id
+							);
 						}
 
 						activeTeamTask &&
@@ -78,7 +88,14 @@ export function ActiveTaskHandlerModal({
 				action: async () => {
 					try {
 						if (todayPlan && todayPlan.id && activeTeamTask) {
-							await addTaskToPlan({ taskId: activeTeamTask.id }, todayPlan.id);
+							await addTaskToPlan(
+								{
+									// Same rule here: assign the plan owner, not whoever clicked
+									employeeId: todayPlan.employeeId ?? undefined,
+									taskId: activeTeamTask.id
+								},
+								todayPlan.id
+							);
 						}
 						if (defaultPlannedTask) {
 							setActiveTask(defaultPlannedTask);

--- a/apps/web/core/components/features/daily-plan/enforce-planed-task-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/enforce-planed-task-modal.tsx
@@ -40,11 +40,12 @@ export function EnforcePlanedTaskModal(props: IEnforcePlannedTaskModalProps) {
 	);
 
 	const handleAddTaskToPlan = useCallback(() => {
-		if (user?.employee && task && plan.id) {
+		if (user?.employee && task && plan.id && plan.employeeId) {
 			addTaskToPlan(
 				{
 					taskId: task.id,
-					employeeId: plan.employeeId ?? user.employee.id,
+					// Always assign the plan owner, never fall back to the current user
+					employeeId: plan.employeeId,
 					organizationId: plan.organizationId ?? user.employee.organizationId
 				},
 				plan.id


### PR DESCRIPTION
# 🚀 Fix Daily Plan Auto-Assignment for Manager Scenarios

## Description

This PR fixes the auto-assignment logic when adding tasks to Daily Plans to ensure that **the plan owner is always auto-assigned**, not the current user (manager).

**Problem:**
- When a manager prepared a Daily Plan for another employee and added tasks to it, the manager was incorrectly auto-assigned to those tasks instead of the employee who owns the plan.
- This happened because several components had fallback logic like `employeeId ?? user.employee.id`, which defaulted to the current user when `employeeId` was missing or undefined.

**Solution:**
- Removed all fallback logic that defaulted to `user.employee.id`
- Ensured all call sites to `addTaskToPlan` and `createDailyPlan` explicitly pass the plan owner's `employeeId`
- Added guard checks to prevent adding tasks to plans without a valid `employeeId`

**Why these changes are useful:**
- Managers can now prepare Daily Plans for team members without being incorrectly assigned to tasks
- The auto-assignment logic is consistent across all Daily Plan flows (Timer, AllPlans, Profile, TaskCard)
- Prevents confusion and manual reassignment work

## What Was Changed

### Major Changes

- **`enforce-planed-task-modal.tsx`**: Removed fallback to `user.employee.id`, now strictly uses `plan.employeeId` with guard check
- **`add-task-estimation-hours-modal.tsx`**: 
  - For existing plans: Use `plan.employeeId` with error thrown if missing
  - For new plans: Require explicit `employeeId` prop, no fallback to current user
- **`active-task-handler-modal.tsx`**: Added explicit `employeeId: todayPlan.employeeId` to both `addTaskToPlan` calls (options 1 and 2)

### Minor Changes

- Added inline comments explaining the auto-assignment logic and why fallbacks were removed
- Improved error handling when `plan.employeeId` is missing

## How to Test This PR

### Scenario A: Employee on their own plan (should still work)

1. Run the app with `pnpm web:dev`
2. Log in as a regular employee (not manager)
3. Navigate to Today Tasks or your profile's Plans tab
4. Add a task to your Daily Plan (via TaskCard "Plan for Today" button, or Timer modal, or AllPlans)
5. **Expected**: The task should be auto-assigned to you (visible in task members)

### Scenario B: Manager on another employee's plan (the fix)

1. Log in as a manager
2. Navigate to a team member's profile (e.g., `/profile/[employeeId]`)
3. Go to their "Plans" tab
4. Create a new Daily Plan for a future date OR select an existing plan
5. Add a task to that employee's plan (via AllPlans modal or AddTaskToPlan modal)
6. **Expected**: 
   - The task should be auto-assigned to **the employee** (plan owner), NOT the manager
   - Check the task card to verify the employee is in `task.members`, not the manager

### Scenario C: Timer flow (self-plan)

1. Log in as any user
2. Start the timer on a task
3. If prompted by `ActiveTaskHandlerModal`, choose "Add the task as default to the plan"
4. **Expected**: The task should be auto-assigned to the current user (self-plan scenario)

## Related Issues

- Addresses feedback from @evereq in PR #4153 discussion
- Related to Daily Plan auto-assignment logic and manager workflows

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer

- The core auto-assignment logic in `useDailyPlan` (`addTaskToPlanMutation.onSuccess`) was already correct – it respects the `employeeId` passed in the request
- The bug was in the **call sites** that were using fallback logic like `employeeId ?? user.employee.id`
- All fixes ensure that `plan.employeeId` or the target employee's ID is used, never the current user as a fallback
- The `add-task-to-plan.tsx` component was already correct (uses `employee?.employeeId` prop directly)
- The `task-card.tsx` `PlanTask` component uses `profile?.member?.employeeId`, which correctly represents the plan owner in profile contexts


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Daily Plan auto-assignment so tasks added to a plan are assigned to the plan owner, not the current user. This prevents managers from being incorrectly auto-assigned when editing team members’ plans.

- **Bug Fixes**
  - Removed fallbacks to user.employee.id; always pass plan.employeeId to addTaskToPlan and createDailyPlan.
  - Added guard checks and errors when employeeId is missing to block invalid assignments.
  - Updated ActiveTaskHandler, AddTaskEstimationHours, and EnforcePlannedTask modals to consistently assign the plan owner in both existing and new plan flows.

<sup>Written for commit 9e75ef0ae0b834213f8e9a0f0dd18556fce3f974. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tasks added to daily plans are now correctly assigned to the plan owner rather than the user performing the action, improving accuracy and accountability in team task management scenarios.
  * Enhanced validation when adding tasks to daily plans by enforcing proper employee context, reducing assignment errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->