### PR TITLE
Rename and replace auth/team by auth/signup page and update links to redirect to signup

### DIFF
--- a/apps/web/app/[locale]/auth/signup/page.tsx
+++ b/apps/web/app/[locale]/auth/signup/page.tsx
@@ -1,10 +1,10 @@
 // import { APPLICATION_DEFAULT_LANGUAGE } from '@app/constants';
-import AuthTeam from '@/core/components/pages/auth/team/page-component';
+import AuthSignup from '@/core/components/pages/auth/signup/page-component';
 
 // export async function generateStaticParams() {
 // 	return [{ locale: APPLICATION_DEFAULT_LANGUAGE }];
 // }
 
 export default function Page() {
-	return <AuthTeam />;
+	return <AuthSignup />;
 }

--- a/apps/web/core/components/pages/auth/accept-invite/workspace-not-found-message-card.tsx
+++ b/apps/web/core/components/pages/auth/accept-invite/workspace-not-found-message-card.tsx
@@ -20,7 +20,7 @@ export function WorkspaceNotFoundMessageCard() {
 					<Link href={'/'}>{t('pages.invite.acceptInvite.buttons.RETURN_TO_DASHBOARD')}</Link>
 				</Button>
 				<Button>
-					<Link href={'/auth/team'}>{t('pages.invite.acceptInvite.buttons.CREATE_NEW_WORKSPACE')}</Link>
+					<Link href={'/auth/signup'}>{t('pages.invite.acceptInvite.buttons.CREATE_NEW_WORKSPACE')}</Link>
 				</Button>
 			</div>
 		</div>

--- a/apps/web/core/components/pages/auth/passcode/page-component.tsx
+++ b/apps/web/core/components/pages/auth/passcode/page-component.tsx
@@ -148,7 +148,7 @@ function EmailScreen({ form, className }: { form: TAuthenticationPasscode } & IC
 
 							<div className="flex gap-2 justify-between items-center w-full text-sm">
 								<span>{t('common.DONT_HAVE_ACCOUNT')}</span>
-								<Link href="/auth/team" className="underline whitespace-nowrap text-primary dark:text-primary-light text-nowrap">
+								<Link href="/auth/signup" className="underline whitespace-nowrap text-primary dark:text-primary-light text-nowrap">
 									<span>{t('common.REGISTER')}</span>
 								</Link>
 							</div>

--- a/apps/web/core/components/pages/auth/password/page-component.tsx
+++ b/apps/web/core/components/pages/auth/password/page-component.tsx
@@ -138,7 +138,7 @@ function LoginFormActions({ form, t, showMagicCodeLink = false }: LoginFormActio
 			{/* Register Link - Better design with justify-between */}
 			<div className="flex gap-3 justify-between items-center mb-3 w-full text-sm">
 				<span>{t('common.DONT_HAVE_ACCOUNT')}</span>
-				<Link href="/auth/team" className="underline whitespace-nowrap text-primary dark:text-primary-light text-nowrap">
+				<Link href="/auth/signup" className="underline whitespace-nowrap text-primary dark:text-primary-light text-nowrap">
 					<span>{t('common.REGISTER')}</span>
 				</Link>
 			</div>

--- a/apps/web/core/components/pages/auth/signup/page-component.tsx
+++ b/apps/web/core/components/pages/auth/signup/page-component.tsx
@@ -14,7 +14,7 @@ import Turnstile from 'react-turnstile';
 import { EverCard } from '@/core/components/common/ever-card';
 import { InputField } from '@/core/components/duplicated-components/_input';
 
-function AuthTeam() {
+function AuthSignup() {
 	const {
 		handleSubmit,
 		step,
@@ -205,7 +205,7 @@ function ChooseModeForm({
 					{t('pages.authTeam.GET_STARTED_TITLE')}
 				</Text.Heading>
 
-				<div className="mb-6 w-full space-y-4">
+				<div className="mb-6 space-y-4 w-full">
 					{/* Solo Option */}
 					<label
 						className={clsxm(
@@ -221,13 +221,13 @@ function ChooseModeForm({
 							value="solo"
 							checked={startMode === 'solo'}
 							onChange={() => onStartModeChange('solo')}
-							className="mt-1 mr-3 h-4 w-4 text-primary-600 focus:ring-primary-500"
+							className="mt-1 mr-3 w-4 h-4 text-primary-600 focus:ring-primary-500"
 						/>
 						<div className="flex-1">
 							<span className="font-medium text-gray-900 dark:text-white">
 								{t('pages.authTeam.START_SOLO')}
 							</span>
-							<p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+							<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
 								{t('pages.authTeam.START_SOLO_NOTE')}
 							</p>
 						</div>
@@ -248,7 +248,7 @@ function ChooseModeForm({
 							value="team"
 							checked={startMode === 'team'}
 							onChange={() => onStartModeChange('team')}
-							className="mt-1 mr-3 h-4 w-4 text-primary-600 focus:ring-primary-500"
+							className="mt-1 mr-3 w-4 h-4 text-primary-600 focus:ring-primary-500"
 						/>
 						<div className="flex-1">
 							<span className="font-medium text-gray-900 dark:text-white">
@@ -259,7 +259,7 @@ function ChooseModeForm({
 
 					{/* Team Name Input - only shown when team mode is selected */}
 					{startMode === 'team' && (
-						<div className="mt-4 pl-7">
+						<div className="pl-7 mt-4">
 							<InputField
 								name="team"
 								value={form.team}
@@ -312,4 +312,4 @@ function ReCAPTCHA({ handleOnChange, errors }: { handleOnChange: any; errors: an
 	return content || <></>;
 }
 
-export default AuthTeam;
+export default AuthSignup;


### PR DESCRIPTION
# 🚀 Rename and replace auth/team by auth/signup page and update links to redirect to signup



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the old /auth/team flow with a new /auth/signup page and component. Updated all Register/Create Workspace links to point to /auth/signup from invite, passcode, and password screens.

<sup>Written for commit 66e3030cf06a8f689b62ecf8634c45d270fc316f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Updates**
  * Enhanced signup page with refined layout and spacing adjustments.
  * Updated authentication flow: login, email verification, and workspace recovery screens now route directly to the signup page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->