### PR TITLE
Fixed [Bug]-[Web] [Auth] User not redirected after workspace selection despite successful authentication

### DIFF
--- a/apps/web/core/hooks/auth/use-authentication-passcode.ts
+++ b/apps/web/core/hooks/auth/use-authentication-passcode.ts
@@ -92,16 +92,20 @@ export function useAuthenticationPasscode() {
 			signInWorkspaceQueryCall(workspaceParams)
 				.then(() => {
 					setAuthenticated(true);
+					// Reset infinite loading before navigation to ensure clean state
+					infiniteWLoading.current = false;
 					router.push('/');
 				})
 				.catch((err: AxiosError) => {
+					// Reset infinite loading on error to stop the loading state
+					infiniteWLoading.current = false;
 					if (err.response?.status === 400) {
 						setErrors((err.response?.data as any)?.errors || {});
 					}
 					inputCodeRef.current?.clear();
 				});
 		},
-		[signInWorkspaceQueryCall, router]
+		[signInWorkspaceQueryCall, router, infiniteWLoading]
 	);
 
 	/**

--- a/apps/web/core/hooks/auth/use-authentication-password.ts
+++ b/apps/web/core/hooks/auth/use-authentication-password.ts
@@ -90,26 +90,33 @@ export function useAuthenticationPassword() {
 			});
 	};
 
-	const signInToWorkspaceRequest = (params: {
-		email: string;
-		token: string;
-		selectedTeam: string;
-		defaultTeamId?: IOrganizationTeam['id'];
-		lastTeamId?: string; // Optional: undefined when user has no teams
-	}) => {
-		signInWorkspaceQueryCall(params)
-			.then(() => {
-				setAuthenticated(true);
-				router.push('/');
-			})
-			.catch((err: AxiosError) => {
-				if (err.response?.status === 400) {
-					setErrors((err.response?.data as any)?.errors || {});
-				}
+	const signInToWorkspaceRequest = useCallback(
+		(params: {
+			email: string;
+			token: string;
+			selectedTeam: string;
+			defaultTeamId?: IOrganizationTeam['id'];
+			lastTeamId?: string; // Optional: undefined when user has no teams
+		}) => {
+			signInWorkspaceQueryCall(params)
+				.then(() => {
+					setAuthenticated(true);
+					// Reset infinite loading before navigation to ensure clean state
+					infiniteLoading.current = false;
+					router.push('/');
+				})
+				.catch((err: AxiosError) => {
+					// Reset infinite loading on error to stop the loading state
+					infiniteLoading.current = false;
+					if (err.response?.status === 400) {
+						setErrors((err.response?.data as any)?.errors || {});
+					}
 
-				inputCodeRef.current?.clear();
-			});
-	};
+					inputCodeRef.current?.clear();
+				});
+		},
+		[signInWorkspaceQueryCall, router, infiniteLoading]
+	);
 
 	const handleWorkspaceSubmit = (e: any, token: string, selectedTeam: string) => {
 		e.preventDefault();

--- a/apps/web/core/hooks/auth/use-authentication-social-login.ts
+++ b/apps/web/core/hooks/auth/use-authentication-social-login.ts
@@ -95,7 +95,10 @@ export function useAuthenticationSocialLogin() {
 					setSignInWorkspaceLoading(false);
 					router.push('/');
 				})
-				.catch((err) => console.log(err));
+				.catch((err) => {
+					console.error('Workspace signin error:', err);
+					setSignInWorkspaceLoading(false);
+				});
 		},
 		[router, updateNextAuthSession]
 	);


### PR DESCRIPTION
# 🚀 Fix infinite loading state after workspace selection during authentication

## Description

This PR fixes a critical bug where users were stuck in an infinite loading state after selecting a workspace and clicking "Continue" during the authentication flow.

- **Problem**: After authentication (magic code, email/password, or OAuth), users could select a workspace/team but the "Continue" button would remain in a loading state indefinitely. Users had to manually refresh the page to access the dashboard.
- **Root Cause**: The `infiniteLoading` ref was never reset to `false` after the workspace signin request completed (success or error). Additionally, the social login hook's catch block didn't reset the loading state.
- **Solution**: Properly reset the loading state in both success and error cases across all authentication flows.

## What Was Changed

### Major Changes

- **`use-authentication-social-login.ts`**: Added `setSignInWorkspaceLoading(false)` in the `.catch()` block to reset loading state on API errors
- **`use-authentication-passcode.ts`**: Added `infiniteWLoading.current = false` in both `.then()` and `.catch()` blocks to ensure loading state is always reset
- **`use-authentication-password.ts`**: Added `infiniteLoading.current = false` in both `.then()` and `.catch()` blocks, and refactored `signInToWorkspaceRequest` to use `useCallback` for consistency

### Minor Changes

- Improved error logging in social login hook with `console.error` instead of `console.log`

## How to Test This PR

1. Run the app with `yarn dev:web`
2. Open the browser at `http://localhost:3030`
3. Test all three authentication flows:

   **Magic Code Flow:**
   - Enter a valid email address
   - Receive and enter the magic code
   - Select a workspace and team
   - Click "Continue"
   - ✅ Verify: User is redirected to dashboard without manual refresh

   **Email/Password Flow:**
   - Enter valid email and password credentials
   - Select a workspace and team
   - Click "Continue"
   - ✅ Verify: User is redirected to dashboard without manual refresh

   **OAuth/Social Login Flow:**
   - Login with Google/GitHub/etc.
   - Select a workspace and team
   - Click "Continue"
   - ✅ Verify: User is redirected to dashboard without manual refresh

4. Test error scenarios:
   - Simulate API failure (e.g., network disconnect)
   - ✅ Verify: Loading state resets and user can retry


## Related Issues

- Closes [ETP-215](https://evertech.atlassian.net/browse/ETP-215)

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

- The `infiniteLoading` pattern is used intentionally to prevent loading state flickering during navigation. The fix ensures it's properly reset in all exit paths (success and error).
- All three authentication hooks were updated for consistency.
- No breaking changes - the fix is backwards compatible.


[ETP-215]: https://evertech.atlassian.net/browse/ETP-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the infinite loading after workspace selection in auth and ensures users are redirected to the dashboard without a manual refresh. Addresses ETP-215 by resetting loading state across all auth methods.

- **Bug Fixes**
  - Passcode and password: reset infinite loading on success and error before navigation.
  - Social login: handle errors with console.error and clear workspace loading in catch.
  - Refactor: useCallback for signInToWorkspaceRequest for consistent state management.

<sup>Written for commit 3cf6ff634c7d2ce9d2f580fa50988884ec950894. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading state not properly resetting after authentication attempts across passcode, password, and social login flows.
  * Improved error logging for workspace sign-in failures.

* **Refactor**
  * Optimized authentication callback efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->