### PR TITLE
Fixed: Etp 167 task web user profile tabs affect user team card state across pages global state leak

### DIFF
--- a/apps/web/core/components/pages/teams/team/team-members-views/user-team-card/index.tsx
+++ b/apps/web/core/components/pages/teams/team/team-members-views/user-team-card/index.tsx
@@ -109,7 +109,9 @@ export function UserTeamCard({
 	// Memoize expensive hook calls
 	const profile = useUserProfilePage();
 	const [userDetailAccordion, setUserDetailAccordion] = useAtom(userAccordion);
-	const hook = useTaskFilter(profile);
+	// Use isolated tab state for UserTeamCard to prevent global state leak from profile page
+	// With 'auto' default: shows daily plans if user has them, otherwise shows assigned tasks
+	const hook = useTaskFilter(profile, { persistState: false, defaultTab: 'auto' });
 	const memberInfo = useTeamMemberCard(member);
 	// NOTE: memberInfo.memberTask already prioritizes activeTeamTask (Jotai atom) for auth user
 	// This provides instant UI updates when changing tasks (see useTeamMemberCard hook)

--- a/apps/web/core/hooks/tasks/use-task-filter.ts
+++ b/apps/web/core/hooks/tasks/use-task-filter.ts
@@ -91,13 +91,9 @@ export function useTaskFilter(profile: I_UserProfilePage, options: UseTaskFilter
 		// If defaultTab is 'auto', calculate the smart default
 		if (defaultTab === 'auto') {
 			// Check if user has daily plans with tasks
-			const hasDailyPlanTasks =
-				profileDailyPlans?.items && profileDailyPlans.items.some((plan) => plan.tasks && plan.tasks.length > 0);
-			if (hasDailyPlanTasks) {
-				return 'dailyplan';
-			}
-			// Otherwise, show assigned tasks
-			return 'assigned';
+			const hasDailyPlanTasks = profileDailyPlans?.items?.some((plan) => plan.tasks && plan.tasks.length > 0);
+			// Show daily plans if available, otherwise default to assigned tasks
+			return hasDailyPlanTasks ? 'dailyplan' : 'assigned';
 		}
 		return defaultTab;
 	});
@@ -115,13 +111,8 @@ export function useTaskFilter(profile: I_UserProfilePage, options: UseTaskFilter
 	useEffect(() => {
 		if (hasInitializedAutoTab && profileDailyPlans?.items) {
 			const hasDailyPlanTasks = profileDailyPlans.items.some((plan) => plan.tasks && plan.tasks.length > 0);
-			if (hasDailyPlanTasks) {
-				setLocalTab('dailyplan');
-			} else if (profile?.tasksGrouped?.assignedTasks?.length) {
-				setLocalTab('assigned');
-			} else {
-				setLocalTab('assigned');
-			}
+			// Show daily plans if user has them, otherwise default to assigned tasks
+			setLocalTab(hasDailyPlanTasks ? 'dailyplan' : 'assigned');
 		}
 		// Only run when profileDailyPlans changes, not on every render
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/hooks/tasks/use-task-filter.ts
+++ b/apps/web/core/hooks/tasks/use-task-filter.ts
@@ -33,8 +33,10 @@ export type UseTaskFilterOptions = {
 	 */
 	persistState?: boolean;
 	/**
-	 * Default tab to use when persistState is false or no localStorage value exists
-	 * Can be 'auto' to automatically select based on daily plans/assigned tasks
+	 * Default tab to use when persistState is false.
+	 * Note: This option is only effective when persistState is false.
+	 * When persistState is true, the tab defaults to 'worked' via localStorage.
+	 * Can be 'auto' to automatically select based on daily plans availability.
 	 */
 	defaultTab?: ITab | 'auto';
 };
@@ -114,9 +116,7 @@ export function useTaskFilter(profile: I_UserProfilePage, options: UseTaskFilter
 			// Show daily plans if user has them, otherwise default to assigned tasks
 			setLocalTab(hasDailyPlanTasks ? 'dailyplan' : 'assigned');
 		}
-		// Only run when profileDailyPlans changes, not on every render
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [hasInitializedAutoTab, profileDailyPlans?.items]);
+	}, [hasInitializedAutoTab, profileDailyPlans?.items, setLocalTab]);
 
 	const [filterType, setFilterType] = useState<FilterType>(undefined);
 


### PR DESCRIPTION
# 🚀 Fix global state leak between profile page tabs and UserTeamCard

## Description

This PR fixes a UX issue where switching tabs on the user profile page (`/profile/[memberId]`) would affect the data displayed in the UserTeamCard on the homepage.

- **Problem**: The tab state (Worked/Assigned/Unassigned/Planned/Stats) was stored globally in localStorage with a shared key `'task-tab'`. When a user selected a different tab on the profile page, this selection persisted and affected the UserTeamCard component, showing unexpected data instead of the daily plan view.
- **Root Cause**: Both the profile page and UserTeamCard used the same `useTaskFilter` hook which stored tab state in localStorage with a shared key.
- **Solution**: Extended the `useTaskFilter` hook to support isolated state management, allowing UserTeamCard to use local component state instead of the shared localStorage.

## What Was Changed

### Major Changes

- **`use-task-filter.ts`**: Added `UseTaskFilterOptions` type with two new options:
  - `persistState`: Controls whether to use localStorage (default: `true`) or local state (`false`)
  - `defaultTab`: Supports `'auto'` value for smart default selection based on daily plans availability

- **`user-team-card/index.tsx`**: Updated to use isolated tab state with smart defaults:
  - Uses `persistState: false` to prevent localStorage pollution
  - Uses `defaultTab: 'auto'` to show daily plans if available, otherwise assigned tasks

### Minor Changes

- Added useEffect to handle dynamic tab selection when daily plans data loads asynchronously

## How to Test This PR

1. Run the app with `yarn dev:web`
2. Open the browser at `http://localhost:3030`
3. Test the isolation:

   **Step 1: Verify profile page behavior is unchanged**
   - Go to `/profile/[memberId]`
   - Switch between tabs (Worked, Assigned, Planned, etc.)
   - Refresh the page
   - ✅ Verify: The selected tab persists after refresh

   **Step 2: Verify UserTeamCard is now isolated**
   - On the profile page, select the "Worked" tab
   - Navigate to the homepage
   - Click the Chevron toggle on any team member card to expand it
   - ✅ Verify: The UserTeamCard shows Daily Plan (if user has daily plans) or Assigned tasks (if not) - NOT the "Worked" tab from profile page

   **Step 3: Verify smart defaults**
   - For a user WITH daily plans: UserTeamCard should show "dailyplan" tab by default
   - For a user WITHOUT daily plans: UserTeamCard should show "assigned" tab by default

## Screenshots (if needed)

| Before | After |
| ------ | ----- |
| UserTeamCard inherits tab from profile page (e.g., shows "Worked" data) | UserTeamCard shows Daily Plan or Assigned tasks independently |

### Previous screenshots

Please add here videos or images of the previous status (tab state leaking from profile to UserTeamCard)

### Current screenshots

Please add here videos or images of the current (new) status (isolated tab states)

## Related Issues

- Closes [ETP-167](https://evertech.atlassian.net/browse/ETP-167)

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

- The `useTaskFilter` hook is backward compatible - existing usages without options will continue to work as before (using localStorage)
- Only the UserTeamCard now uses isolated state; other components (profile page, user-team-block-header) retain the shared localStorage behavior
- The smart default logic (`defaultTab: 'auto'`) follows the UX requirements discussed in Slack:
  - If user has daily plans → show daily plans
  - If user has no daily plans → show assigned tasks


[ETP-167]: https://evertech.atlassian.net/browse/ETP-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task filter state no longer persists across team member/profile pages—each profile now keeps its own isolated tab state.
  * Improved default tab behavior: automatically shows daily plans when available, otherwise falls back to assigned tasks.
  * Prevents automatic data refreshes from overwriting a user’s manual tab selection once made.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a global state leak where profile page tab selection affected UserTeamCard, isolating state and adding smart defaults for a clearer UX. Also prevents auto-selection from overriding a user's choice. Addresses ETP-167.

- **Bug Fixes**
  - Extended useTaskFilter with options: persistState and defaultTab ('auto').
  - UserTeamCard uses isolated state (persistState: false) and smart default: daily plan if available, else assigned.
  - Added effect to adjust default when daily plans load asynchronously.
  - Tracked manual tab selection to avoid overwriting it on data refetch.

<sup>Written for commit a368ace9afaf6ff545876715bc355e6c4f404a46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



