### PR TITLE
fix: resolve missing employeeId before updating daily plan

### DIFF
--- a/apps/web/core/components/daily-plan/plan-header.tsx
+++ b/apps/web/core/components/daily-plan/plan-header.tsx
@@ -77,7 +77,8 @@ export function PlanHeader({ plan, planMode }: { plan: TDailyPlan; planMode: Fil
 			}
 			setTime(hours);
 
-			await updateDailyPlan({ workTimePlanned: hours }, plan.id ?? '');
+			// Server requires employeeId in the payload, to correctly check permissions
+			await updateDailyPlan({ workTimePlanned: hours, employeeId: plan.employeeId || undefined }, plan.id ?? '');
 
 			setEditTime(false);
 			toast.success('Plan updated successfully');

--- a/apps/web/core/components/daily-plan/plan-header.tsx
+++ b/apps/web/core/components/daily-plan/plan-header.tsx
@@ -93,6 +93,7 @@ export function PlanHeader({ plan, planMode }: { plan: TDailyPlan; planMode: Fil
 		parseStringInputToHours,
 		plan.workTimePlanned,
 		plan.id,
+		plan.employeeId,
 		updateDailyPlan,
 		updateDailyPlanLoading,
 		setTime,

--- a/apps/web/core/components/features/daily-plan/add-daily-plan-work-hours-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/add-daily-plan-work-hours-modal.tsx
@@ -41,7 +41,8 @@ export function AddDailyPlanWorkHourModal(props: IAddDailyPlanWorkHoursModalProp
 
 			// Update the plan work time only if the user changed it
 			if (plan && plan.workTimePlanned !== workTimePlanned) {
-				await updateDailyPlan({ workTimePlanned }, plan.id ?? '');
+				// Server requires employeeId in the payload, to correctly check permissions
+				await updateDailyPlan({ workTimePlanned, employeeId: plan.employeeId || undefined }, plan.id ?? '');
 			}
 
 			startTimer();

--- a/apps/web/core/components/features/daily-plan/add-task-estimation-hours-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/add-task-estimation-hours-modal.tsx
@@ -228,7 +228,8 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 
 			// Update the plan work time only if the user changed it
 			if (plan && plan.workTimePlanned !== workTimePlanned) {
-				await updateDailyPlan({ workTimePlanned }, plan.id ?? '');
+				// Server requires employeeId in the payload, to correctly check permissions
+				await updateDailyPlan({ workTimePlanned, employeeId: plan.employeeId || undefined }, plan.id ?? '');
 				toast.success('Plan updated successfully', {
 					description: `Work time planned updated to ${workTimePlanned} hours`,
 					duration: 3000

--- a/apps/web/core/components/features/daily-plan/add-task-estimation-hours-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/add-task-estimation-hours-modal.tsx
@@ -173,7 +173,8 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 
 			// Update the plan work time only if the user changed it
 			if (plan && plan.workTimePlanned !== workTimePlanned) {
-				await updateDailyPlan({ workTimePlanned }, plan.id ?? '');
+				// Server requires employeeId in the payload, to correctly check permissions
+				await updateDailyPlan({ workTimePlanned, employeeId: plan.employeeId || undefined }, plan.id ?? '');
 				toast.success('Plan updated successfully', {
 					description: `Work time planned updated to ${workTimePlanned} hours`,
 					duration: 3000

--- a/apps/web/core/services/client/api/daily-plans/daily-plan.service.ts
+++ b/apps/web/core/services/client/api/daily-plans/daily-plan.service.ts
@@ -197,6 +197,36 @@ class DailyPlanService extends APIService {
 	};
 
 	/**
+	 * Get daily plan by its ID with validation
+	 *
+	 * @param planId - The target plan's ID
+	 * @returns Promise<TDailyPlan> - Validated daily plan data
+	 * @throws ValidationError if response data doesn't match schema
+	 */
+	getPlanById = async (planId: string): Promise<TDailyPlan> => {
+		try {
+			const response = await this.get<TDailyPlan>(`/daily-plan/${planId}`, {
+				tenantId: this.tenantId
+			});
+
+			// Validate the response data using zod validation with auto-normalization
+			return zodStrictApiResponseValidate(dailyPlanSchema, response.data, 'getPlanById API response');
+		} catch (error) {
+			if (error instanceof ZodValidationError) {
+				this.logger.error(
+					'Daily plan by id validation failed:',
+					{
+						message: error.message,
+						issues: error.issues
+					},
+					'DailyPlanService'
+				);
+			}
+			throw error;
+		}
+	};
+
+	/**
 	 * Create a new daily plan with validation
 	 *
 	 * @param data - Daily plan data without ID


### PR DESCRIPTION
# fix: resolve missing employeeId before updating daily plan

_fix a backend validation failure when updating a daily plan if employeeId is missing from the update payload_

## Description

The backend requires an employeeId to identify the owner of the daily plan for all update requests.
In some frontend update flows (especially when updating tasks and recalculating workTimePlanned),
the frontend does not always have employeeId available at the time of the request, 
which caused the update to be rejected.

To make the update flow more robust, this PR introduces a fallback mechanism that ensures 
employeeId is always present before sending the update request, while still supporting 
reassignment scenarios where employeeId is explicitly provided


## What Was Changed
- Added a centralized fallback mechanism to resolve employeeId before updating a daily plan.
- If employeeId is missing from the payload, the existing daily plan is fetched to retrieve the current owner employeeId, and then the update request is sent with the completed payload.
- If employeeId is provided (for example, reassignment), it is used directly with no extra network call.

## How to Test This PR

1. Run the app locally
2. Open [http://localhost:3030/](http://localhost:3030)
3. Open today's plan modal
4. Add a task on today's plan
5. Change "planned working hours"
6. Click on "Start Working" button
7. Check if update request succeeds
 

### Previous screenshots

https://github.com/user-attachments/assets/421c69ef-c23f-46f2-a723-c21a97412299

### Current screenshots

https://github.com/user-attachments/assets/e3b76a37-975e-4cfd-8d8f-872316064d57

## Related Issues

Please list related issues, tasks or discussions:

- https://evertech.atlassian.net/browse/ETP-216?atlOrigin=eyJpIjoiZDkxNWJlZDQ4M2Q5NDA1M2I0YTBmYTliZDkzMzBhOTMiLCJwIjoiaiJ9


## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## ⚠️⚠️⚠️ Reviewers Suggested

- `@evereq` for architecture validation
- `@ndekocode` for integration review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure employeeId is always included when updating a daily plan to fix backend validation errors. If employeeId is provided (e.g., reassignment) we use it directly; otherwise we fetch the existing plan to use its owner.

- **Bug Fixes**
  - Added a fallback in useDailyPlan: fetch the plan by ID and use its employeeId when missing.
  - Components now pass plan.employeeId to updateDailyPlan to avoid unnecessary fetches.
  - Introduced getPlanById API with schema validation and error logging.

<sup>Written for commit 79f2659013b249d78a102aa392b196f420b54ac1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way to fetch full daily plan details by plan ID.

* **Improvements**
  * All daily-plan update requests now include employee identification; updates derive and include that identifier when missing to ensure consistent request shape.

* **Bug Fixes**
  * Validation errors from plan retrieval are now logged with context before being surfaced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->