### PR TITLE
Refactor useOrganizationTeams - Separate Read Operations from CUD Operations

### DIFF
--- a/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
+++ b/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
@@ -1,29 +1,29 @@
 'use client';
 import { Container } from '@/core/components';
-import { MainLayout } from '@/core/components/layouts/default-layout';
-import { useParams } from 'next/navigation';
-import { useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { useAtomValue } from 'jotai';
-import { fullWidthState } from '@/core/stores/common/full-width';
-import { withAuthentication } from '@/core/components/layouts/app/authenticator';
-import { getCoreRowModel, getFilteredRowModel, useReactTable, VisibilityState } from '@tanstack/react-table';
-import { cn, getStatusColor } from '@/core/lib/helpers';
 import { Input } from '@/core/components/common/input';
-import { Check, Search, Settings2 } from 'lucide-react';
-import { usePagination } from '@/core/hooks/common/use-pagination';
-import { Menu, Transition } from '@headlessui/react';
+import { Button } from '@/core/components/duplicated-components/_button';
+import { Paginate } from '@/core/components/duplicated-components/_pagination';
+import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
+import { withAuthentication } from '@/core/components/layouts/app/authenticator';
+import { MainLayout } from '@/core/components/layouts/default-layout';
+import { TeamTasksPageSkeleton } from '@/core/components/layouts/skeletons/team-tasks-page-skeleton';
 import { columns, hidableColumnNames } from '@/core/components/pages/teams/team/tasks/columns';
 import StatusBadge from '@/core/components/pages/teams/team/tasks/status-badge';
 import { TaskTable } from '@/core/components/pages/teams/team/tasks/task-table';
-import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
-import { Paginate } from '@/core/components/duplicated-components/_pagination';
-import { Button } from '@/core/components/duplicated-components/_button';
+import { usePagination } from '@/core/hooks/common/use-pagination';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { cn, getStatusColor } from '@/core/lib/helpers';
+import { tasksByTeamState } from '@/core/stores';
+import { fullWidthState } from '@/core/stores/common/full-width';
 import { ETaskStatusName } from '@/core/types/generics/enums/task';
-import { ColumnDef } from '@tanstack/react-table';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { TeamTasksPageSkeleton } from '@/core/components/layouts/skeletons/team-tasks-page-skeleton';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
+import { Menu, Transition } from '@headlessui/react';
+import { ColumnDef, getCoreRowModel, getFilteredRowModel, useReactTable, VisibilityState } from '@tanstack/react-table';
+import { useAtomValue } from 'jotai';
+import { Check, Search, Settings2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useParams } from 'next/navigation';
+import { useMemo, useState } from 'react';
 
 const TeamTask = () => {
 	const t = useTranslations();
@@ -31,7 +31,8 @@ const TeamTask = () => {
 	const fullWidth = useAtomValue(fullWidthState);
 	const currentLocale = params ? params.locale : null;
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
+
 	const breadcrumbPath = useMemo(
 		() => [
 			{ title: JSON.parse(t('pages.home.BREADCRUMB')), href: '/' },

--- a/apps/web/app/[locale]/(main)/calendar/page.tsx
+++ b/apps/web/app/[locale]/(main)/calendar/page.tsx
@@ -25,7 +25,8 @@ import {
 	LazySetupTimeSheet,
 	LazyAddManualTimeModal
 } from '@/core/components/optimized-components/calendar';
-import { activeTeamState, isTrackingEnabledState } from '@/core/stores';
+import { isTrackingEnabledState } from '@/core/stores';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const CalendarPage = () => {
 	const t = useTranslations();
@@ -33,7 +34,7 @@ const CalendarPage = () => {
 
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const [calendarTimeSheet, setCalendarTimeSheet] = useLocalStorageState<timesheetCalendar>(
 		'calendar-timesheet',
 		'Calendar'

--- a/apps/web/app/[locale]/(main)/kanban/page.tsx
+++ b/apps/web/app/[locale]/(main)/kanban/page.tsx
@@ -44,8 +44,9 @@ import {
 	LazyKanbanSearch,
 	LazyInviteFormModal
 } from '@/core/components/optimized-components/kanban';
-import { activeTeamState, isTrackingEnabledState } from '@/core/stores';
+import { isTrackingEnabledState } from '@/core/stores';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const Kanban = () => {
 	// Get all required hooks and states
@@ -64,7 +65,7 @@ const Kanban = () => {
 
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const t = useTranslations();
 	const params = useParams<{ locale: string }>();
 	const fullWidth = useAtomValue(fullWidthState);

--- a/apps/web/app/[locale]/(main)/profile/[memberId]/page.tsx
+++ b/apps/web/app/[locale]/(main)/profile/[memberId]/page.tsx
@@ -1,36 +1,38 @@
 'use client';
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { useLocalStorageState, useUserProfilePage } from '@/core/hooks';
-import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { Container } from '@/core/components';
-import { ArrowLeftIcon } from 'assets/svg';
+import { ProfileErrorBoundary } from '@/core/components/common/profile-error-boundary';
+import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { MainHeader, MainLayout } from '@/core/components/layouts/default-layout';
+import { useLocalStorageState, useUserProfilePage } from '@/core/hooks';
+import { useProfileValidation } from '@/core/hooks/users/use-profile-validation';
+import { ArrowLeftIcon } from 'assets/svg';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import React, { Suspense, useCallback, useMemo } from 'react';
-import { useTranslations } from 'next-intl';
-import { useProfileValidation } from '@/core/hooks/users/use-profile-validation';
-import { ProfileErrorBoundary } from '@/core/components/common/profile-error-boundary';
 
-import { useAtomValue, useSetAtom } from 'jotai';
-import { fullWidthState } from '@/core/stores/common/full-width';
-import { activityTypeState } from '@/core/stores/timer/activity-type';
-import { cn } from '@/core/lib/helpers';
-import { useTaskFilter } from '@/core/hooks/tasks/use-task-filter';
-import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
-import { VerticalSeparator } from '@/core/components/duplicated-components/separator';
 import { ProfilePageSkeleton } from '@/core/components/common/skeleton/profile-page-skeleton';
 import { TimerSkeleton } from '@/core/components/common/skeleton/timer-skeleton';
+import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
+import { VerticalSeparator } from '@/core/components/duplicated-components/separator';
 import {
 	LazyAppsTab,
 	LazyScreenshootTab,
-	LazyUserProfileTask,
-	LazyUserProfileDetail,
-	LazyVisitedSitesTab,
+	LazyTaskFilter,
 	LazyTimer,
-	LazyTaskFilter
+	LazyUserProfileDetail,
+	LazyUserProfileTask,
+	LazyVisitedSitesTab
 } from '@/core/components/optimized-components';
-import { activeTeamManagersState, activeTeamState, isTrackingEnabledState } from '@/core/stores';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTaskFilter } from '@/core/hooks/tasks/use-task-filter';
+import { cn } from '@/core/lib/helpers';
+import { isTrackingEnabledState } from '@/core/stores';
+import { fullWidthState } from '@/core/stores/common/full-width';
+import { activityTypeState } from '@/core/stores/timer/activity-type';
+import { useAtomValue, useSetAtom } from 'jotai';
 
 export type FilterTab = 'Tasks' | 'Screenshots' | 'Apps' | 'Visited Sites';
 
@@ -44,11 +46,12 @@ const Profile = React.memo(function ProfilePage({ params }: { params: { memberId
 	const profileValidation = useProfileValidation(unwrappedParams.memberId);
 
 	// const { filteredTeams, userManagedTeams } = useOrganizationAndTeamManagers();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const profileUser = profileValidation.member?.employee?.user ?? null;
 
 	const profile = useUserProfilePage();
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
+
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
 	const fullWidth = useAtomValue(fullWidthState);
 	const [activityFilter, setActivityFilter] = useLocalStorageState<FilterTab>('activity-filter', 'Tasks');

--- a/apps/web/app/[locale]/(main)/reports/weekly-limit/page.tsx
+++ b/apps/web/app/[locale]/(main)/reports/weekly-limit/page.tsx
@@ -1,36 +1,37 @@
 'use client';
+import { ReportsPageSkeleton } from '@/core/components/common/skeleton/reports-page-skeleton';
+import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
 import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { MainLayout } from '@/core/components/layouts/default-layout';
-import { useEffect, useMemo, useState } from 'react';
-import { getAccessTokenCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
-import { useTimeLimits } from '@/core/hooks/activities/use-time-limits';
-import { DateRange } from 'react-day-picker';
-import { endOfMonth, startOfMonth } from 'date-fns';
-import moment from 'moment';
-import { usePagination } from '@/core/hooks/common/use-pagination';
-import { getUserOrganizationsRequest } from '@/core/services/server/requests';
-import { useTranslations } from 'next-intl';
+import { TGroupByOption } from '@/core/components/pages/reports/weekly-limit/group-by-select';
 import { groupDataByEmployee } from '@/core/components/pages/reports/weekly-limit/time-report-table';
-import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
+import { useTimeLimits } from '@/core/hooks/activities/use-time-limits';
+import { usePagination } from '@/core/hooks/common/use-pagination';
+import { getAccessTokenCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
+import { getUserOrganizationsRequest } from '@/core/services/server/requests';
 import { IOrganization } from '@/core/types/interfaces/organization/organization';
 import { TTimeLimitReportList } from '@/core/types/schemas';
-import { TGroupByOption } from '@/core/components/pages/reports/weekly-limit/group-by-select';
-import { ReportsPageSkeleton } from '@/core/components/common/skeleton/reports-page-skeleton';
+import { endOfMonth, startOfMonth } from 'date-fns';
+import moment from 'moment';
+import { useTranslations } from 'next-intl';
+import { useEffect, useMemo, useState } from 'react';
+import { DateRange } from 'react-day-picker';
 // Skeletons are now handled by optimized components
 
 // Import optimized components from centralized location
 import {
-	LazyGroupBySelect,
-	LazyWeeklyLimitExportMenu,
-	LazyTimeReportTable,
 	LazyDatePickerWithRange,
+	LazyGroupBySelect,
 	LazyMembersSelect,
+	LazyPaginate,
+	LazyTimeReportTable,
 	LazyTimeReportTableByMember,
-	LazyPaginate
+	LazyWeeklyLimitExportMenu
 } from '@/core/components/optimized-components/reports';
-import { activeTeamState, isTrackingEnabledState, myPermissionsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { isTrackingEnabledState, myPermissionsState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
 
 function WeeklyLimitReport() {
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
@@ -58,7 +59,7 @@ function WeeklyLimitReport() {
 			},
 		[organization]
 	);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const [member, setMember] = useState<string>('all');
 	const [dateRange, setDateRange] = useState<DateRange>({
 		from: startOfMonth(new Date()),

--- a/apps/web/app/[locale]/(main)/settings/team/page.tsx
+++ b/apps/web/app/[locale]/(main)/settings/team/page.tsx
@@ -1,35 +1,36 @@
 'use client';
 
-import { withAuthentication } from '@/core/components/layouts/app/authenticator';
-import { useAuthenticateUser } from '@/core/hooks';
-import { activeTeamState, fetchingTeamInvitationsState, isTeamMemberState, teamInvitationsState } from '@/core/stores';
-import Link from 'next/link';
-import { useTranslations } from 'next-intl';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { Accordian } from '@/core/components/common/accordian';
-import { activeSettingTeamTab } from '@/core/stores/common/setting';
-import { InteractionObserverVisible } from '@/core/components/pages/settings/interaction-observer';
-import NoTeam from '@/core/components/common/no-team';
-import { TeamAvatar } from '@/core/components/teams/team-avatar';
 import { EverCard } from '@/core/components/common/ever-card';
+import NoTeam from '@/core/components/common/no-team';
+import { withAuthentication } from '@/core/components/layouts/app/authenticator';
+import { InteractionObserverVisible } from '@/core/components/pages/settings/interaction-observer';
+import { TeamAvatar } from '@/core/components/teams/team-avatar';
+import { useAuthenticateUser } from '@/core/hooks';
+import { fetchingTeamInvitationsState, isTeamMemberState, teamInvitationsState } from '@/core/stores';
+import { activeSettingTeamTab } from '@/core/stores/common/setting';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 // Import optimized components from centralized location
 import {
-	LazyTeamSettingForm,
-	LazyInvitationSetting,
-	LazyMemberSetting,
-	LazyIntegrationSetting,
-	LazyIssuesSettings,
-	LazyDangerZoneTeam
-} from '@/core/components/optimized-components/settings';
-import { Suspense } from 'react';
-import {
-	TeamSettingFormSkeleton,
-	InvitationSettingSkeleton,
-	MemberSettingSkeleton,
+	DangerZoneTeamSkeleton,
 	IntegrationSettingSkeleton,
+	InvitationSettingSkeleton,
 	IssuesSettingsSkeleton,
-	DangerZoneTeamSkeleton
+	MemberSettingSkeleton,
+	TeamSettingFormSkeleton
 } from '@/core/components/common/skeleton/settings-skeletons';
+import {
+	LazyDangerZoneTeam,
+	LazyIntegrationSetting,
+	LazyInvitationSetting,
+	LazyIssuesSettings,
+	LazyMemberSetting,
+	LazyTeamSettingForm
+} from '@/core/components/optimized-components/settings';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { Suspense } from 'react';
 
 const Team = () => {
 	const t = useTranslations();
@@ -38,7 +39,7 @@ const Team = () => {
 	const [isFetchingTeamInvitations] = useAtom(fetchingTeamInvitationsState);
 	const { user, isTeamManager } = useAuthenticateUser();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const isTeamMember = useAtomValue(isTeamMemberState);
 	const teamInvitations = useAtomValue(teamInvitationsState);
 

--- a/apps/web/app/[locale]/(main)/task/[id]/page.tsx
+++ b/apps/web/app/[locale]/(main)/task/[id]/page.tsx
@@ -19,7 +19,8 @@ import Link from 'next/link';
 
 // Import optimized components from centralized location
 import { LazyTaskDetailsComponent } from '@/core/components/optimized-components';
-import { activeTeamState, detailedTaskState, isTrackingEnabledState } from '@/core/stores';
+import { detailedTaskState, isTrackingEnabledState } from '@/core/stores';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const TaskDetails = () => {
 	const profile = useUserProfilePage();
@@ -27,7 +28,7 @@ const TaskDetails = () => {
 	const router = useRouter();
 	const params = useParams();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 	const detailedTask = useAtomValue(detailedTaskState);
 	const { getTaskById, getTasksByIdLoading } = useTeamTasks();

--- a/apps/web/app/[locale]/page-component.tsx
+++ b/apps/web/app/[locale]/page-component.tsx
@@ -1,54 +1,55 @@
 'use client';
 import React, { Suspense, useEffect } from 'react';
 
-import { useDailyPlan, useIsMemberManager, useTeamInvitations } from '@/core/hooks';
-import { clsxm } from '@/core/lib/utils';
-import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { Container } from '@/core/components';
+import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { MainLayout } from '@/core/components/layouts/default-layout';
 import { IssuesView, LAST_SELECTED_TEAM_MEMBERS_VIEW_MODE } from '@/core/constants/config/constants';
+import { useDailyPlan, useIsMemberManager, useTeamInvitations } from '@/core/hooks';
+import { clsxm } from '@/core/lib/utils';
 import { useTranslations } from 'next-intl';
 
 import { Analytics } from '@vercel/analytics/react';
 
-import 'react-loading-skeleton/dist/skeleton.css';
 import '@/styles/globals.css';
+import 'react-loading-skeleton/dist/skeleton.css';
 
-import { useAtom, useAtomValue } from 'jotai';
-import { fullWidthState } from '@/core/stores/common/full-width';
 import HeaderTabs from '@/core/components/common/header-tabs';
+import { fullWidthState } from '@/core/stores/common/full-width';
 import { headerTabs } from '@/core/stores/common/header-tabs';
-import { usePathname } from 'next/navigation';
 import { PeoplesIcon } from 'assets/svg';
+import { useAtom, useAtomValue } from 'jotai';
+import { usePathname } from 'next/navigation';
 // TeamMemberHeader and NoTeam now lazy-loaded below
 import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
 
 // Import skeleton components
-import TeamMembersSkeleton from '@/core/components/common/skeleton/team-members-skeleton';
+import { NoTeamSkeleton } from '@/core/components/common/skeleton/no-team-skeleton';
+import { TaskTimerSectionSkeleton } from '@/core/components/common/skeleton/task-timer-section-skeleton';
 import TeamInvitationsSkeleton from '@/core/components/common/skeleton/team-invitations-skeleton';
+import { TeamMemberHeaderSkeleton } from '@/core/components/common/skeleton/team-member-header-skeleton';
+import TeamMembersSkeleton from '@/core/components/common/skeleton/team-members-skeleton';
 import TeamNotificationsSkeleton from '@/core/components/common/skeleton/team-notifications-skeleton';
 import UnverifiedEmailSkeleton from '@/core/components/common/skeleton/unverified-email-skeleton';
-import { TaskTimerSectionSkeleton } from '@/core/components/common/skeleton/task-timer-section-skeleton';
 import { TaskTimerSection } from '@/core/components/pages/dashboard/task-timer-section';
-import { TeamMemberHeaderSkeleton } from '@/core/components/common/skeleton/team-member-header-skeleton';
-import { NoTeamSkeleton } from '@/core/components/common/skeleton/no-team-skeleton';
 // Import optimized components from centralized location
+import { LazyChatwootWidget, LazyNoTeam, LazyUnverifiedEmail } from '@/core/components/optimized-components/common';
 import {
-	LazyTeamOutstandingNotifications,
-	LazyTeamMembers,
 	LazyTeamInvitations,
-	LazyTeamMemberHeader
+	LazyTeamMemberHeader,
+	LazyTeamMembers,
+	LazyTeamOutstandingNotifications
 } from '@/core/components/optimized-components/teams';
-import { LazyChatwootWidget, LazyUnverifiedEmail, LazyNoTeam } from '@/core/components/optimized-components/common';
-import { activeTeamState, isTeamMemberState, isTrackingEnabledState, myInvitationsState } from '@/core/stores';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { isTeamMemberState, isTrackingEnabledState, myInvitationsState } from '@/core/stores';
 
 function MainPage() {
 	const t = useTranslations();
 
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const isTeamMember = useAtomValue(isTeamMemberState);
 
@@ -75,7 +76,8 @@ function MainPage() {
 		}
 		const lastTeamMembersViewMode = localStorage?.getItem(LAST_SELECTED_TEAM_MEMBERS_VIEW_MODE);
 		if (lastTeamMembersViewMode && path == '/') {
-			if (Object.values(IssuesView).includes(lastTeamMembersViewMode as IssuesView) &&
+			if (
+				Object.values(IssuesView).includes(lastTeamMembersViewMode as IssuesView) &&
 				lastTeamMembersViewMode != IssuesView.KANBAN
 			) {
 				setView(lastTeamMembersViewMode as IssuesView);

--- a/apps/web/core/components/auth/must-be-a-manager.tsx
+++ b/apps/web/core/components/auth/must-be-a-manager.tsx
@@ -1,9 +1,9 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { useAuthenticateUser } from '@/core/hooks';
-import { useOrganizationTeams } from '@/core/hooks/organizations';
 import GlobalSkeleton from '../common/global-skeleton';
 import { useRouter } from 'next/navigation';
+import { useGetOrganizationTeamsQuery } from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
 
 type Props = {
 	children: React.ReactNode;
@@ -14,7 +14,7 @@ type Props = {
 export default function MustBeAManager({ children, redirectTo = '/', useRedirect = true }: Props) {
 	// All hooks must be called before any conditional returns
 	const { userLoading: isUserLoading, isTeamManager } = useAuthenticateUser();
-	const { getOrganizationTeamsLoading: isTeamsLoading } = useOrganizationTeams();
+	const { isPending: isTeamsLoading } = useGetOrganizationTeamsQuery();
 	const router = useRouter();
 	const [checked, setChecked] = useState(false);
 	const [isRedirecting, setIsRedirecting] = useState(false);

--- a/apps/web/core/components/collaborate/index.tsx
+++ b/apps/web/core/components/collaborate/index.tsx
@@ -1,7 +1,4 @@
-import { imgTitle } from '@/core/lib/helpers/index';
-import { useCollaborative, useModal } from '@/core/hooks';
-import { TUser } from '@/core/types/schemas';
-import { clsxm, isValidUrl } from '@/core/lib/utils';
+import { Button } from '@/core/components/common/button';
 import {
 	Command,
 	CommandEmpty,
@@ -19,19 +16,21 @@ import {
 	DialogTitle,
 	DialogTrigger
 } from '@/core/components/common/dialog';
+import { ScrollArea } from '@/core/components/common/scroll-bar';
+import { useCollaborative, useModal } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { imgTitle } from '@/core/lib/helpers/index';
+import { clsxm, isValidUrl } from '@/core/lib/utils';
+import { TUser } from '@/core/types/schemas';
 import { useJitsu } from '@jitsu/jitsu-react';
-import { Button } from '@/core/components/common/button';
+import { BrushSquareIcon, PhoneUpArrowIcon, UserLinearIcon } from 'assets/svg';
 import { Check } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { useCallback, useMemo } from 'react';
 import stc from 'string-to-color';
-import { useTranslations } from 'next-intl';
-import { BrushSquareIcon, PhoneUpArrowIcon, UserLinearIcon } from 'assets/svg';
-import { ScrollArea } from '@/core/components/common/scroll-bar';
 import { JitsuAnalytics } from '../analytics/jitsu-analytics';
 import { Avatar } from '../duplicated-components/avatar';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
 const Collaborate = () => {
 	const { onMeetClick, onBoardClick, collaborativeMembers, setCollaborativeMembers } = useCollaborative();
@@ -41,7 +40,7 @@ const Collaborate = () => {
 
 	const { data: user } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const members = useMemo(
 		() =>
 			activeTeam?.members && activeTeam?.members.length

--- a/apps/web/core/components/common/image-overlapper.tsx
+++ b/apps/web/core/components/common/image-overlapper.tsx
@@ -1,33 +1,32 @@
-import { useCallback, useMemo, useState } from 'react';
+import { Divider, Modal, SpinnerLoader } from '@/core/components';
 import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
-import Image from 'next/image';
-import Link from 'next/link';
-import Skeleton from 'react-loading-skeleton';
 import { ScrollArea } from '@/core/components/common/scroll-bar';
-import { useModal, useTeamTasks } from '@/core/hooks';
-import { Modal, Divider, SpinnerLoader } from '@/core/components';
-import { useTranslations } from 'next-intl';
-import { toast } from 'sonner';
-import { TaskAssignButton } from '@/core/components/tasks/task-assign-button';
-import { clsxm } from '@/core/lib/utils';
-import TeamMember from '@/core/components/teams/team-member';
-import { Url } from 'next/dist/shared/lib/router/router';
-import { IconsCheck, IconsPersonAddRounded, IconsPersonRounded } from '@/core/components/icons';
-import { cn } from '../../lib/helpers';
-import { TaskAvatars } from '../tasks/task-items';
-import { Tooltip } from '../duplicated-components/tooltip';
 import {
 	Tooltip as ShadcnTooltip,
+	TooltipArrow,
 	TooltipContent,
 	TooltipProvider,
-	TooltipTrigger,
-	TooltipArrow
+	TooltipTrigger
 } from '@/core/components/common/tooltip';
+import { IconsCheck, IconsPersonAddRounded, IconsPersonRounded } from '@/core/components/icons';
+import { TaskAssignButton } from '@/core/components/tasks/task-assign-button';
+import TeamMember from '@/core/components/teams/team-member';
+import { useModal, useTeamTasks } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { clsxm } from '@/core/lib/utils';
 import { ITimerStatus } from '@/core/types/interfaces/timer/timer-status';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
 import { TEmployee, TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useTranslations } from 'next-intl';
+import { Url } from 'next/dist/shared/lib/router/router';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useCallback, useMemo, useState } from 'react';
+import Skeleton from 'react-loading-skeleton';
+import { toast } from 'sonner';
+import { cn } from '../../lib/helpers';
+import { Tooltip } from '../duplicated-components/tooltip';
+import { TaskAvatars } from '../tasks/task-items';
 
 export interface ImageOverlapperProps {
 	id: string;
@@ -75,7 +74,7 @@ export default function ImageOverlapper({
 	const imageLength = images?.length;
 	const { isOpen, openModal, closeModal } = useModal();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const allMembers = useMemo(() => activeTeam?.members || [], [activeTeam]);
 	const [assignedMembers, setAssignedMembers] = useState<TEmployee[]>([...(item?.members || [])]);
 	const [unassignedMembers, setUnassignedMembers] = useState<TEmployee[]>([]);

--- a/apps/web/core/components/common/no-team.tsx
+++ b/apps/web/core/components/common/no-team.tsx
@@ -1,15 +1,14 @@
 'use client';
-import { useModal } from '@/core/hooks';
-import { clsxm } from '@/core/lib/utils';
+import { NoTeamIcon } from '@/assets/svg';
 import { Button, Text } from '@/core/components';
-import React, { PropsWithChildren } from 'react';
+import { useModal } from '@/core/hooks';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { clsxm } from '@/core/lib/utils';
 import { useTranslations } from 'next-intl';
+import React, { PropsWithChildren } from 'react';
 import { Tooltip } from '../duplicated-components/tooltip';
 import { CreateTeamModal } from '../features/teams/create-team-modal';
-import { organizationTeamsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { NoTeamIcon } from '@/assets/svg';
 
 type Props = PropsWithChildren & React.ComponentPropsWithRef<'div'>;
 const NoTeam = ({ className, ...rest }: Props) => {
@@ -17,7 +16,7 @@ const NoTeam = ({ className, ...rest }: Props) => {
 	const { isOpen, closeModal, openModal } = useModal();
 	const { data: user } = useUserQuery();
 
-	const teams = useAtomValue(organizationTeamsState);
+	const { teams } = useOrganisationTeams();
 
 	React.useEffect(() => {
 		closeModal();

--- a/apps/web/core/components/common/switch.tsx
+++ b/apps/web/core/components/common/switch.tsx
@@ -1,13 +1,13 @@
-import { Switch } from '@headlessui/react';
-import { useCallback, useEffect, useState } from 'react';
-import { Text } from './typography';
-import { useTranslations } from 'next-intl';
 import { DAILY_PLAN_SUGGESTION_MODAL_DATE } from '@/core/constants/config/constants';
-import { useOrganizationEmployeeTeams, useOrganizationTeams } from '../../hooks/organizations';
-import { IEmployee } from '@/core/types/interfaces/organization/employee';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { ERoleName } from '@/core/types/generics/enums/role';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { IEmployee } from '@/core/types/interfaces/organization/employee';
+import { Switch } from '@headlessui/react';
+import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useState } from 'react';
+import { useOrganizationEmployeeTeams } from '../../hooks/organizations';
+import { Text } from './typography';
+import { useEditOrganizationTeamMutation } from '@/core/hooks/organizations/teams/use-edit-organization-team-mutation';
 
 export default function TimeTrackingToggle({ activeManager }: { activeManager: IEmployee | undefined }) {
 	const t = useTranslations();
@@ -15,7 +15,7 @@ export default function TimeTrackingToggle({ activeManager }: { activeManager: I
 
 	const { updateOrganizationTeamEmployee } = useOrganizationEmployeeTeams();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const handleChange = useCallback(() => {
 		if (activeManager && activeTeam) {
@@ -57,13 +57,13 @@ export default function TimeTrackingToggle({ activeManager }: { activeManager: I
 export function ShareProfileViewsToggle() {
 	const t = useTranslations();
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const { editOrganizationTeam } = useOrganizationTeams();
+	const activeTeam = useCurrentTeam();
+	const editOrganizationTeam = useEditOrganizationTeamMutation();
 	const [enabled, setEnabled] = useState<boolean | undefined>(activeTeam?.shareProfileView);
 
 	const handleChange = useCallback(async () => {
 		if (activeTeam && typeof enabled != 'undefined') {
-			await editOrganizationTeam({
+			await editOrganizationTeam.mutateAsync({
 				...activeTeam,
 				shareProfileView: !enabled,
 				memberIds: activeTeam.members
@@ -112,13 +112,13 @@ export function ShareProfileViewsToggle() {
 
 export function RequireDailyPlanToTrack() {
 	const t = useTranslations();
-	const activeTeam = useAtomValue(activeTeamState);
-	const { editOrganizationTeam } = useOrganizationTeams();
+	const activeTeam = useCurrentTeam();
+	const editOrganizationTeam = useEditOrganizationTeamMutation();
 	const [enabled, setEnabled] = useState<boolean | undefined>(activeTeam?.requirePlanToTrack);
 
 	const handleChange = useCallback(async () => {
 		if (activeTeam && typeof enabled != 'undefined') {
-			await editOrganizationTeam({
+			await editOrganizationTeam.mutateAsync({
 				...activeTeam,
 				requirePlanToTrack: !enabled,
 				memberIds: activeTeam.members

--- a/apps/web/core/components/common/team-member.tsx
+++ b/apps/web/core/components/common/team-member.tsx
@@ -1,18 +1,23 @@
 import InviteCard from '@/core/components/teams/invite/invite-card';
 import { InvitedCard } from '@/core/components/teams/invite/invited-card';
 import UsersCard from '@/core/components/teams/members-card/members-card';
-import { useTranslations } from 'next-intl';
 import { useAuthenticateUser } from '@/core/hooks/auth';
-import { useOrganizationTeams } from '@/core/hooks/organizations';
-import { activeTeamState, getTeamInvitationsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import {
+	useGetOrganizationTeamQuery,
+	useGetOrganizationTeamsQuery
+} from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
+import { useTeamMemberInvitation } from '@/core/hooks/organizations/teams/use-team-member-invitations';
+import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
 
 export const TeamMemberSection = () => {
 	const { isTeamManager, user } = useAuthenticateUser();
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const { getOrganizationTeamsLoading } = useOrganizationTeams();
-	const teamInvitations = useAtomValue(getTeamInvitationsState);
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, []);
+
+	const { isPending: getOrganizationTeamsLoading } = useGetOrganizationTeamsQuery();
+	const teamInvitations = useTeamMemberInvitation();
 	const members = activeTeam?.members || [];
 	// const style = { width: `${100 / members.length}%` };
 

--- a/apps/web/core/components/duplicated-components/teams-dropdown.tsx
+++ b/apps/web/core/components/duplicated-components/teams-dropdown.tsx
@@ -1,21 +1,30 @@
+import { useCreateOrganizationTeam } from '@/core/hooks/organizations/teams/use-create-organization-team';
+import {
+	useGetOrganizationTeamQuery,
+	useGetOrganizationTeamsQuery
+} from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
+import { useSetActiveTeam } from '@/core/hooks/organizations/teams/use-set-active-team';
 import { imgTitle } from '@/core/lib/helpers/img-title';
+import { clsxm } from '@/core/lib/utils';
 import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { PlusIcon } from '@heroicons/react/24/solid';
-import { useState } from 'react';
-import { Spinner } from '../common/spinner';
 import { useTranslations } from 'next-intl';
-import { useOrganizationTeams } from '@/core/hooks/organizations';
-import { clsxm } from '@/core/lib/utils';
-import { activeTeamState, organizationTeamsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { useMemo, useState } from 'react';
+import { Spinner } from '../common/spinner';
+
 export const TeamsDropDown = () => {
 	const [edit, setEdit] = useState<boolean>(false);
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const teams = useAtomValue(organizationTeamsState);
-	const { setActiveTeam, getOrganizationTeamsLoading } = useOrganizationTeams();
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
+
+	const { data: teamsResult, isPending: getOrganizationTeamsLoading } = useGetOrganizationTeamsQuery();
+	const teams = useMemo(() => teamsResult?.data?.items ?? [], [teamsResult]);
+
+	const setActiveTeam = useSetActiveTeam();
+
 	const t = useTranslations();
 	return (
 		<div className="w-[290px] max-w-sm">
@@ -117,7 +126,8 @@ export const TeamsDropDown = () => {
 };
 
 function CreateNewTeam({ setEdit }: { setEdit: (value: React.SetStateAction<boolean>) => void }) {
-	const { createOTeamLoading, createOrganizationTeam } = useOrganizationTeams();
+	const { createOrganizationTeam, loading: createOTeamLoading } = useCreateOrganizationTeam();
+
 	const [error, setError] = useState<string | null>(null);
 	const t = useTranslations();
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {

--- a/apps/web/core/components/features/daily-plan/add-daily-plan-work-hours-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/add-daily-plan-work-hours-modal.tsx
@@ -1,14 +1,13 @@
 import { Modal, SpinnerLoader, Text } from '@/core/components';
 import { Button } from '@/core/components/duplicated-components/_button';
-import { useCallback, useMemo, useState } from 'react';
 import { DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE } from '@/core/constants/config/constants';
 import { useDailyPlan, useTimerView } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
 import { useTranslations } from 'next-intl';
+import { useCallback, useMemo, useState } from 'react';
 import { EverCard } from '../../common/ever-card';
 import { InputField } from '../../duplicated-components/_input';
-import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
 
 interface IAddDailyPlanWorkHoursModalProps {
 	closeModal: () => void;
@@ -23,7 +22,7 @@ export function AddDailyPlanWorkHourModal(props: IAddDailyPlanWorkHoursModalProp
 	const { updateDailyPlan } = useDailyPlan();
 	const { startTimer } = useTimerView();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const [workTimePlanned, setworkTimePlanned] = useState<number | undefined>(plan.workTimePlanned);
 	const currentDate = useMemo(() => new Date().toISOString().split('T')[0], []);
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);

--- a/apps/web/core/components/features/daily-plan/create-daily-plan-form-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/create-daily-plan-form-modal.tsx
@@ -1,12 +1,5 @@
-import { Dispatch, memo, SetStateAction, useCallback, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useDailyPlan } from '@/core/hooks';
 import { Modal, Text } from '@/core/components';
-import { imgTitle, tomorrowDate, yesterdayDate } from '@/core/lib/helpers/index';
-import { ReloadIcon } from '@radix-ui/react-icons';
-import moment from 'moment';
 import { Calendar } from '@/core/components/common/calendar';
-import { Button } from '@/core/components/duplicated-components/_button';
 import {
 	Command,
 	CommandEmpty,
@@ -16,19 +9,26 @@ import {
 	CommandList
 } from '@/core/components/common/command';
 import { ScrollArea } from '@/core/components/common/scroll-bar';
-import { clsxm, isValidUrl } from '@/core/lib/utils';
-import stc from 'string-to-color';
-import { Check, ChevronDown } from 'lucide-react';
-import { cn } from '@/core/lib/helpers';
+import { Button } from '@/core/components/duplicated-components/_button';
 import { LAST_OPTION__CREATE_DAILY_PLAN_MODAL } from '@/core/constants/config/constants';
+import { useDailyPlan } from '@/core/hooks';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { cn } from '@/core/lib/helpers';
+import { imgTitle, tomorrowDate, yesterdayDate } from '@/core/lib/helpers/index';
+import { clsxm, isValidUrl } from '@/core/lib/utils';
+import { EDailyPlanMode, EDailyPlanStatus } from '@/core/types/generics/enums/daily-plan';
+import { TDailyPlan, TOrganizationTeam, TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { ReloadIcon } from '@radix-ui/react-icons';
+import { Check, ChevronDown } from 'lucide-react';
+import moment from 'moment';
 import { useTranslations } from 'next-intl';
+import { Dispatch, memo, SetStateAction, useCallback, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import stc from 'string-to-color';
 import { EverCard } from '../../common/ever-card';
 import { Avatar } from '../../duplicated-components/avatar';
-import { EDailyPlanStatus, EDailyPlanMode } from '@/core/types/generics/enums/daily-plan';
-import { TDailyPlan, TOrganizationTeam, TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { useAtomValue } from 'jotai';
-import { activeTeamManagersState, activeTeamState } from '@/core/stores';
 
 export function CreateDailyPlanFormModal({
 	open,
@@ -48,9 +48,9 @@ export function CreateDailyPlanFormModal({
 	const { handleSubmit, reset } = useForm();
 	const { data: user } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
 	// Use useDailyPlan with employeeId to get the correct employee's plans
 	const { profileDailyPlans, createDailyPlan, createDailyPlanLoading } = useDailyPlan(employeeId ?? null);

--- a/apps/web/core/components/features/daily-plan/enforce-planed-task-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/enforce-planed-task-modal.tsx
@@ -1,12 +1,11 @@
-import { useAuthenticateUser, useDailyPlan, useTimer } from '@/core/hooks';
 import { Button, Modal, Text } from '@/core/components';
+import { useAuthenticateUser, useDailyPlan, useTimer } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useTranslations } from 'next-intl';
 import { ReactNode, useCallback, useMemo } from 'react';
 import { EverCard } from '../../common/ever-card';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
 
 interface IEnforcePlannedTaskModalProps {
 	open: boolean;
@@ -26,7 +25,7 @@ export function EnforcePlanedTaskModal(props: IEnforcePlannedTaskModalProps) {
 
 	const { hasPlan } = useTimer();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 

--- a/apps/web/core/components/features/daily-plan/suggest-daily-plan-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/suggest-daily-plan-modal.tsx
@@ -1,18 +1,17 @@
 import { Modal, Text } from '@/core/components';
 import { Button } from '@/core/components/duplicated-components/_button';
-import { useCallback, useMemo } from 'react';
 import {
 	DAILY_PLAN_SUGGESTION_MODAL_DATE,
 	HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL
 } from '@/core/constants/config/constants';
+import { useTimer } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { useTimer } from '@/core/hooks';
 import { usePathname } from 'next/navigation';
+import { useCallback, useMemo } from 'react';
 import { EverCard } from '../../common/ever-card';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
 interface ISuggestDailyPlanModalProps {
 	closeModal: () => void;
@@ -23,7 +22,7 @@ export function SuggestDailyPlanModal(props: ISuggestDailyPlanModalProps) {
 	const { isOpen, closeModal } = props;
 	const { hasPlan } = useTimer();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 	const name = useMemo(
 		() => user?.name || user?.firstName || user?.lastName || user?.username || '',

--- a/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
+++ b/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
@@ -1,25 +1,27 @@
 import '@/styles/style.css';
 
-import { format } from 'date-fns';
 import { Button, Modal } from '@/core/components';
 import { cn } from '@/core/lib/helpers';
+import { format } from 'date-fns';
 import { CalendarDays, Clock7 } from 'lucide-react';
 import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { DatePicker } from '@/core/components/common/date-picker';
 import { manualTimeReasons } from '@/core/constants/config/constants';
 import { useManualTime } from '@/core/hooks/activities/use-manual-time';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useIsMemberManager } from '@/core/hooks/organizations/teams/use-team-member';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { clsxm } from '@/core/lib/utils';
-import { DatePicker } from '@/core/components/common/date-picker';
-import { getNestedValue, Item, ManageOrMemberComponent } from '../../teams/manage-member-component';
-import { CustomSelect } from '../../common/multiple-select';
+import { activeTeamTaskState, tasksByTeamState } from '@/core/stores';
 import { IAddManualTimeRequest } from '@/core/types/interfaces/timer/time-slot/time-slot';
 import { TOrganizationTeam } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState, organizationTeamsState, tasksByTeamState } from '@/core/stores';
+import { CustomSelect } from '../../common/multiple-select';
+import { getNestedValue, Item, ManageOrMemberComponent } from '../../teams/manage-member-component';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
 
 /**
  * Interface for the properties of the `AddManualTimeModal` component.
@@ -55,8 +57,8 @@ export function AddManualTimeModal(props: Readonly<IAddManualTimeModalProps>) {
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const tasks = useAtomValue(tasksByTeamState);
-	const activeTeam = useAtomValue(activeTeamState);
-	const teams = useAtomValue(organizationTeamsState);
+	const activeTeam = useCurrentTeam();
+	const { teams } = useOrganisationTeams();
 	const { data: user } = useUserQuery();
 	const { isTeamManager } = useIsMemberManager(user);
 

--- a/apps/web/core/components/features/projects/add-or-edit-project/steps/review-summary.tsx
+++ b/apps/web/core/components/features/projects/add-or-edit-project/steps/review-summary.tsx
@@ -1,24 +1,25 @@
 import { Button } from '@/core/components';
-import { Fragment, ReactNode, useCallback, useMemo } from 'react';
 import { Calendar, Clipboard } from 'lucide-react';
-import { Thumbnail } from './basic-information-form';
 import moment from 'moment';
+import { Fragment, ReactNode, useCallback, useMemo } from 'react';
+import { Thumbnail } from './basic-information-form';
 
-import { IStepElementProps } from '../container';
-import { useLocale, useTranslations } from 'next-intl';
-import { useOrganizationProjects } from '@/core/hooks/organizations';
 import { VerticalSeparator } from '@/core/components/duplicated-components/separator';
-import { ERoleName } from '@/core/types/generics/enums/role';
-import { IProjectRelation } from '@/core/types/interfaces/project/organization-project';
-import { ETaskStatusName } from '@/core/types/generics/enums/task';
-import { EProjectBudgetType } from '@/core/types/generics/enums/project';
-import { EProjectBilling } from '@/core/types/generics/enums/project';
-import { TCreateProjectRequest, TTag } from '@/core/types/schemas';
 import { DEFAULT_USER_IMAGE_URL } from '@/core/constants/data/mock-data';
-import { ECurrencies } from '@/core/types/generics/enums/currency';
-import { activeTeamState, organizationProjectsState, organizationTeamsState, rolesState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { useOrganizationProjects } from '@/core/hooks/organizations';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { organizationProjectsState, rolesState } from '@/core/stores';
+import { ECurrencies } from '@/core/types/generics/enums/currency';
+import { EProjectBilling, EProjectBudgetType } from '@/core/types/generics/enums/project';
+import { ERoleName } from '@/core/types/generics/enums/role';
+import { ETaskStatusName } from '@/core/types/generics/enums/task';
+import { IProjectRelation } from '@/core/types/interfaces/project/organization-project';
+import { TCreateProjectRequest, TTag } from '@/core/types/schemas';
+import { useAtomValue } from 'jotai';
+import { useLocale, useTranslations } from 'next-intl';
+import { IStepElementProps } from '../container';
 
 export default function FinalReview(props: IStepElementProps) {
 	const { goToPrevious, finish, currentData: finalData, mode } = props;
@@ -30,7 +31,7 @@ export default function FinalReview(props: IStepElementProps) {
 		setOrganizationProjects
 	} = useOrganizationProjects();
 	const t = useTranslations();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const rolesFromApi = useAtomValue(rolesState);
 	const { data: user } = useUserQuery();
@@ -423,7 +424,7 @@ function TeamAndRelations(props: ITeamAndRelationsProps) {
 
 	const organizationProjects = useAtomValue(organizationProjectsState);
 
-	const teams = useAtomValue(organizationTeamsState);
+	const { teams } = useOrganisationTeams();
 
 	// Deduplicated list of all team members to prevent user duplication
 	const allMembers = useMemo(() => {

--- a/apps/web/core/components/features/projects/add-or-edit-project/steps/team-and-relations-form.tsx
+++ b/apps/web/core/components/features/projects/add-or-edit-project/steps/team-and-relations-form.tsx
@@ -1,18 +1,20 @@
 import { Button } from '@/core/components';
-import { CheckIcon, Plus, X, LockIcon } from 'lucide-react';
-import { FormEvent, useCallback, useState, useMemo } from 'react';
-import { Identifiable, Select, Thumbnail } from './basic-information-form';
-import { IStepElementProps } from '../container';
+import { ROLES } from '@/core/constants/config/constants';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { cn } from '@/core/lib/helpers';
-import { useTranslations } from 'next-intl';
 import { getInitialValue } from '@/core/lib/helpers/create-project';
+import { organizationProjectsState, rolesState } from '@/core/stores';
 import { EProjectRelation } from '@/core/types/generics/enums/project';
 import { ERoleName } from '@/core/types/generics/enums/role';
 import { TProjectRelation } from '@/core/types/schemas';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, organizationProjectsState, organizationTeamsState, rolesState } from '@/core/stores';
-import { ROLES } from '@/core/constants/config/constants';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { CheckIcon, LockIcon, Plus, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { FormEvent, useCallback, useMemo, useState } from 'react';
+import { IStepElementProps } from '../container';
+import { Identifiable, Select, Thumbnail } from './basic-information-form';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
 
 export default function TeamAndRelationsForm(props: IStepElementProps) {
 	const { goToNext, goToPrevious, currentData } = props;
@@ -30,8 +32,8 @@ export default function TeamAndRelationsForm(props: IStepElementProps) {
 
 	// Get teams for multi-select
 	const organizationProjects = useAtomValue(organizationProjectsState);
-	const allTeams = useAtomValue(organizationTeamsState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const { teams: allTeams } = useOrganisationTeams();
+	const activeTeam = useCurrentTeam();
 
 	// Filter available teams based on user role:
 	// - Admin: Can see all teams

--- a/apps/web/core/components/features/projects/quick-create-project-modal.tsx
+++ b/apps/web/core/components/features/projects/quick-create-project-modal.tsx
@@ -1,13 +1,14 @@
-import { useOrganizationProjects } from '@/core/hooks';
 import { Button, Modal, Text } from '@/core/components';
-import { useTranslations } from 'next-intl';
-import { useCallback, useEffect, useState } from 'react';
-import { InputField } from '../../duplicated-components/_input';
-import { EverCard } from '../../common/ever-card';
+import { useOrganizationProjects } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { isTeamManagerState } from '@/core/stores';
 import { TOrganizationProject } from '@/core/types/schemas';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, isTeamManagerState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useState } from 'react';
+import { EverCard } from '../../common/ever-card';
+import { InputField } from '../../duplicated-components/_input';
 
 interface IQuickCreateProjectModalProps {
 	open: boolean;
@@ -35,7 +36,7 @@ export function QuickCreateProjectModal(props: IQuickCreateProjectModalProps) {
 	const [name, setName] = useState('');
 
 	// Get active team and current user info
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const isTeamManager = useAtomValue(isTeamManagerState);
 	const { data: user } = useUserQuery();
 

--- a/apps/web/core/components/features/tasks/edit-task-modal.tsx
+++ b/apps/web/core/components/features/tasks/edit-task-modal.tsx
@@ -1,22 +1,23 @@
 import { Modal, statusColor } from '@/core/components';
-import { DatePickerFilter } from '../../pages/timesheet/timesheet-filter-date';
-import { FormEvent, useCallback, useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { clsxm } from '@/core/lib/utils';
-import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components/teams/manage-member-component';
-import { statusTable } from '../../timesheet/timesheet-action';
-import { ITimeLog } from '@/core/types/interfaces/timer/time-log/time-log';
-import { differenceBetweenHours, formatTimeFromDate, secondsToTime, toDate } from '@/core/lib/helpers/index';
-import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
 import { ToastAction } from '@/core/components/common/toast';
+import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components/teams/manage-member-component';
+import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { differenceBetweenHours, formatTimeFromDate, secondsToTime, toDate } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { organizationProjectsState } from '@/core/stores';
+import { ITimeLog } from '@/core/types/interfaces/timer/time-log/time-log';
 import { ReloadIcon } from '@radix-ui/react-icons';
 import { addMinutes, format, parseISO } from 'date-fns';
-import { Clock7 } from 'lucide-react';
-import { CustomSelect } from '../../common/multiple-select';
-import { TaskNameInfoDisplay } from '../../tasks/task-displays';
-import { toast } from 'sonner';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, organizationProjectsState } from '@/core/stores';
+import { Clock7 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { FormEvent, useCallback, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { CustomSelect } from '../../common/multiple-select';
+import { DatePickerFilter } from '../../pages/timesheet/timesheet-filter-date';
+import { TaskNameInfoDisplay } from '../../tasks/task-displays';
+import { statusTable } from '../../timesheet/timesheet-action';
 
 export interface IEditTaskModalProps {
 	isOpen: boolean;
@@ -26,7 +27,7 @@ export interface IEditTaskModalProps {
 export function EditTaskModal({ isOpen, closeModal, dataTimesheet }: IEditTaskModalProps) {
 	const organizationProjects = useAtomValue(organizationProjectsState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const t = useTranslations();
 	const { updateTimesheet, loadingUpdateTimesheet } = useTimesheet({});
 	const initialTimeRange = {

--- a/apps/web/core/components/features/teams/create-team-modal.tsx
+++ b/apps/web/core/components/features/teams/create-team-modal.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useOrganizationTeams } from '@/core/hooks';
 import { BackButton, Button, Modal, Text } from '@/core/components';
+import { useCreateOrganizationTeam } from '@/core/hooks/organizations/teams/use-create-organization-team';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
+import { timerStatusState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
 import { Dispatch, SetStateAction, useMemo, useState } from 'react';
 import { EverCard } from '../../common/ever-card';
 import { InputField } from '../../duplicated-components/_input';
-import { organizationTeamsState, timerStatusState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
 
 /**
  * Create team modal
@@ -27,14 +28,14 @@ export function CreateTeamModal({
 	const timerRunningStatus = useMemo(() => {
 		return Boolean(timerStatus?.running);
 	}, [timerStatus]);
-	const teams = useAtomValue(organizationTeamsState);
-	const { createOTeamLoading, createOrganizationTeam } = useOrganizationTeams();
+	const { teams } = useOrganisationTeams();
+	const { createOrganizationTeam, loading: createOTeamLoading } = useCreateOrganizationTeam();
 	const [error, setError] = useState<string | null>(null);
 
 	const [name, setName] = useState('');
 
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		console.log("Team Submit");
+		console.log('Team Submit');
 		e.preventDefault();
 		setError(null);
 		const form = new FormData(e.currentTarget);

--- a/apps/web/core/components/features/teams/invite-form-modal.tsx
+++ b/apps/web/core/components/features/teams/invite-form-modal.tsx
@@ -1,35 +1,37 @@
 'use client';
 
+import { BackButton, Button, Modal, Text } from '@/core/components';
+import { EverCard } from '@/core/components/common/ever-card';
+import { useTeamInvitations } from '@/core/hooks/organizations';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useTeamMemberInvitation } from '@/core/hooks/organizations/teams/use-team-member-invitations';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { rolesState, workingEmployeesState } from '@/core/stores';
+import { ERoleName } from '@/core/types/generics/enums/role';
 import { AxiosError } from 'axios';
 import { isEmail, isNotEmpty } from 'class-validator';
-import { BackButton, Button, Modal, Text } from '@/core/components';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
-import { InviteEmailDropdown } from '../../teams/invite/invite-email-dropdown';
-import { useTeamInvitations } from '@/core/hooks/organizations';
-import { EverCard } from '@/core/components/common/ever-card';
-import { InputField } from '../../duplicated-components/_input';
-import { IInviteEmail } from '../../teams/invite/invite-email-item';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '../../common/select';
-import { useAtomValue } from 'jotai';
-import { activeTeamState, getTeamInvitationsState, rolesState, workingEmployeesState } from '@/core/stores';
-import { ERoleName } from '@/core/types/generics/enums/role';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { InputField } from '../../duplicated-components/_input';
+import { InviteEmailDropdown } from '../../teams/invite/invite-email-dropdown';
+import { IInviteEmail } from '../../teams/invite/invite-email-item';
 
 export function InviteFormModal({ open, closeModal }: { open: boolean; closeModal: () => void }) {
 	const { data: user } = useUserQuery();
 	const roles = useAtomValue(rolesState);
 	const t = useTranslations();
 
-	const teamInvitations = useAtomValue(getTeamInvitationsState);
+	const teamInvitations = useTeamMemberInvitation();
 	const { inviteUser, inviteLoading, resendTeamInvitation, resendInviteLoading } = useTeamInvitations();
 
 	const [errors, setErrors] = useState<{ email?: string; name?: string; role?: string }>({});
 	const [selectedEmail, setSelectedEmail] = useState<IInviteEmail>();
 	const workingEmployees = useAtomValue(workingEmployeesState);
 	const [currentOrgEmails, setCurrentOrgEmails] = useState<IInviteEmail[]>([]);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const nameInputRef = useRef<HTMLInputElement>(null);
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 	const isLoading = inviteLoading || resendInviteLoading;

--- a/apps/web/core/components/features/teams/request-to-join-modal.tsx
+++ b/apps/web/core/components/features/teams/request-to-join-modal.tsx
@@ -1,18 +1,17 @@
 'use client';
 
-import { useAuthenticationPasscode, useRequestToJoinTeam } from '@/core/hooks';
-import { clsxm } from '@/core/lib/utils';
 import { Button, Modal, SpinnerLoader, Text } from '@/core/components';
-import { useCallback, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { ArrowLeftIcon } from 'assets/svg';
 import { AuthCodeInputField } from '@/core/components/auth/auth-code-input';
 import { EverCard } from '@/core/components/common/ever-card';
 import { InputField } from '@/core/components/duplicated-components/_input';
-import { PositionDropDown } from '../../layouts/default-layout/header/position-dropdown';
+import { useAuthenticationPasscode, useRequestToJoinTeam } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { clsxm } from '@/core/lib/utils';
 import { TJoinTeamRequest } from '@/core/types/schemas';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { ArrowLeftIcon } from 'assets/svg';
+import { useTranslations } from 'next-intl';
+import { useCallback, useState } from 'react';
+import { PositionDropDown } from '../../layouts/default-layout/header/position-dropdown';
 
 export const RequestToJoinModal = ({ open, closeModal }: { open: boolean; closeModal: () => void }) => {
 	const [currentTab, setCurrentTab] = useState<'ALREADY_MEMBER' | 'BECOME_MEMBER'>('ALREADY_MEMBER');
@@ -155,7 +154,7 @@ const BecomeMember = ({ closeModal }: { closeModal: any }) => {
 	const t = useTranslations();
 	const { formValues, setFormValues, errors, setErrors, sendCodeLoading, inputCodeRef } = useAuthenticationPasscode();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const {
 		requestToJoinTeam,
 		validateRequestToJoinTeam,

--- a/apps/web/core/components/features/teams/transfer-team-modal.tsx
+++ b/apps/web/core/components/features/teams/transfer-team-modal.tsx
@@ -1,23 +1,25 @@
-import { useOrganizationTeams } from '@/core/hooks';
-import { activeTeamManagersState, activeTeamState } from '@/core/stores';
 import { BackButton, Button, Modal, Text } from '@/core/components';
-import { useCallback, useState } from 'react';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { IOrganizationTeamEmployee } from '@/core/types/interfaces/team/organization-team-employee';
 import { useTranslations } from 'next-intl';
-import { useAtomValue } from 'jotai';
+import { useCallback, useState } from 'react';
 import { EverCard } from '../../common/ever-card';
 import { TransferTeamDropdown } from '../../teams/transfer-team/transfer-team-dropdown';
-import { IOrganizationTeamEmployee } from '@/core/types/interfaces/team/organization-team-employee';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useEditOrganizationTeamMutation } from '@/core/hooks/organizations/teams/use-edit-organization-team-mutation';
 
 /**
  * Transfer team modal
  */
 export function TransferTeamModal({ open, closeModal }: { open: boolean; closeModal: () => void }) {
 	const t = useTranslations();
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
-	const { editOrganizationTeam, editOrganizationTeamLoading } = useOrganizationTeams();
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const { mutateAsync: editOrganizationTeam, isPending: editOrganizationTeamLoading } =
+		useEditOrganizationTeamMutation();
+
+	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 
 	const [selectedMember, setSelectedMember] = useState<IOrganizationTeamEmployee>();

--- a/apps/web/core/components/features/timesheet/add-mask-modal.tsx
+++ b/apps/web/core/components/features/timesheet/add-mask-modal.tsx
@@ -1,8 +1,3 @@
-import React, { useCallback, useMemo } from 'react';
-import { TranslationHooks, useTranslations } from 'next-intl';
-import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components/teams/manage-member-component';
-import { useTimelogFilterOptions } from '@/core/hooks';
-import { clsxm } from '@/core/lib/utils';
 import { Modal } from '@/core/components';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/core/components/common/accordion';
 import {
@@ -13,16 +8,22 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@/core/components/common/select';
+import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components/teams/manage-member-component';
+import { useTimelogFilterOptions } from '@/core/hooks';
 import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { toUTC } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { ETimeLogSource, ETimeLogType } from '@/core/types/generics/enums/timer';
 import { PlusIcon, ReloadIcon } from '@radix-ui/react-icons';
+import { useAtomValue } from 'jotai';
+import { TranslationHooks, useTranslations } from 'next-intl';
+import React, { useCallback, useMemo } from 'react';
 import { CustomSelect } from '../../common/multiple-select';
+import { DatePickerFilter } from '../../pages/timesheet/timesheet-filter-date';
 import { TaskNameInfoDisplay } from '../../tasks/task-displays';
 import { ToggleButton } from '../tasks/edit-task-modal';
-import { DatePickerFilter } from '../../pages/timesheet/timesheet-filter-date';
-import { ETimeLogType, ETimeLogSource } from '@/core/types/generics/enums/timer';
-import { useAtomValue } from 'jotai';
-import { activeTeamState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
 
 export interface IAddTaskModalProps {
 	isOpen: boolean;
@@ -54,7 +55,7 @@ export function AddTaskModal({ closeModal, isOpen }: IAddTaskModalProps) {
 	const { generateTimeOptions } = useTimelogFilterOptions();
 	const organizationProjects = useAtomValue(organizationProjectsState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { createTimesheet, loadingCreateTimesheet } = useTimesheet({});
 
 	const timeOptions = generateTimeOptions(5);

--- a/apps/web/core/components/integration/calendar/time-sheet-filter-popover.tsx
+++ b/apps/web/core/components/integration/calendar/time-sheet-filter-popover.tsx
@@ -1,9 +1,10 @@
-import { Button } from '@/core/components/duplicated-components/_button';
 import { Modal } from '@/core/components';
-import { statusOptions } from '@/core/constants/config/constants';
-import { MultiSelect } from '@/core/components/common/multi-select';
 import { Input } from '@/core/components/common/input';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
+import { MultiSelect } from '@/core/components/common/multi-select';
+import { Button } from '@/core/components/duplicated-components/_button';
+import { statusOptions } from '@/core/constants/config/constants';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { tasksByTeamState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
 interface TimeSheetFilterProps {
 	isOpen: boolean;
@@ -11,7 +12,7 @@ interface TimeSheetFilterProps {
 }
 
 export function TimeSheetFilter({ closeModal, isOpen }: TimeSheetFilterProps) {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const tasks = useAtomValue(tasksByTeamState);
 	// const [taskId, setTaskId] = useState<TTask | TTask[] | null>([]);

--- a/apps/web/core/components/layouts/app-sidebar.tsx
+++ b/apps/web/core/components/layouts/app-sidebar.tsx
@@ -1,54 +1,55 @@
-import * as React from 'react';
 import {
+	AudioWaveform,
+	Command,
+	FolderKanban,
+	GalleryVerticalEnd,
+	LoaderCircle,
 	MonitorSmartphone,
 	SquareActivity,
-	X,
-	Command,
-	AudioWaveform,
-	GalleryVerticalEnd,
-	FolderKanban,
-	LoaderCircle
+	X
 } from 'lucide-react';
 import Image from 'next/image';
+import * as React from 'react';
 
 import {
 	Sidebar,
 	SidebarContent,
-	SidebarHeader,
-	SidebarRail,
-	SidebarTrigger,
-	useSidebar,
-	SidebarMenuSubButton,
 	SidebarFooter,
-	SidebarSeparator
+	SidebarHeader,
+	SidebarMenuSubButton,
+	SidebarRail,
+	SidebarSeparator,
+	SidebarTrigger,
+	useSidebar
 } from '@/core/components/common/sidebar';
-import Link from 'next/link';
+import { useFavorites, useModal } from '@/core/hooks';
 import { cn } from '@/core/lib/helpers';
 import { isValidProjectForDisplay, projectBelongsToTeam, projectHasNoTeams } from '@/core/lib/helpers/type-guards';
-import { useFavorites, useModal } from '@/core/hooks';
 import { useTranslations } from 'next-intl';
-import { SidebarOptInForm } from './sidebar-opt-in-form';
+import Link from 'next/link';
 import { useMemo } from 'react';
+import { WorkspacesSwitcher } from '../common/workspace-switcher';
 import { DashboardIcon, FavoriteIcon, HomeIcon, InboxIcon, SidebarTaskIcon } from '../icons';
 import { TaskIssueStatus } from '../tasks/task-issue';
-import { WorkspacesSwitcher } from '../common/workspace-switcher';
+import { SidebarOptInForm } from './sidebar-opt-in-form';
 // Import optimized components from centralized location
+import { ModalSkeleton } from '@/core/components/common/skeleton/modal-skeleton';
 import { LazySidebarCommandModal } from '@/core/components/optimized-components/common';
 import { LazyCreateTeamModal } from '@/core/components/optimized-components/teams';
-import { NavHome } from '../nav-home';
-import { NavMain } from './nav-main';
-import { Suspense } from 'react';
-import { ModalSkeleton } from '@/core/components/common/skeleton/modal-skeleton';
+import { APP_NAME } from '@/core/constants/config/constants';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { isTeamManagerState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { currentEmployeeFavoritesState } from '@/core/stores/common/favorites';
 import { EBaseEntityEnum } from '@/core/types/generics/enums/entity';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
-import { currentEmployeeFavoritesState } from '@/core/stores/common/favorites';
-import { activeTeamState, isTeamManagerState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { APP_NAME } from '@/core/constants/config/constants';
+import { Suspense } from 'react';
 import { GlobalAllPlansModal } from '../daily-plan';
-import { GlobalAssignTaskModal } from '../features/tasks/global-assign-task-modal';
 import { GlobalProjectActionModal } from '../features/projects/global-project-action-modal';
+import { GlobalAssignTaskModal } from '../features/tasks/global-assign-task-modal';
+import { NavHome } from '../nav-home';
+import { NavMain } from './nav-main';
 type AppSidebarProps = React.ComponentProps<typeof Sidebar> & { publicTeam: boolean | undefined };
 export function AppSidebar({ publicTeam, ...props }: AppSidebarProps) {
 	const { data: user } = useUserQuery();
@@ -61,7 +62,7 @@ export function AppSidebar({ publicTeam, ...props }: AppSidebarProps) {
 	const { isOpen, closeModal } = useModal();
 	const t = useTranslations();
 	const organizationProjects = useAtomValue(organizationProjectsState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	// Filter projects based on active team context:
 	// - "All Teams" mode (no active team): show ALL projects

--- a/apps/web/core/components/pages/kanban/menu-kanban-card.tsx
+++ b/apps/web/core/components/pages/kanban/menu-kanban-card.tsx
@@ -1,19 +1,20 @@
-import { useAuthenticateUser, useModal, useTeamMemberCard, useTeamTasks } from '@/core/hooks';
-import { activeTeamState, activeTeamTaskId, taskStatusesState } from '@/core/stores';
-import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
-import { ThreeCircleOutlineVerticalIcon } from 'assets/svg';
 import { SpinnerLoader } from '@/core/components';
+import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
 import { PlanTask } from '@/core/components/tasks/task-card';
-import { useTranslations } from 'next-intl';
-import { useAtomValue, useSetAtom } from 'jotai';
-import { Combobox, Transition } from '@headlessui/react';
-import React, { JSX, useCallback } from 'react';
-import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
-import { HorizontalSeparator } from '../../duplicated-components/separator';
+import { useAuthenticateUser, useModal, useTeamMemberCard, useTeamTasks } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { activeTeamTaskId, taskStatusesState } from '@/core/stores';
 import { EDailyPlanMode } from '@/core/types/generics/enums/daily-plan';
+import { EIssueType, ETaskPriority } from '@/core/types/generics/enums/task';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { EIssueType, ETaskPriority } from '@/core/types/generics/enums/task';
+import { Combobox, Transition } from '@headlessui/react';
+import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
+import { ThreeCircleOutlineVerticalIcon } from 'assets/svg';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
+import React, { JSX, useCallback } from 'react';
+import { HorizontalSeparator } from '../../duplicated-components/separator';
 import { CreateDailyPlanFormModal } from '../../features/daily-plan/create-daily-plan-form-modal';
 
 export default function MenuKanbanCard({ item: task, member }: { item: TTask; member: any }) {
@@ -25,7 +26,7 @@ export default function MenuKanbanCard({ item: task, member }: { item: TTask; me
 	const { closeModal, isOpen, openModal } = useModal();
 	const authUser = useAuthenticateUser();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	// Use the authenticated user's employee ID (prefer employeeId FK over employee.id relation)
 	const employeeId = authUser?.user?.employeeId ?? authUser?.user?.employee?.id ?? '';

--- a/apps/web/core/components/pages/permissions/page-component.tsx
+++ b/apps/web/core/components/pages/permissions/page-component.tsx
@@ -1,20 +1,21 @@
 'use client';
 
-import { activeTeamManagersState, rolesState } from '@/core/stores';
-import NotFound from '@/core/components/pages/404';
-import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { CommonToggle, Container, Divider, Text } from '@/core/components';
+import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { MainHeader, MainLayout } from '@/core/components/layouts/default-layout';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { useAtomValue } from 'jotai';
-import { fullWidthState } from '@/core/stores/common/full-width';
+import NotFound from '@/core/components/pages/404';
 import { useIsMemberManager } from '@/core/hooks/organizations';
-import { useRolePermissions } from '@/core/hooks/roles';
-import { Breadcrumb } from '../../duplicated-components/breadcrumb';
-import { EverCard } from '../../common/ever-card';
-import { TRole } from '@/core/types/schemas';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useRolePermissions } from '@/core/hooks/roles';
+import { rolesState } from '@/core/stores';
+import { fullWidthState } from '@/core/stores/common/full-width';
+import { TRole } from '@/core/types/schemas';
+import { useAtomValue } from 'jotai';
+import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { EverCard } from '../../common/ever-card';
+import { Breadcrumb } from '../../duplicated-components/breadcrumb';
 
 const Permissions = () => {
 	// Translations
@@ -28,7 +29,7 @@ const Permissions = () => {
 	const [selectedRole, setSelectedRole] = useState<TRole | null>(null);
 
 	// Hooks with data fetching
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 	const { rolePermissionsFormated, getRolePermissions, updateRolePermission } = useRolePermissions();
 	const { isTeamManager } = useIsMemberManager(user);
 	const roles = useAtomValue(rolesState);

--- a/apps/web/core/components/pages/projects/project-detail/page-component.tsx
+++ b/apps/web/core/components/pages/projects/project-detail/page-component.tsx
@@ -1,46 +1,47 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
-import { useTranslations, useLocale } from 'next-intl';
-import { useAtomValue } from 'jotai';
-import Image from 'next/image';
-import moment from 'moment';
-import {
-	ArrowLeftIcon,
-	Calendar,
-	ExternalLink,
-	Users,
-	Banknote,
-	Tag,
-	Building2,
-	CircleDot,
-	Pencil,
-	Archive,
-	Trash,
-	RotateCcw,
-	MoreVertical,
-	ShieldAlert
-} from 'lucide-react';
 import { Menu, Transition } from '@headlessui/react';
+import { useQuery } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
+import {
+	Archive,
+	ArrowLeftIcon,
+	Banknote,
+	Building2,
+	Calendar,
+	CircleDot,
+	ExternalLink,
+	MoreVertical,
+	Pencil,
+	RotateCcw,
+	ShieldAlert,
+	Tag,
+	Trash,
+	Users
+} from 'lucide-react';
+import moment from 'moment';
+import { useLocale, useTranslations } from 'next-intl';
+import Image from 'next/image';
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useMemo } from 'react';
 
-import { MainLayout } from '@/core/components/layouts/default-layout';
 import { Container } from '@/core/components';
+import { ProjectDetailSkeleton } from '@/core/components/common/skeleton/projects';
+import { Button } from '@/core/components/duplicated-components/_button';
 import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
 import { HorizontalSeparator, VerticalSeparator } from '@/core/components/duplicated-components/separator';
-import { cn } from '@/core/lib/helpers';
-import { activeTeamState, isTrackingEnabledState } from '@/core/stores';
-import { fullWidthState } from '@/core/stores/common/full-width';
-import { organizationProjectService } from '@/core/services/client/api/organizations';
-import { queryKeys } from '@/core/query/keys';
-import { EProjectBilling, EProjectBudgetType } from '@/core/types/generics/enums/project';
-import { Button } from '@/core/components/duplicated-components/_button';
-import { ProjectDetailSkeleton } from '@/core/components/common/skeleton/projects';
-import { InfoItem, MemberCard, Section, StatusBadge } from './components';
+import { MainLayout } from '@/core/components/layouts/default-layout';
 import { useProjectPermissions } from '@/core/hooks/projects/use-project-permissions';
 import { useProjectActionModal } from '@/core/hooks/use-project-action-modal';
+import { cn } from '@/core/lib/helpers';
 import { projectBelongsToTeam, projectHasNoTeams } from '@/core/lib/helpers/type-guards';
+import { queryKeys } from '@/core/query/keys';
+import { organizationProjectService } from '@/core/services/client/api/organizations';
+import { isTrackingEnabledState } from '@/core/stores';
+import { fullWidthState } from '@/core/stores/common/full-width';
+import { EProjectBilling, EProjectBudgetType } from '@/core/types/generics/enums/project';
+import { InfoItem, MemberCard, Section, StatusBadge } from './components';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 export default function ProjectDetailPageComponent() {
 	const t = useTranslations();
@@ -51,7 +52,7 @@ export default function ProjectDetailPageComponent() {
 	const currentLocale = params?.locale;
 
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const fullWidth = useAtomValue(fullWidthState);
 
 	// Fetch project by ID

--- a/apps/web/core/components/pages/reports/weekly-limit/members-select.tsx
+++ b/apps/web/core/components/pages/reports/weekly-limit/members-select.tsx
@@ -6,10 +6,9 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@/core/components/common/select';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useTranslations } from 'next-intl';
 import { useCallback, useState } from 'react';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
 
 interface IProps {
 	onChange: (value: string) => void;
@@ -29,7 +28,7 @@ interface IProps {
 export function MembersSelect(props: IProps) {
 	const { onChange } = props;
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const [selected, setSelected] = useState<string>('all');
 	const t = useTranslations();
 	const handleChange = useCallback(

--- a/apps/web/core/components/pages/settings/personal/danger-zone-personal.tsx
+++ b/apps/web/core/components/pages/settings/personal/danger-zone-personal.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { useModal, useOrganizationTeams, useUser } from '@/core/hooks';
+import { useModal, useUser } from '@/core/hooks';
 import { Button, Text } from '@/core/components';
 import Image from 'next/image';
 import { useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { RemoveModal } from '../../../settings/remove-modal';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useRemoveUserFromAllTeamMutation } from '@/core/hooks/organizations/teams/use-remove-user-from-all-team-mutation';
 type RemoveModalType = 'REMOVE' | 'DELETE' | 'DELETE_ALL' | string;
 type ActionFunction = () => void;
 
@@ -17,7 +18,9 @@ export const DangerZone = () => {
 	const { deleteUser, deleteUserLoading } = useUser();
 	const { data: user } = useUserQuery();
 
-	const { removeUserFromAllTeam, removeUserFromAllTeamLoading } = useOrganizationTeams();
+	const { mutateAsync: removeUserFromAllTeam, isPending: removeUserFromAllTeamLoading } =
+		useRemoveUserFromAllTeamMutation();
+
 	const handleRemoveUser = useCallback(() => {
 		if (user) {
 			return removeUserFromAllTeam(user.id);

--- a/apps/web/core/components/pages/settings/team/danger-zone-team.tsx
+++ b/apps/web/core/components/pages/settings/team/danger-zone-team.tsx
@@ -1,14 +1,15 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { useIsMemberManager, useModal, useOrganizationEmployeeTeams, useOrganizationTeams } from '@/core/hooks';
-import { activeTeamManagersState, activeTeamState } from '@/core/stores';
 import { Button, Text } from '@/core/components';
-import { useCallback, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { useAtomValue } from 'jotai';
-import { LAST_WORKSPACE_AND_TEAM } from '@/core/constants/config/constants';
-import { RemoveModal } from '@/core/components/settings/remove-modal';
 import { TransferTeamModal } from '@/core/components/features/teams/transfer-team-modal';
+import { RemoveModal } from '@/core/components/settings/remove-modal';
+import { LAST_WORKSPACE_AND_TEAM } from '@/core/constants/config/constants';
+import { useIsMemberManager, useModal, useOrganizationEmployeeTeams } from '@/core/hooks';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useDeleteOrganizationTeamMutation } from '@/core/hooks/organizations/teams/use-delete-organization-team-mutation';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTranslations } from 'next-intl';
+import { useCallback, useState } from 'react';
 
 export const DangerZoneTeam = () => {
 	const t = useTranslations();
@@ -16,13 +17,14 @@ export const DangerZoneTeam = () => {
 	const { isOpen: dangerIsOpen, closeModal: dangerCloseModal, openModal: dangerOpenaModal } = useModal();
 	const [removeModalType, setRemoveModalType] = useState<'DISPOSE' | 'QUIT' | null>(null);
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const { deleteOrganizationTeam, deleteOrganizationTeamLoading } = useOrganizationTeams();
+	const activeTeam = useCurrentTeam();
+	const { mutateAsync: deleteOrganizationTeam, isPending: deleteOrganizationTeamLoading } =
+		useDeleteOrganizationTeamMutation();
 	const { deleteOrganizationTeamEmployee, deleteOrganizationEmployeeTeamLoading } = useOrganizationEmployeeTeams();
 	const { data: user } = useUserQuery();
 
 	const { isTeamManager } = useIsMemberManager(user);
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
 	const handleDisposeTeam = useCallback(() => {
 		if (activeTeam) {

--- a/apps/web/core/components/pages/settings/team/integration-setting.tsx
+++ b/apps/web/core/components/pages/settings/team/integration-setting.tsx
@@ -1,22 +1,20 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { GitHubLogoIcon } from '@radix-ui/react-icons';
-import { useTranslations } from 'next-intl';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/core/components/common/select';
-import { useGitHubIntegration, useIntegrationTenant, useIntegrationTypes } from '@/core/hooks';
-import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
-import { GITHUB_APP_NAME } from '@/core/constants/config/constants';
-import { useOrganizationProjects } from '@/core/hooks';
-import { TrashIcon } from 'assets/svg';
 import { Button } from '@/core/components';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/core/components/common/select';
+import { InputField } from '@/core/components/duplicated-components/_input';
+import { GITHUB_APP_NAME } from '@/core/constants/config/constants';
+import { useGitHubIntegration, useIntegrationTenant, useIntegrationTypes, useOrganizationProjects } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { getActiveProjectIdCookie } from '@/core/lib/helpers/index';
 import { Switch } from '@headlessui/react';
+import { GitHubLogoIcon } from '@radix-ui/react-icons';
+import { TrashIcon } from 'assets/svg';
 import debounce from 'lodash/debounce';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import qs from 'qs';
-import { InputField } from '@/core/components/duplicated-components/_input';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
 export const IntegrationSetting = () => {
 	const t = useTranslations();
@@ -39,7 +37,7 @@ export const IntegrationSetting = () => {
 
 	const url = `https://github.com/apps/${GITHUB_APP_NAME.value}/installations/new?${queries.toString()}`;
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const [selectedRepo, setSelectedRepo] = useState<string | undefined>(undefined);
 

--- a/apps/web/core/components/pages/settings/team/invitation-setting.tsx
+++ b/apps/web/core/components/pages/settings/team/invitation-setting.tsx
@@ -1,19 +1,18 @@
-import { useModal, useRequestToJoinTeam } from '@/core/hooks';
 import { Button, NoData } from '@/core/components';
-import { SearchNormalIcon } from 'assets/svg';
-import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
-import { ChangeEvent, useEffect, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { InvitationTable } from '../../../teams/invite/invitation-table';
 import { InputField } from '@/core/components/duplicated-components/_input';
-import { getTeamInvitationsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
+import { useModal, useRequestToJoinTeam } from '@/core/hooks';
+import { useTeamMemberInvitation } from '@/core/hooks/organizations/teams/use-team-member-invitations';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { SearchNormalIcon } from 'assets/svg';
+import { useTranslations } from 'next-intl';
+import { ChangeEvent, useEffect, useState } from 'react';
+import { InvitationTable } from '../../../teams/invite/invitation-table';
 
 export const InvitationSetting = () => {
 	const t = useTranslations();
 
-	const teamInvitations = useAtomValue(getTeamInvitationsState);
+	const teamInvitations = useTeamMemberInvitation();
 	const { getRequestToJoin, requestToJoin } = useRequestToJoinTeam();
 
 	const { data: user } = useUserQuery();

--- a/apps/web/core/components/pages/settings/team/member-setting.tsx
+++ b/apps/web/core/components/pages/settings/team/member-setting.tsx
@@ -1,19 +1,18 @@
-import { useModal } from '@/core/hooks';
 import { Button, NoData, Text } from '@/core/components';
-import { SearchNormalIcon } from 'assets/svg';
-import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
-import { ChangeEvent, useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { MemberTable } from '../../../teams/member-table';
 import { InputField } from '@/core/components/duplicated-components/_input';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
+import { useModal } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { SearchNormalIcon } from 'assets/svg';
+import { useTranslations } from 'next-intl';
+import { ChangeEvent, useMemo, useState } from 'react';
+import { MemberTable } from '../../../teams/member-table';
 
 export const MemberSetting = () => {
 	const t = useTranslations();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const [filterString, setFilterString] = useState<string>('');
 
 	const { data: user } = useUserQuery();

--- a/apps/web/core/components/pages/settings/team/team-setting-form.tsx
+++ b/apps/web/core/components/pages/settings/team/team-setting-form.tsx
@@ -1,38 +1,42 @@
-import { useIsMemberManager, useOrganizationTeams } from '@/core/hooks';
-import { ERoleName } from '@/core/types/generics/enums/role';
-import { activeTeamState } from '@/core/stores';
 import { Button, ColorPicker, Text } from '@/core/components';
 import { EmojiPicker } from '@/core/components/common/emoji-picker';
 import TimeTrackingToggle, { RequireDailyPlanToTrack, ShareProfileViewsToggle } from '@/core/components/common/switch';
-import debounce from 'lodash/debounce';
-import isEqual from 'lodash/isEqual';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useTranslations } from 'next-intl';
-import { useAtom } from 'jotai';
-import { useParams } from 'next/navigation';
-import { CheckSquareOutlineIcon, EditPenUnderlineIcon } from 'assets/svg';
-import TeamSize from '@/core/components/teams/team-size-popover';
 import { InputField } from '@/core/components/duplicated-components/_input';
 import { Tooltip } from '@/core/components/duplicated-components/tooltip';
-import { toast } from 'sonner';
-import { TOrganizationTeam, TOrganizationTeamUpdate } from '@/core/types/schemas';
+import TeamSize from '@/core/components/teams/team-size-popover';
+import { useIsMemberManager } from '@/core/hooks';
+import { useEditOrganizationTeamMutation } from '@/core/hooks/organizations/teams/use-edit-organization-team-mutation';
+import {
+	useGetOrganizationTeamQuery,
+	useGetOrganizationTeamsQuery
+} from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { activeTeamState, organizationTeamsState } from '@/core/stores';
+import { ERoleName } from '@/core/types/generics/enums/role';
+import { TOrganizationTeam, TOrganizationTeamUpdate } from '@/core/types/schemas';
+import { CheckSquareOutlineIcon, EditPenUnderlineIcon } from 'assets/svg';
+import { useAtom, useSetAtom } from 'jotai';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 import { LoaderCircle } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 
 export const TeamSettingForm = () => {
 	const { data: user } = useUserQuery();
 	const { register, setValue, handleSubmit, getValues, trigger } = useForm();
 	const t = useTranslations();
 
+	const { isLoading: loading } = useGetOrganizationTeamsQuery();
+	const { isLoading: loadingTeam } = useGetOrganizationTeamQuery();
+	const { mutateAsync: editOrganizationTeam, isPending: editOrganizationTeamLoading } =
+		useEditOrganizationTeamMutation();
+
 	const [activeTeam, setActiveTeam] = useAtom(activeTeamState);
-	const {
-		editOrganizationTeam,
-		getOrganizationTeamsLoading: loading,
-		loadingTeam,
-		setTeams,
-		editOrganizationTeamLoading
-	} = useOrganizationTeams();
+	const setTeams = useSetAtom(organizationTeamsState);
 	const { isTeamManager, activeManager } = useIsMemberManager(user);
 	const [copied, setCopied] = useState<boolean>(false);
 	const [disabled, setDisabled] = useState<boolean>(true);

--- a/apps/web/core/components/pages/task/details-section/blocks/task-estimations-info.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-estimations-info.tsx
@@ -1,4 +1,15 @@
-import { activeTeamState, detailedTaskState } from '@/core/stores';
+import { Card } from '@/core/components/duplicated-components/card';
+import {
+	Select,
+	Thumbnail
+} from '@/core/components/features/projects/add-or-edit-project/steps/basic-information-form';
+import { TaskEstimate } from '@/core/components/tasks/task-estimate';
+import { TaskMemberEstimate } from '@/core/components/tasks/task-member-estimate';
+import { cn } from '@/core/lib/helpers';
+import { detailedTaskState } from '@/core/stores';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TCreateTaskEstimation } from '@/core/types/schemas/task/task-estimation.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import {
 	Disclosure,
 	DisclosureButton,
@@ -9,28 +20,18 @@ import {
 	Transition
 } from '@headlessui/react';
 import { ChevronDownIcon, ChevronUpIcon } from 'assets/svg';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
+import { CheckIcon, Plus } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import React, { useCallback, useMemo, useState } from 'react';
 import ProfileInfoWithTime from '../components/profile-info-with-time';
 import TaskRow from '../components/task-row';
-import React, { useCallback, useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { TaskEstimate } from '@/core/components/tasks/task-estimate';
-import { CheckIcon, Plus } from 'lucide-react';
-import {
-	Select,
-	Thumbnail
-} from '@/core/components/features/projects/add-or-edit-project/steps/basic-information-form';
-import { cn } from '@/core/lib/helpers';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { Card } from '@/core/components/duplicated-components/card';
-import { TaskMemberEstimate } from '@/core/components/tasks/task-member-estimate';
-import { TCreateTaskEstimation } from '@/core/types/schemas/task/task-estimation.schema';
-import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const TaskEstimationsInfo = () => {
 	const [task] = useAtom(detailedTaskState);
 	const t = useTranslations();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const teamMembers = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 
@@ -124,7 +125,7 @@ export default TaskEstimationsInfo;
 
 function AddNewMemberEstimation({ task, onSuccess }: { task: TTask; onSuccess?: () => void }) {
 	const [selectedMember, setSelectedMember] = useState<TOrganizationTeamEmployee | null>(null);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const teamMembers = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 	const taskEstimation = useMemo<TCreateTaskEstimation>(
 		() => ({

--- a/apps/web/core/components/pages/task/details-section/blocks/task-main-info.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-main-info.tsx
@@ -1,29 +1,30 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { calculateRemainingDays, formatDateString } from '@/core/lib/helpers/index';
 import { useSyncRef, useTeamTasks } from '@/core/hooks';
-import { activeTeamState, detailedTaskState } from '@/core/stores';
+import { calculateRemainingDays, formatDateString } from '@/core/lib/helpers/index';
 import { clsxm } from '@/core/lib/utils';
+import { detailedTaskState } from '@/core/stores';
 import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
 import { TrashIcon } from 'assets/svg';
-import { forwardRef, useCallback, useState } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
+import { forwardRef, useCallback, useState } from 'react';
 import ProfileInfo from '../components/profile-info';
 import TaskRow from '../components/task-row';
 
 import { DatePicker } from '@/core/components/common/date-picker';
-import Link from 'next/link';
-import { useTranslations } from 'next-intl';
-import { PencilSquareIcon } from '@heroicons/react/20/solid';
 import { ActiveTaskIssuesDropdown } from '@/core/components/tasks/task-issue';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { PencilSquareIcon } from '@heroicons/react/20/solid';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useTaskMemberManagement } from '@/core/hooks/tasks/use-task-member-management';
 import { MemberSection } from './member-section';
 
 const TaskMainInfo = () => {
 	const [task] = useAtom(detailedTaskState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const t = useTranslations();
 
 	return (

--- a/apps/web/core/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-progress.tsx
@@ -1,23 +1,24 @@
-import { activeTeamState, detailedTaskState } from '@/core/stores';
-import { useAtom, useAtomValue } from 'jotai';
-import TaskRow from '../components/task-row';
+import { TaskProgressBar } from '@/core/components/tasks/task-progress-bar';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { secondsToTime } from '@/core/lib/helpers/index';
+import { detailedTaskState } from '@/core/stores';
+import { ITime } from '@/core/types/interfaces/common/time';
+import { TTaskStatistics } from '@/core/types/interfaces/task/task';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
+import { ChevronDownIcon, ChevronUpIcon } from 'assets/svg';
+import { useAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useState } from 'react';
 import ProfileInfoWithTime from '../components/profile-info-with-time';
-import { secondsToTime } from '@/core/lib/helpers/index';
-import { ChevronDownIcon, ChevronUpIcon } from 'assets/svg';
-import { useTranslations } from 'next-intl';
-import { TaskProgressBar } from '@/core/components/tasks/task-progress-bar';
-import { TTaskStatistics } from '@/core/types/interfaces/task/task';
-import { ITime } from '@/core/types/interfaces/common/time';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import TaskRow from '../components/task-row';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const TaskProgress = () => {
 	const [task] = useAtom(detailedTaskState);
 	const { data: user } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const t = useTranslations();
 
 	const [userTotalTime, setUserTotalTime] = useState<ITime>({
@@ -184,7 +185,7 @@ export default TaskProgress;
 const IndividualMembersTotalTime = ({ numMembersToShow }: { numMembersToShow: number }) => {
 	const [task] = useAtom(detailedTaskState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const matchingMembers = activeTeam?.members?.filter((member) =>
 		task?.members?.some((taskMember) => taskMember.id === member.employeeId)

--- a/apps/web/core/components/pages/task/details-section/blocks/task-secondary-info.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-secondary-info.tsx
@@ -1,29 +1,17 @@
-import { useModal, useTeamTasks } from '@/core/hooks';
-import { activeTeamState, detailedTaskState, isTeamManagerState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { ERoleName } from '@/core/types/generics/enums/role';
-import { PlusIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Button, Modal, SpinnerLoader } from '@/core/components';
-import { TaskVersionForm } from '@/core/components/tasks/version-form';
-import { cloneDeep } from 'lodash';
-import Link from 'next/link';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useAtomValue } from 'jotai';
-import TaskRow from '../components/task-row';
-import { useTranslations } from 'next-intl';
-import { toast } from 'sonner';
-import { AddIcon, CircleIcon, Square4OutlineIcon, TrashIcon } from 'assets/svg';
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger
 } from '@/core/components/common/dropdown-menu';
-import { clsxm } from '@/core/lib/utils';
-import { organizationProjectsState } from '@/core/stores/projects/organization-projects';
-import { isValidProjectForDisplay, projectBelongsToTeam, projectHasNoTeams } from '@/core/lib/helpers/type-guards';
+import { EverCard } from '@/core/components/common/ever-card';
 import { ScrollArea, ScrollBar } from '@/core/components/common/scroll-bar';
-import Image from 'next/image';
+import { Tooltip } from '@/core/components/duplicated-components/tooltip';
+import { QuickCreateProjectModal } from '@/core/components/features/projects/quick-create-project-modal';
+import { TaskLabels } from '@/core/components/tasks/task-labels';
+import { TaskPrioritiesForm } from '@/core/components/tasks/task-priorities-form';
+import { TaskSizesForm } from '@/core/components/tasks/task-sizes-form';
 import {
 	ActiveTaskPropertiesDropdown,
 	ActiveTaskSizesDropdown,
@@ -32,18 +20,31 @@ import {
 	EpicPropertiesDropdown as TaskEpicDropdown,
 	TaskStatus
 } from '@/core/components/tasks/task-status';
-import { TaskLabels } from '@/core/components/tasks/task-labels';
 import { TaskStatusesForm } from '@/core/components/tasks/task-statuses-form';
-import { TaskPrioritiesForm } from '@/core/components/tasks/task-priorities-form';
-import { TaskSizesForm } from '@/core/components/tasks/task-sizes-form';
-import { Tooltip } from '@/core/components/duplicated-components/tooltip';
-import { EverCard } from '@/core/components/common/ever-card';
-import { QuickCreateProjectModal } from '@/core/components/features/projects/quick-create-project-modal';
+import { TaskVersionForm } from '@/core/components/tasks/version-form';
+import { useModal, useTeamTasks } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTaskLabelsValue } from '@/core/hooks/tasks/use-task-labels-value';
+import { cn } from '@/core/lib/helpers';
+import { isValidProjectForDisplay, projectBelongsToTeam, projectHasNoTeams } from '@/core/lib/helpers/type-guards';
+import { clsxm } from '@/core/lib/utils';
+import { detailedTaskState, isTeamManagerState } from '@/core/stores';
+import { organizationProjectsState } from '@/core/stores/projects/organization-projects';
+import { ERoleName } from '@/core/types/generics/enums/role';
 import { EIssueType } from '@/core/types/generics/enums/task';
 import { TOrganizationProject, TTaskVersion } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useTaskLabelsValue } from '@/core/hooks/tasks/use-task-labels-value';
-import { cn } from '@/core/lib/helpers';
+import { ChevronDownIcon, PlusIcon } from '@heroicons/react/20/solid';
+import { AddIcon, CircleIcon, Square4OutlineIcon, TrashIcon } from 'assets/svg';
+import { useAtomValue } from 'jotai';
+import { cloneDeep } from 'lodash';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import TaskRow from '../components/task-row';
 
 type StatusType = 'version' | 'epic' | 'status' | 'label' | 'size' | 'priority';
 
@@ -311,7 +312,7 @@ export function ProjectDropDown(props: ITaskProjectDropdownProps) {
 	const { task, controlled = false, onChange, styles } = props;
 	const { openModal, isOpen, closeModal } = useModal();
 	const organizationProjects = useAtomValue(organizationProjectsState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { updateTask, updateLoading } = useTeamTasks();
 	const t = useTranslations();
 

--- a/apps/web/core/components/pages/teams/team/tasks/dropdown-menu-task.tsx
+++ b/apps/web/core/components/pages/teams/team/tasks/dropdown-menu-task.tsx
@@ -1,25 +1,24 @@
-import { Button } from '@/core/components/duplicated-components/_button';
 import {
 	DropdownMenu,
-	DropdownMenuTrigger,
 	DropdownMenuContent,
 	DropdownMenuItem,
-	DropdownMenuSeparator
+	DropdownMenuSeparator,
+	DropdownMenuTrigger
 } from '@/core/components/common/dropdown-menu';
+import { Button } from '@/core/components/duplicated-components/_button';
 import { useAuthenticateUser, useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks';
 import { useTranslations } from 'next-intl';
-import { FC, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { FC, useCallback } from 'react';
 
-import { toast } from 'sonner';
-import { TTask } from '@/core/types/schemas/task/task.schema';
 import { Spinner } from '@/core/components/common/spinner';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useFavoriteTasks } from '@/core/hooks/tasks/use-favorites-task';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { toast } from 'sonner';
 
 const DropdownMenuTask: FC<{ task: TTask }> = ({ task }) => {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const router = useRouter();
 	const { user } = useAuthenticateUser();
 	const isAssigned = task?.members?.some((m) => m?.user?.id === user?.id);

--- a/apps/web/core/components/pages/teams/team/team-members-views/team-members-card-view.tsx
+++ b/apps/web/core/components/pages/teams/team/team-members-views/team-members-card-view.tsx
@@ -1,15 +1,14 @@
+import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
+import { InvitedCard, InviteUserTeamCard } from '@/core/components/teams/invite/user-invite-card';
 import { useIsMemberManager, useModal, useOrganizationEmployeeTeams } from '@/core/hooks';
+import { useTeamMemberInvitation } from '@/core/hooks/organizations/teams/use-team-member-invitations';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { EInviteStatus } from '@/core/types/generics/enums/invite';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { Transition } from '@headlessui/react';
 import React, { memo, useCallback } from 'react';
 import { InviteUserTeamSkeleton, UserTeamCardSkeleton } from './team-members-header';
 import { UserTeamCard } from './user-team-card';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { InvitedCard, InviteUserTeamCard } from '@/core/components/teams/invite/user-invite-card';
-import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
-import { EInviteStatus } from '@/core/types/generics/enums/invite';
-import { useAtomValue } from 'jotai';
-import { getTeamInvitationsState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
 interface Props {
 	teamMembers: TOrganizationTeamEmployee[];
@@ -24,7 +23,7 @@ const TeamMembersCardView: React.FC<Props> = memo(
 
 		const { isTeamManager } = useIsMemberManager(user);
 
-		const teamInvitations = useAtomValue(getTeamInvitationsState);
+		const teamInvitations = useTeamMemberInvitation();
 
 		const { updateOrganizationTeamEmployeeOrderOnList } = useOrganizationEmployeeTeams();
 

--- a/apps/web/core/components/pages/teams/team/team-members-views/user-team-block/user-team-block-header.tsx
+++ b/apps/web/core/components/pages/teams/team/team-members-views/user-team-block/user-team-block-header.tsx
@@ -1,27 +1,27 @@
 import { Button } from '@/core/components';
-import { useModal, useUserProfilePage } from '@/core/hooks';
-import { taskBlockFilterState, blockViewSearchQueryState } from '@/core/stores/tasks/task-filter';
-import { useAtom, useAtomValue } from 'jotai';
-import { useTranslations } from 'next-intl';
-import { useMemo, useEffect } from 'react';
-import { activeTeamState } from '@/core/stores';
-import { clsxm } from '@/core/lib/utils';
-import {
-	SearchNormalIcon,
-	TimerPlayIcon,
-	CheckCircleTickIcon,
-	CrossCircleIcon,
-	StopCircleIcon,
-	PauseIcon
-} from 'assets/svg';
-import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
-import { useTaskFilter } from '@/core/hooks/tasks/use-task-filter';
-import { TaskNameFilter } from '@/core/components/pages/profile/task-filters';
 import { VerticalSeparator } from '@/core/components/duplicated-components/separator';
+import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
+import { TaskNameFilter } from '@/core/components/pages/profile/task-filters';
+import { useModal, useUserProfilePage } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTaskFilter } from '@/core/hooks/tasks/use-task-filter';
 import { useProcessedTeamMembers } from '@/core/hooks/teams/use-processed-team-members';
 import { useTeamMemberFilterStatsForUI } from '@/core/hooks/teams/use-team-member-filter-stats';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { clsxm } from '@/core/lib/utils';
 import { TeamMemberFilterType } from '@/core/lib/utils/team-members.utils';
+import { blockViewSearchQueryState, taskBlockFilterState } from '@/core/stores/tasks/task-filter';
+import {
+	CheckCircleTickIcon,
+	CrossCircleIcon,
+	PauseIcon,
+	SearchNormalIcon,
+	StopCircleIcon,
+	TimerPlayIcon
+} from 'assets/svg';
+import { useAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
+import { useEffect, useMemo } from 'react';
 
 // Interface for filter stats (kept for UI compatibility)
 interface IFilter {
@@ -73,7 +73,7 @@ const statusButtons = (
 export function UserTeamBlockHeader() {
 	const t = useTranslations();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 	const { openModal, isOpen, closeModal } = useModal();
 	const [activeFilter, setActiveFilter] = useAtom<TeamMemberFilterType>(taskBlockFilterState);

--- a/apps/web/core/components/pages/teams/team/team-members.tsx
+++ b/apps/web/core/components/pages/teams/team/team-members.tsx
@@ -1,24 +1,26 @@
-import { useOrganizationTeams } from '@/core/hooks';
-import { Transition } from '@headlessui/react';
-import UserTeamCardSkeletonCard from '@/core/components/teams/user-team-card-skeleton';
+import { Container } from '@/core/components';
 import InviteUserTeamCardSkeleton from '@/core/components/teams/invite-team-card-skeleton';
 import { UserCard } from '@/core/components/teams/team-page-skeleton';
+import UserTeamCardSkeletonCard from '@/core/components/teams/user-team-card-skeleton';
 import { IssuesView } from '@/core/constants/config/constants';
-import { useAtomValue } from 'jotai';
-import { taskBlockFilterState, blockViewSearchQueryState } from '@/core/stores/tasks/task-filter';
-import { Container } from '@/core/components';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useFuseMemberSearch } from '@/core/hooks/teams/use-fuse-member-search';
+import { useFilteredTeamMembers, useProcessedTeamMembers } from '@/core/hooks/teams/use-processed-team-members';
+import { TeamMemberFilterType } from '@/core/lib/utils/team-members.utils';
 import { fullWidthState } from '@/core/stores/common/full-width';
-import { useMemo, memo } from 'react';
+import { blockViewSearchQueryState, taskBlockFilterState } from '@/core/stores/tasks/task-filter';
+import { TaskCardProps } from '@/core/types/interfaces/task/task-card';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { Transition } from '@headlessui/react';
+import { useAtomValue } from 'jotai';
+import { memo, useMemo } from 'react';
+import TeamMembersBlockView from './team-members-views/team-members-block-view';
 import TeamMembersCardView from './team-members-views/team-members-card-view';
 import TeamMembersTableView from './team-members-views/user-team-table/team-members-table-view';
-import TeamMembersBlockView from './team-members-views/team-members-block-view';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { TaskCardProps } from '@/core/types/interfaces/task/task-card';
-import { useProcessedTeamMembers, useFilteredTeamMembers } from '@/core/hooks/teams/use-processed-team-members';
-import { activeTeamState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { TeamMemberFilterType } from '@/core/lib/utils/team-members.utils';
-import { useFuseMemberSearch } from '@/core/hooks/teams/use-fuse-member-search';
+import {
+	useGetOrganizationTeamQuery,
+	useGetOrganizationTeamsQuery
+} from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
 
 // Types for better performance and security
 
@@ -66,8 +68,10 @@ export const TeamMembers = memo<TeamMembersProps>(({ publicTeam = false, kanbanV
 	const searchQuery = useAtomValue(blockViewSearchQueryState);
 	const fullWidth = useAtomValue(fullWidthState);
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const { getOrganizationTeamsLoading: teamsFetching } = useOrganizationTeams();
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
+
+	const { isPending: teamsFetching } = useGetOrganizationTeamsQuery();
 
 	// Use refactored hooks for member processing
 	const processedMembers = useProcessedTeamMembers(activeTeam, user!);

--- a/apps/web/core/components/pages/time-and-activity/page-component.tsx
+++ b/apps/web/core/components/pages/time-and-activity/page-component.tsx
@@ -1,28 +1,29 @@
 'use client';
-import { MainLayout } from '@/core/components/layouts/default-layout';
-import { useTranslations } from 'next-intl';
-import { useRouter, useParams } from 'next/navigation';
-import { useAtomValue } from 'jotai';
-import { fullWidthState } from '@/core/stores/common/full-width';
 import { Container } from '@/core/components';
-import { cn } from '@/core/lib/helpers';
-import { ArrowLeftIcon } from '@radix-ui/react-icons';
-import { useMemo, useState, useCallback } from 'react';
 import { Card } from '@/core/components/common/card';
-import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
-import { GroupByType, useReportActivity } from '@/core/hooks/activities/use-report-activity';
-import { useTimeActivityStats } from '@/core/hooks/activities/use-time-activity-stats';
+import { TimeActivityPageSkeleton } from '@/core/components/common/skeleton/time-activity-page-skeleton';
 import { ViewOption } from '@/core/components/common/view-select';
 import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
-import { TimeActivityPageSkeleton } from '@/core/components/common/skeleton/time-activity-page-skeleton';
-import { FilterState } from '@/core/types/interfaces/timesheet/time-limit-report';
+import { MainLayout } from '@/core/components/layouts/default-layout';
 import {
-	LazyTimeActivityHeader,
-	LazyCardTimeAndActivity,
 	LazyActivityTable,
+	LazyCardTimeAndActivity,
+	LazyTimeActivityHeader,
 	LazyTimeActivityTable
 } from '@/core/components/optimized-components/reports';
-import { activeTeamState, isTrackingEnabledState, tasksByTeamState, organizationProjectsState } from '@/core/stores';
+import { GroupByType, useReportActivity } from '@/core/hooks/activities/use-report-activity';
+import { useTimeActivityStats } from '@/core/hooks/activities/use-time-activity-stats';
+import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { cn } from '@/core/lib/helpers';
+import { isTrackingEnabledState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { fullWidthState } from '@/core/stores/common/full-width';
+import { FilterState } from '@/core/types/interfaces/timesheet/time-limit-report';
+import { ArrowLeftIcon } from '@radix-ui/react-icons';
+import { useAtomValue } from 'jotai';
+import { useTranslations } from 'next-intl';
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useMemo, useState } from 'react';
 
 const STORAGE_KEY = 'ever-teams-activity-view-options';
 
@@ -135,7 +136,7 @@ const TimeActivityComponents = () => {
 
 	const tasks = useAtomValue(tasksByTeamState);
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const breadcrumbPath = useMemo(
 		() => [

--- a/apps/web/core/components/pages/timesheet/timesheet-filter-popover.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-filter-popover.tsx
@@ -1,20 +1,21 @@
-import React from 'react';
-import { Button } from '@/core/components/duplicated-components/_button';
-import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
 import { SettingFilterIcon } from '@/assets/svg';
-import { useTranslations } from 'next-intl';
+import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
+import { Button } from '@/core/components/duplicated-components/_button';
 import { useTimelogFilterOptions } from '@/core/hooks';
 import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { cn } from '@/core/lib/helpers';
-import { statusTable } from '../../timesheet/timesheet-action';
-import { MultiSelect } from '../../common/multi-select';
+import { organizationProjectsState, tasksByTeamState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { useTranslations } from 'next-intl';
+import React from 'react';
+import { MultiSelect } from '../../common/multi-select';
+import { statusTable } from '../../timesheet/timesheet-action';
 
 export const TimeSheetFilterPopover = React.memo(function TimeSheetFilterPopover() {
 	const [shouldRemoveItems, setShouldRemoveItems] = React.useState(false);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const organizationProjects = useAtomValue(organizationProjectsState);
 	const tasks = useAtomValue(tasksByTeamState);

--- a/apps/web/core/components/pages/timesheet/timesheet-page-content.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-page-content.tsx
@@ -11,6 +11,17 @@ import { useLocalStorageState, useModal } from '@/core/hooks';
 import { fullWidthState } from '@/core/stores/common/full-width';
 import { useAtomValue } from 'jotai';
 
+import { TimesheetDetailModalSkeleton } from '@/core/components/common/skeleton/timesheet-skeletons';
+import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
+import { IconsSearch } from '@/core/components/icons';
+import {
+	LazyCalendarView,
+	LazyTimesheetCard,
+	LazyTimesheetDetailModal,
+	LazyTimesheetFilter,
+	LazyTimesheetPagination,
+	LazyTimesheetView
+} from '@/core/components/optimized-components/calendar';
 import {
 	CalendarViewIcon,
 	ListViewIcon,
@@ -19,27 +30,16 @@ import {
 	PendingTaskIcon,
 	SelectedTimesheet
 } from '@/core/components/timesheet';
-import { ArrowLeftIcon } from 'assets/svg';
-import type { IconBaseProps } from 'react-icons';
-import { TimesheetDetailModalSkeleton } from '@/core/components/common/skeleton/timesheet-skeletons';
-import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
-import { IconsSearch } from '@/core/components/icons';
 import { ViewToggleButton } from '@/core/components/timesheet/timesheet-toggle-view';
 import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
 import { useTimesheetFilters } from '@/core/hooks/activities/use-timesheet-filters';
 import { useTimesheetPagination } from '@/core/hooks/activities/use-timesheet-pagination';
 import { useTimesheetViewData } from '@/core/hooks/activities/use-timesheet-view-data';
-import { differenceBetweenHours, getGreeting, secondsToTime } from '@/core/lib/helpers/index';
-import { activeTeamState } from '@/core/stores';
-import {
-	LazyCalendarView,
-	LazyTimesheetView,
-	LazyTimesheetDetailModal,
-	LazyTimesheetFilter,
-	LazyTimesheetCard,
-	LazyTimesheetPagination
-} from '@/core/components/optimized-components/calendar';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { differenceBetweenHours, getGreeting, secondsToTime } from '@/core/lib/helpers/index';
+import { ArrowLeftIcon } from 'assets/svg';
+import type { IconBaseProps } from 'react-icons';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 type TimesheetViewMode = 'ListView' | 'CalendarView';
 export type TimesheetDetailMode = 'Pending' | 'MenHours' | 'MemberWork';
@@ -56,7 +56,7 @@ export function TimeSheetPageContent({ params }: { params: { memberId: string } 
 		return [10, 20, 30, 50];
 	};
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const isTrackingEnabled = !!activeTeam?.members?.find(
 		(member) => member.employee?.userId === user?.id && member.isTrackingEnabled

--- a/apps/web/core/components/projects/filters-card-modal.tsx
+++ b/apps/web/core/components/projects/filters-card-modal.tsx
@@ -1,14 +1,15 @@
 import { Button, Modal } from '@/core/components';
-import { ListFilterPlus, X } from 'lucide-react';
-import { useTranslations } from 'next-intl';
-import { MultiSelectWithSearch } from '../common/multi-select-with-search';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import Image from 'next/image';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { EverCard } from '../common/ever-card';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
+import { organizationProjectsState, taskStatusesState } from '@/core/stores';
 import { EProjectBudgetType } from '@/core/types/generics/enums/project';
 import { useAtomValue } from 'jotai';
-import { organizationProjectsState, organizationTeamsState, taskStatusesState } from '@/core/stores';
+import { ListFilterPlus, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { EverCard } from '../common/ever-card';
+import { MultiSelectWithSearch } from '../common/multi-select-with-search';
 
 interface IFiltersCardModalProps {
 	open: boolean;
@@ -23,7 +24,7 @@ export default function FiltersCardModal({ open, closeModal }: IFiltersCardModal
 	const [selectedStatus, setSelectedStatus] = useState<string[]>([]);
 	const [selectedBudgetType, setSelectedBudgetType] = useState<string[]>([]);
 	const params = useSearchParams();
-	const teams = useAtomValue(organizationTeamsState);
+	const { teams } = useOrganisationTeams();
 
 	const organizationProjects = useAtomValue(organizationProjectsState);
 	const teamMembers = useMemo(

--- a/apps/web/core/components/settings/table-action-popover.tsx
+++ b/apps/web/core/components/settings/table-action-popover.tsx
@@ -1,16 +1,16 @@
-import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
-import { useTranslations } from 'next-intl';
-import { ConfirmationModal } from './confirmation-modal';
-import { ThreeCircleOutlineHorizontalIcon } from 'assets/svg';
-import { useEmployeeUpdate, useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks/organizations';
 import { useModal } from '@/core/hooks/common';
+import { useEmployeeUpdate, useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks/organizations';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { rolesState } from '@/core/stores';
-import { useDropdownAction } from '../pages/teams/team/team-members-views/user-team-card/user-team-card-menu';
 import { ERoleName } from '@/core/types/generics/enums/role';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
+import { ThreeCircleOutlineHorizontalIcon } from 'assets/svg';
 import { useAtomValue } from 'jotai';
-import { activeTeamManagersState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTranslations } from 'next-intl';
+import { useDropdownAction } from '../pages/teams/team/team-members-views/user-team-card/user-team-card-menu';
+import { ConfirmationModal } from './confirmation-modal';
 
 type Props = {
 	member: TOrganizationTeamEmployee;
@@ -25,7 +25,7 @@ export const TableActionPopover = ({ member, handleEdit, status }: Props) => {
 	// const [isOpen, setIsOpen] = useState(false);
 	const t = useTranslations();
 	const { data: user } = useUserQuery();
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
 	const memberInfo = useTeamMemberCard(member);
 	const taskEdition = useTMCardTaskEdit(memberInfo.memberTask);

--- a/apps/web/core/components/tasks/daily-plan/table-view/cells/task-action-menu-cell.tsx
+++ b/apps/web/core/components/tasks/daily-plan/table-view/cells/task-action-menu-cell.tsx
@@ -1,17 +1,16 @@
-import { CellContext } from '@tanstack/react-table';
-import { ActiveTaskStatusDropdown } from '../../../task-status';
-import { useMemo, useState } from 'react';
 import { I_UserProfilePage, useTeamMemberCard } from '@/core/hooks';
-import { get } from 'lodash';
-import { TaskCardMenu } from '../../../task-card';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { CellContext } from '@tanstack/react-table';
+import { get } from 'lodash';
+import { useMemo, useState } from 'react';
+import { TaskCardMenu } from '../../../task-card';
+import { ActiveTaskStatusDropdown } from '../../../task-status';
 
 export default function TaskActionMenuCell(props: CellContext<TTask, unknown>) {
 	const [loading, setLoading] = useState(false);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const members = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 	const profile = get(props.column, 'columnDef.meta.profile') as unknown as I_UserProfilePage;
 	const plan = get(props.column, 'columnDef.meta.plan');

--- a/apps/web/core/components/tasks/daily-plan/table-view/cells/task-estimation-cell.tsx
+++ b/apps/web/core/components/tasks/daily-plan/table-view/cells/task-estimation-cell.tsx
@@ -1,9 +1,8 @@
 import { TaskEstimateInfo } from '@/core/components/pages/teams/team/team-members-views/user-team-card/task-estimate';
 import { I_UserProfilePage, useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks';
-import { activeTeamState } from '@/core/stores';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { CellContext } from '@tanstack/react-table';
-import { useAtomValue } from 'jotai';
 import { get } from 'lodash';
 import { useMemo } from 'react';
 
@@ -11,7 +10,7 @@ export default function DailyPlanTaskEstimationCell(props: CellContext<TTask, un
 	const plan = get(props.column, 'columnDef.meta.plan');
 	const profile = get(props.column, 'columnDef.meta.profile') as unknown as I_UserProfilePage;
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const members = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 	const currentMember = useMemo(
 		() =>

--- a/apps/web/core/components/tasks/daily-plan/table-view/cells/task-times-cell.tsx
+++ b/apps/web/core/components/tasks/daily-plan/table-view/cells/task-times-cell.tsx
@@ -1,16 +1,15 @@
-import { CellContext } from '@tanstack/react-table';
-import { TaskTimes } from '../../../task-times';
 import { I_UserProfilePage, useTeamMemberCard } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { CellContext } from '@tanstack/react-table';
 import get from 'lodash/get';
 import { useMemo } from 'react';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { TaskTimes } from '../../../task-times';
 
 export default function DailyPlanTaskTimesCell(props: CellContext<TTask, unknown>) {
 	const profile = get(props.column, 'columnDef.meta.profile') as unknown as I_UserProfilePage;
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const members = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 	const currentMember = useMemo(
 		() =>

--- a/apps/web/core/components/tasks/kanban-card.tsx
+++ b/apps/web/core/components/tasks/kanban-card.tsx
@@ -1,17 +1,17 @@
-import { DraggableProvided } from '@hello-pangea/dnd';
+import CircularProgress from '@/core/components/svgs/circular-progress';
 import PriorityIcon from '@/core/components/svgs/priority-icon';
 import { useTaskStatistics, useTeamMemberCard, useTimerView } from '@/core/hooks';
-import { ImageOverlapperProps } from '../common/image-overlapper';
-import Link from 'next/link';
-import CircularProgress from '@/core/components/svgs/circular-progress';
 import { secondsToTime } from '@/core/lib/helpers/index';
-import { activeTeamState, activeTeamTaskId, activeTeamTaskState } from '@/core/stores';
-import { useAtom, useAtomValue } from 'jotai';
-import { HorizontalSeparator } from '../duplicated-components/separator';
-import { ITag } from '@/core/types/interfaces/tag/tag';
+import { activeTeamTaskId, activeTeamTaskState } from '@/core/stores';
 import { ETaskPriority } from '@/core/types/generics/enums/task';
-import { TTask } from '@/core/types/schemas/task/task.schema';
+import { ITag } from '@/core/types/interfaces/tag/tag';
 import { TTaskStatistics } from '@/core/types/interfaces/task/task';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { DraggableProvided } from '@hello-pangea/dnd';
+import { useAtom, useAtomValue } from 'jotai';
+import Link from 'next/link';
+import { ImageOverlapperProps } from '../common/image-overlapper';
+import { HorizontalSeparator } from '../duplicated-components/separator';
 
 import { LazyImageComponent, LazyMenuKanbanCard } from '@/core/components/optimized-components/kanban';
 import {
@@ -20,6 +20,7 @@ import {
 	LazyTaskIssueStatus
 } from '@/core/components/optimized-components/tasks';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 function getStyle(provided: DraggableProvided, style: any) {
 	if (!style) {
@@ -133,7 +134,7 @@ type ItemProps = {
  */
 export default function Item(props: ItemProps) {
 	const { item, isDragging, provided, style } = props;
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 	const { getEstimation } = useTaskStatistics(0);
 	const [activeTask, setActiveTask] = useAtom(activeTeamTaskId);

--- a/apps/web/core/components/tasks/task-block-card.tsx
+++ b/apps/web/core/components/tasks/task-block-card.tsx
@@ -1,19 +1,20 @@
-import { TTaskStatistics } from '@/core/types/interfaces/task/task';
-import { TaskInput } from './task-input';
-import { useAtom, useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskId, activeTeamTaskState, timerStatusState } from '@/core/stores';
-import Link from 'next/link';
-import { useTaskStatistics, useTeamMemberCard } from '@/core/hooks';
 import ImageComponent, { ImageOverlapperProps } from '@/core/components/common/image-overlapper';
-import { TaskIssueStatus } from './task-issue';
-import { Priority, setCommentIconColor } from '@/core/components/tasks/kanban-card';
 import CircularProgress from '@/core/components/svgs/circular-progress';
+import { Priority, setCommentIconColor } from '@/core/components/tasks/kanban-card';
+import { useTaskStatistics, useTeamMemberCard } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { secondsToTime } from '@/core/lib/helpers/index';
+import { activeTeamTaskId, activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { TTaskStatistics } from '@/core/types/interfaces/task/task';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useAtom, useAtomValue } from 'jotai';
+import Link from 'next/link';
 import React from 'react';
 import { HorizontalSeparator } from '../duplicated-components/separator';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { LazyMenuKanbanCard, LazyTaskAllStatusTypes } from '../optimized-components';
+import { TaskInput } from './task-input';
+import { TaskIssueStatus } from './task-issue';
 
 interface TaskItemProps {
 	task: TTask;
@@ -22,7 +23,7 @@ interface TaskItemProps {
 export default function TaskBlockCard(props: TaskItemProps) {
 	const { task } = props;
 	const [activeTask, setActiveTask] = useAtom(activeTeamTaskId);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const timerStatus = useAtomValue(timerStatusState);
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);

--- a/apps/web/core/components/tasks/task-card.tsx
+++ b/apps/web/core/components/tasks/task-card.tsx
@@ -1,5 +1,14 @@
 'use client';
-import { secondsToTime, tomorrowDate } from '@/core/lib/helpers/index';
+import { SpinnerLoader, Text } from '@/core/components';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuPortal,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger
+} from '@/core/components/common/dropdown-menu';
+import ImageComponent, { ImageOverlapperProps } from '@/core/components/common/image-overlapper';
 import {
 	I_TeamMemberCardHook,
 	I_UserProfilePage,
@@ -10,52 +19,44 @@ import {
 	useTaskStatistics,
 	useTeamMemberCard
 } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import ImageComponent, { ImageOverlapperProps } from '@/core/components/common/image-overlapper';
-import { EDailyPlanStatus, EDailyPlanMode } from '@/core/types/generics/enums/daily-plan';
+import { useFavoriteTasks } from '@/core/hooks/tasks/use-favorites-task';
+import { useTimerButtonLogic } from '@/core/hooks/tasks/use-timer-button';
+import { secondsToTime, tomorrowDate } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { activeTeamTaskState, timerSecondsState } from '@/core/stores';
+import { Nullable, SetAtom } from '@/core/types/generics';
+import { EDailyPlanMode, EDailyPlanStatus } from '@/core/types/generics/enums/daily-plan';
+import { IClassName } from '@/core/types/interfaces/common/class-name';
+import { IEmployee } from '@/core/types/interfaces/organization/employee';
 import {
 	IDailyPlanTasksUpdate,
 	IRemoveTaskFromManyPlansRequest
 } from '@/core/types/interfaces/task/daily-plan/daily-plan';
-import { activeTeamState, activeTeamTaskState, timerSecondsState } from '@/core/stores';
-import { clsxm } from '@/core/lib/utils';
-import {
-	DropdownMenu,
-	DropdownMenuTrigger,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownMenuPortal
-} from '@/core/components/common/dropdown-menu';
-import { SpinnerLoader, Text } from '@/core/components';
+import { TDailyPlan, TOrganizationTeam, TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { ReloadIcon } from '@radix-ui/react-icons';
+import { SixSquareGridIcon, ThreeCircleOutlineVerticalIcon } from 'assets/svg';
+import { SetStateAction, useAtomValue } from 'jotai';
+import { LoaderCircle } from 'lucide-react';
+import moment from 'moment';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import React, { useCallback, useMemo, useState, useTransition } from 'react';
-import { SetStateAction, useAtomValue } from 'jotai';
+import { toast } from 'sonner';
+import { EverCard } from '../common/ever-card';
+import { AddTasksEstimationHoursModal, EnforcePlanedTaskModal, SuggestDailyPlanModal } from '../daily-plan';
+import { VerticalSeparator } from '../duplicated-components/separator';
+import { AddTaskToPlan } from '../features/daily-plan/add-task-to-plan';
+import { CreateDailyPlanFormModal } from '../features/daily-plan/create-daily-plan-form-modal';
+import { TaskEstimateInfo } from '../pages/teams/team/team-members-views/user-team-card/task-estimate';
 import { TimerButton } from '../timer/timer-button';
 import { TaskAllStatusTypes } from './task-all-status-type';
 import { TaskNameInfoDisplay } from './task-displays';
 import { TaskAvatars } from './task-items';
 import { ActiveTaskStatusDropdown } from './task-status';
 import { TaskTimes } from './task-times';
-import { useTranslations } from 'next-intl';
-import { SixSquareGridIcon, ThreeCircleOutlineVerticalIcon } from 'assets/svg';
-import { CreateDailyPlanFormModal } from '../features/daily-plan/create-daily-plan-form-modal';
-import { ReloadIcon } from '@radix-ui/react-icons';
-import moment from 'moment';
-import { AddTasksEstimationHoursModal, EnforcePlanedTaskModal, SuggestDailyPlanModal } from '../daily-plan';
-import { Nullable, SetAtom } from '@/core/types/generics';
-import { TaskEstimateInfo } from '../pages/teams/team/team-members-views/user-team-card/task-estimate';
-import { EverCard } from '../common/ever-card';
-import { VerticalSeparator } from '../duplicated-components/separator';
-import { AddTaskToPlan } from '../features/daily-plan/add-task-to-plan';
-import { IEmployee } from '@/core/types/interfaces/organization/employee';
-import { IClassName } from '@/core/types/interfaces/common/class-name';
-import { toast } from 'sonner';
-import { TDailyPlan, TOrganizationTeam, TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { useTimerButtonLogic } from '@/core/hooks/tasks/use-timer-button';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { LoaderCircle } from 'lucide-react';
-import { useFavoriteTasks } from '@/core/hooks/tasks/use-favorites-task';
 
 type Props = {
 	active?: boolean;
@@ -100,7 +101,7 @@ export const TaskCard = React.memo(function TaskCard(props: Props) {
 	);
 
 	const { data: user } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const canSeeActivity = useCanSeeActivityScreen();
 
 	const isTrackingEnabled = useMemo(

--- a/apps/web/core/components/tasks/task-input.tsx
+++ b/apps/web/core/components/tasks/task-input.tsx
@@ -1,4 +1,7 @@
 'use client';
+import { Button, Divider, SpinnerLoader } from '@/core/components';
+import { LazyRender } from '@/core/components/common/lazy-render';
+import { ProjectDropDown } from '@/core/components/pages/task/details-section/blocks/task-secondary-info';
 import {
 	HostKeys,
 	RTuseTaskInput,
@@ -8,40 +11,32 @@ import {
 	useOutsideClick,
 	useTaskInput
 } from '@/core/hooks';
-import {
-	activeTeamState,
-	activeTeamTaskId,
-	issueTypesListState,
-	timerStatusState,
-	taskLabelsListState
-} from '@/core/stores';
+import { useInfinityScrolling } from '@/core/hooks/common/use-infinity-fetch';
+import { cn } from '@/core/lib/helpers';
 import { clsxm } from '@/core/lib/utils';
+import { activeTeamTaskId, issueTypesListState, taskLabelsListState, timerStatusState } from '@/core/stores';
+import { EIssueType, ETaskPriority, ETaskSize, ETaskStatusName } from '@/core/types/generics/enums/task';
+import { Nullable } from '@/core/types/generics/utils';
+import { IIssueType } from '@/core/types/interfaces/task/issue-type';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { Combobox, Popover, PopoverPanel, Transition } from '@headlessui/react';
 import { CheckIcon, ChevronDownIcon, PlusIcon, UserGroupIcon } from '@heroicons/react/20/solid';
-import { Button, Divider, SpinnerLoader } from '@/core/components';
 import { CircleIcon, CheckCircleTickIcon as TickCircleIcon } from 'assets/svg';
-import { JSX, RefObject, PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
+import { JSX, PropsWithChildren, RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { EverCard } from '../common/ever-card';
+import { InputField } from '../duplicated-components/_input';
+import { OutlineBadge } from '../duplicated-components/badge';
+import { Tooltip } from '../duplicated-components/tooltip';
+import { ObserverComponent } from './observer';
 import { ActiveTaskIssuesDropdown, TaskIssuesDropdown } from './task-issue';
 import { TaskItem } from './task-items';
 import { TaskLabels } from './task-labels';
 import { ActiveTaskPropertiesDropdown, ActiveTaskSizesDropdown, ActiveTaskStatusDropdown } from './task-status';
-import { useTranslations } from 'next-intl';
-import { useInfinityScrolling } from '@/core/hooks/common/use-infinity-fetch';
-import { LazyRender } from '@/core/components/common/lazy-render';
-import { ProjectDropDown } from '@/core/components/pages/task/details-section/blocks/task-secondary-info';
-import { toast } from 'sonner';
-import { cn } from '@/core/lib/helpers';
-import { InputField } from '../duplicated-components/_input';
-import { Tooltip } from '../duplicated-components/tooltip';
-import { EverCard } from '../common/ever-card';
-import { OutlineBadge } from '../duplicated-components/badge';
-import { ObserverComponent } from './observer';
-import { Nullable } from '@/core/types/generics/utils';
-import { IIssueType } from '@/core/types/interfaces/task/issue-type';
-import { EIssueType, ETaskStatusName, ETaskPriority, ETaskSize } from '@/core/types/generics/enums/task';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 type Props = {
 	task?: Nullable<TTask>;
@@ -495,7 +490,7 @@ function TaskCard({
 	const activeTaskEl = useRef<HTMLLIElement | null>(null);
 	const taskLabelsData = useAtomValue(taskLabelsListState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	// Refs for dropdown elements to exclude from outside click detection
 	const statusDropdownRef = useRef<HTMLDivElement>(null);

--- a/apps/web/core/components/tasks/task-progress-bar.tsx
+++ b/apps/web/core/components/tasks/task-progress-bar.tsx
@@ -1,10 +1,11 @@
-import { I_TeamMemberCardHook, useTaskStatistics } from '@/core/hooks';
-import { Nullable } from '@/core/types/generics/utils';
-import { activeTeamState, timerSecondsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
 import RadialProgress from '@/core/components/common/radial-progress';
-import { ProgressBar } from '../duplicated-components/_progress-bar';
+import { I_TeamMemberCardHook, useTaskStatistics } from '@/core/hooks';
+import { timerSecondsState } from '@/core/stores';
+import { Nullable } from '@/core/types/generics/utils';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useAtomValue } from 'jotai';
+import { ProgressBar } from '../duplicated-components/_progress-bar';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 export function TaskProgressBar({
 	isAuthUser,
@@ -24,7 +25,7 @@ export function TaskProgressBar({
 	const seconds = useAtomValue(timerSecondsState);
 	const { getEstimation } = useTaskStatistics(isAuthUser && activeAuthTask ? seconds : 0);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	//removed as when certain task's timer was active it was affecting the timers with no estimations. Was taking user's previous task's estimation
 	// const currentMember = activeTeam?.members.find(
 	// 	(member) => member.id === memberInfo?.member?.id

--- a/apps/web/core/components/tasks/task-times.tsx
+++ b/apps/web/core/components/tasks/task-times.tsx
@@ -1,18 +1,17 @@
-import { secondsToTime } from '@/core/lib/helpers/index';
-import { I_TeamMemberCardHook } from '@/core/hooks';
-import { IClassName } from '@/core/types/interfaces/common/class-name';
-import { Nullable } from '@/core/types/generics/utils';
-import { IEmployee } from '@/core/types/interfaces/organization/employee';
-import { clsxm } from '@/core/lib/utils';
 import { Text } from '@/core/components';
+import { I_TeamMemberCardHook } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { secondsToTime } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { Nullable } from '@/core/types/generics/utils';
+import { IClassName } from '@/core/types/interfaces/common/class-name';
+import { IEmployee } from '@/core/types/interfaces/organization/employee';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 import { Tooltip } from '../duplicated-components/tooltip';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
-import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
 
 type Props = {
 	task: Nullable<TTask>;
@@ -27,7 +26,7 @@ type Props = {
 export function TaskTimes({ className, task, memberInfo, showDaily = true, showTotal = true, isBlock = false }: Props) {
 	// For public page
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const currentMember = useMemo(
 		() => activeTeam?.members?.find((member) => member.id === memberInfo?.member?.id || memberInfo?.id),
 		[activeTeam?.members, memberInfo?.id, memberInfo?.member?.id]
@@ -216,7 +215,7 @@ function TimeBlockInfo({
 export function TodayWorkedTime({ className, memberInfo }: Omit<Props, 'task' | 'activeAuthTask'>) {
 	// Get current timer seconds
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const t = useTranslations();
 

--- a/apps/web/core/components/teams/member-table.tsx
+++ b/apps/web/core/components/teams/member-table.tsx
@@ -1,40 +1,43 @@
+import { Text } from '@/core/components';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/core/components/common/table';
 import { CHARACTER_LIMIT_TO_SHOW } from '@/core/constants/config/constants';
-import { imgTitle } from '@/core/lib/helpers/index';
 import { useSettings, useSyncRef } from '@/core/hooks';
 import { usePagination } from '@/core/hooks/common/use-pagination';
-import { activeTeamIdState, activeTeamState, organizationTeamsState } from '@/core/stores';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUpdateOrganizationTeam } from '@/core/hooks/organizations/teams/use-update-organization-team';
+import { imgTitle } from '@/core/lib/helpers/index';
 import { clsxm } from '@/core/lib/utils';
-import { Text } from '@/core/components';
+import { activeTeamIdState, organizationTeamsState } from '@/core/stores';
+import { ERoleName } from '@/core/types/generics/enums/role';
+import { TOrganizationTeamEmployee, TRole } from '@/core/types/schemas';
+import { useAtom, useAtomValue } from 'jotai';
 import cloneDeep from 'lodash/cloneDeep';
 import moment from 'moment';
-import { ChangeEvent, KeyboardEvent, useCallback, useRef } from 'react';
 import { useTranslations } from 'next-intl';
-import { useAtom, useAtomValue } from 'jotai';
+import { ChangeEvent, KeyboardEvent, useCallback, useRef } from 'react';
 import stc from 'string-to-color';
-import { MemberTableStatus } from './member-table-status';
-import { TableActionPopover } from '../settings/table-action-popover';
-import { EditUserRoleDropdown } from '../features/roles/edit-role-dropdown';
-import { Avatar } from '../duplicated-components/avatar';
 import { InputField } from '../duplicated-components/_input';
-import { Tooltip } from '../duplicated-components/tooltip';
 import { Paginate } from '../duplicated-components/_pagination';
-import { TOrganizationTeamEmployee, TRole } from '@/core/types/schemas';
-import { useUpdateOrganizationTeam } from '@/core/hooks/organizations/teams/use-update-organization-team';
-import { ERoleName } from '@/core/types/generics/enums/role';
-import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/core/components/common/table';
+import { Avatar } from '../duplicated-components/avatar';
+import { Tooltip } from '../duplicated-components/tooltip';
+import { EditUserRoleDropdown } from '../features/roles/edit-role-dropdown';
+import { TableActionPopover } from '../settings/table-action-popover';
+import { MemberTableStatus } from './member-table-status';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
 
 export const MemberTable = ({ members }: { members: TOrganizationTeamEmployee[] }) => {
 	const t = useTranslations();
 	const { total, onPageChange, itemsPerPage, itemOffset, endOffset, setItemsPerPage, currentItems, pageCount } =
 		usePagination<TOrganizationTeamEmployee>({ items: members, defaultItemsPerPage: 5 });
 	const { updateAvatar } = useSettings();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { updateOrganizationTeam } = useUpdateOrganizationTeam();
 
 	const activeTeamRef = useSyncRef(activeTeam);
 
 	const activeTeamId = useAtomValue(activeTeamIdState);
-	const [organizationTeams, setOrganizationTeams] = useAtom(organizationTeamsState);
+	const [, setOrganizationTeams] = useAtom(organizationTeamsState);
+	const { teams: organizationTeams } = useOrganisationTeams();
 	const editMemberRef = useRef<TOrganizationTeamEmployee | null>(null);
 
 	const updateTeamMember = useCallback(

--- a/apps/web/core/components/teams/team-avatar.tsx
+++ b/apps/web/core/components/teams/team-avatar.tsx
@@ -1,26 +1,25 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { imgTitle } from '@/core/lib/helpers/index';
-import { useAuthenticateUser } from '@/core/hooks';
-import { clsxm } from '@/core/lib/utils';
 import { Button } from '@/core/components';
+import { useAuthenticateUser } from '@/core/hooks';
+import { useImageAssets } from '@/core/hooks/common/use-image-assets';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUpdateOrganizationTeam } from '@/core/hooks/organizations/teams/use-update-organization-team';
+import { imgTitle } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
 import Image from 'next/image';
 import { readableColor } from 'polished';
 import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useTranslations } from 'next-intl';
 import stc from 'string-to-color';
-import { useImageAssets } from '@/core/hooks/common/use-image-assets';
 import { Avatar } from '../duplicated-components/avatar';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
-import { useUpdateOrganizationTeam } from '@/core/hooks/organizations/teams/use-update-organization-team';
 
 export const TeamAvatar = ({ disabled, bgColor }: { disabled: boolean; bgColor?: string | null }) => {
 	const t = useTranslations();
 	const { register } = useForm();
 	const [avatarBtn, setAvatarBtn] = useState(false);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { updateOrganizationTeam } = useUpdateOrganizationTeam();
 	const { createImageAssets } = useImageAssets();
 	const { user } = useAuthenticateUser();

--- a/apps/web/core/components/teams/teams-dropdown.tsx
+++ b/apps/web/core/components/teams/teams-dropdown.tsx
@@ -1,33 +1,40 @@
 'use client';
 
-import { useModal, useOrganizationTeams } from '@/core/hooks';
+import { Button, Dropdown } from '@/core/components';
+import { useModal } from '@/core/hooks';
+import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
 import { useProfileValidation } from '@/core/hooks/users/use-profile-validation';
 import { PlusIcon } from '@heroicons/react/24/solid';
-import { Button, Dropdown } from '@/core/components';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { AllTeamItem, TeamItem, mapTeamItems } from './team-item';
 import { useTranslations } from 'next-intl';
-import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
-import React from 'react';
-import { Tooltip } from '../duplicated-components/tooltip';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import { Tooltip } from '../duplicated-components/tooltip';
+import { AllTeamItem, TeamItem, mapTeamItems } from './team-item';
 // Import optimized components from centralized location
-import { LazyCreateTeamModal } from '@/core/components/optimized-components/teams';
-import { Suspense } from 'react';
 import { ModalSkeleton } from '@/core/components/common/skeleton/modal-skeleton';
+import { LazyCreateTeamModal } from '@/core/components/optimized-components/teams';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { activeTeamState, detailedTaskState, organizationTeamsState, timerStatusState } from '@/core/stores';
-import { useAtomValue, useAtom } from 'jotai';
-import { usePathname, useRouter } from 'next/navigation';
 import { cn } from '@/core/lib/helpers';
+import { detailedTaskState, timerStatusState } from '@/core/stores';
+import { useAtom, useAtomValue } from 'jotai';
+import { usePathname, useRouter } from 'next/navigation';
+import { Suspense } from 'react';
+import {
+	useGetOrganizationTeamQuery,
+	useGetOrganizationTeamsQuery
+} from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
+import { useSetActiveTeam } from '@/core/hooks/organizations/teams/use-set-active-team';
 
 export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 	const { data: user } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const teams = useAtomValue(organizationTeamsState);
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
 
-	const { setActiveTeam } = useOrganizationTeams();
+	const { data: teamsResult } = useGetOrganizationTeamsQuery();
+	const teams = useMemo(() => teamsResult?.data?.items ?? [], [teamsResult]);
+
+	const setActiveTeam = useSetActiveTeam();
 	const { userManagedTeams } = useOrganizationAndTeamManagers();
 	const timerStatus = useAtomValue(timerStatusState);
 	const t = useTranslations();

--- a/apps/web/core/components/timer/timer-card.tsx
+++ b/apps/web/core/components/timer/timer-card.tsx
@@ -1,19 +1,20 @@
-import { pad } from '@/core/lib/helpers/number';
-import { useStartStopTimerHandler } from '@/core/hooks/activities/use-start-stop-timer-handler';
-import { useTaskStatistics } from '@/core/hooks/tasks/use-task-statistics';
-import { useTimer } from '@/core/hooks/activities/use-timer';
 import { ProgressBar } from '@/core/components/common/progress-bar';
-import { PauseIcon } from '@/core/components/svgs/pause-icon';
-import { PlayIcon } from '@/core/components/svgs/play-icon';
 import {
 	AddTasksEstimationHoursModal,
 	EnforcePlanedTaskModal,
 	SuggestDailyPlanModal
 } from '@/core/components/daily-plan';
+import { PauseIcon } from '@/core/components/svgs/pause-icon';
+import { PlayIcon } from '@/core/components/svgs/play-icon';
+import { useStartStopTimerHandler } from '@/core/hooks/activities/use-start-stop-timer-handler';
+import { useTimer } from '@/core/hooks/activities/use-timer';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useTaskStatistics } from '@/core/hooks/tasks/use-task-statistics';
+import { pad } from '@/core/lib/helpers/number';
+import { activeTeamTaskState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
-import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState } from '@/core/stores';
 
 const Timer = () => {
 	const t = useTranslations();
@@ -31,7 +32,7 @@ const Timer = () => {
 
 	const { modals, startStopTimerHandler } = useStartStopTimerHandler();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);

--- a/apps/web/core/components/timer/timer.tsx
+++ b/apps/web/core/components/timer/timer.tsx
@@ -1,13 +1,18 @@
-import { pad } from '@/core/lib/helpers/index';
+import { Text } from '@/core/components';
 import { HostKeys, useDetectOS, useHotkeys, useTimerView } from '@/core/hooks';
 import { useTimerOptimisticUI } from '@/core/hooks/activities/use-timer-optimistic-ui';
 import { useTodayWorkedTime } from '@/core/hooks/activities/use-today-worked-time';
+import { pad } from '@/core/lib/helpers/index';
 import { clsxm } from '@/core/lib/utils';
-import { Text } from '@/core/components';
+import { Transition } from '@headlessui/react';
 import { useTranslations } from 'next-intl';
 import { TimerButton } from './timer-button';
-import { Transition } from '@headlessui/react';
 
+import { useStartStopTimerHandler } from '@/core/hooks/activities/use-start-stop-timer-handler';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { activeTeamTaskState } from '@/core/stores';
+import { ETimeLogSource } from '@/core/types/generics/enums/timer';
+import { IClassName } from '@/core/types/interfaces/common/class-name';
 import {
 	ArrowUturnUpIcon,
 	ComputerDesktopIcon,
@@ -16,16 +21,12 @@ import {
 	LifebuoyIcon
 } from '@heroicons/react/24/outline';
 import { HotkeysEvent } from 'hotkeys-js';
+import { useAtomValue } from 'jotai';
 import { useCallback, useMemo } from 'react';
 import { AddTasksEstimationHoursModal, EnforcePlanedTaskModal, SuggestDailyPlanModal } from '../daily-plan';
-import { useStartStopTimerHandler } from '@/core/hooks/activities/use-start-stop-timer-handler';
 import { ProgressBar } from '../duplicated-components/_progress-bar';
-import { Tooltip } from '../duplicated-components/tooltip';
 import { VerticalSeparator } from '../duplicated-components/separator';
-import { IClassName } from '@/core/types/interfaces/common/class-name';
-import { ETimeLogSource } from '@/core/types/generics/enums/timer';
-import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState } from '@/core/stores';
+import { Tooltip } from '../duplicated-components/tooltip';
 
 export function Timer({ className, showTimerButton = true }: IClassName) {
 	const t = useTranslations();
@@ -45,7 +46,7 @@ export function Timer({ className, showTimerButton = true }: IClassName) {
 		stopTimer
 	} = useTimerView();
 	const { modals, startStopTimerHandler } = useStartStopTimerHandler();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 
@@ -229,7 +230,7 @@ export function Timer({ className, showTimerButton = true }: IClassName) {
 export function MinTimerFrame({ className }: IClassName) {
 	const { hours, minutes, seconds, ms_p, timerStatus, disabled, hasPlan, startTimer, stopTimer } = useTimerView();
 	const { modals, startStopTimerHandler } = useStartStopTimerHandler();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 	const t = useTranslations();

--- a/apps/web/core/components/users/user-nav-menu.tsx
+++ b/apps/web/core/components/users/user-nav-menu.tsx
@@ -1,44 +1,45 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { CHARACTER_LIMIT_TO_SHOW } from '@/core/constants/config/constants';
-import { imgTitle } from '@/core/lib/helpers/index';
-import { useAuthenticateUser } from '@/core/hooks';
-import { activeTeamState, isTeamMemberState, publicState, timerStatusState } from '@/core/stores';
-import { clsxm, isValidUrl } from '@/core/lib/utils';
-import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
 import { Divider, FullWidthToggler, Text, ThemeToggler } from '@/core/components';
+import { CHARACTER_LIMIT_TO_SHOW } from '@/core/constants/config/constants';
+import { useAuthenticateUser } from '@/core/hooks';
+import { imgTitle } from '@/core/lib/helpers/index';
+import { clsxm, isValidUrl } from '@/core/lib/utils';
+import { isTeamMemberState, publicState, timerStatusState } from '@/core/stores';
+import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
 
+import Collaborate from '@/core/components/collaborate';
+import { KeyboardShortcuts } from '@/core/components/common/keyboard-shortcuts';
+import { LanguageDropDownWithFlags } from '@/core/components/common/language-dropdown-flags';
+import ThemesPopup from '@/core/components/common/themes-popup';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { signOutFunction } from '@/core/lib/helpers/social-logins';
+import { ETimerStatus } from '@/core/types/generics/enums/timer';
+import { ThemeInterface } from '@/core/types/interfaces/common/theme';
+import gauzyDark from '@/public/assets/themeImages/gauzyDark.png';
+import gauzyLight from '@/public/assets/themeImages/gauzyLight.png';
 import {
+	BriefCaseIcon,
 	DevicesIcon,
+	FullWidthIcon,
 	LogoutRoundIcon,
 	MoonLightOutlineIcon as MoonIcon,
 	PeoplesIcon,
-	BriefCaseIcon,
-	SettingOutlineIcon,
-	FullWidthIcon
+	SettingOutlineIcon
 } from 'assets/svg';
-import ThemesPopup from '@/core/components/common/themes-popup';
+import { useAtomValue } from 'jotai';
+import { ChevronDown, Globe2Icon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
 import Link from 'next/link';
-import { useMemo } from 'react';
-import { useAtomValue } from 'jotai';
-import stc from 'string-to-color';
-import gauzyDark from '@/public/assets/themeImages/gauzyDark.png';
-import gauzyLight from '@/public/assets/themeImages/gauzyLight.png';
-import { TimerStatus, getTimerStatusValue } from '../timer/timer-status';
-import Collaborate from '@/core/components/collaborate';
-import { TeamsDropDown } from '../teams/teams-dropdown';
-import { KeyboardShortcuts } from '@/core/components/common/keyboard-shortcuts';
 import { usePathname } from 'next/navigation';
-import { useTranslations } from 'next-intl';
-import { ChevronDown, Globe2Icon } from 'lucide-react';
-import { LanguageDropDownWithFlags } from '@/core/components/common/language-dropdown-flags';
-import { signOutFunction } from '@/core/lib/helpers/social-logins';
-import { Avatar } from '../duplicated-components/avatar';
+import { useMemo } from 'react';
+import stc from 'string-to-color';
 import { EverCard } from '../common/ever-card';
+import { Avatar } from '../duplicated-components/avatar';
 import { Tooltip } from '../duplicated-components/tooltip';
-import { ETimerStatus } from '@/core/types/generics/enums/timer';
-import { ThemeInterface } from '@/core/types/interfaces/common/theme';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { TeamsDropDown } from '../teams/teams-dropdown';
+import { TimerStatus, getTimerStatusValue } from '../timer/timer-status';
 
 export function UserNavAvatar() {
 	const { data: user } = useUserQuery();
@@ -46,7 +47,7 @@ export function UserNavAvatar() {
 	const name = user?.name || user?.firstName || user?.lastName || user?.username || '';
 	const timerStatus = useAtomValue(timerStatusState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const publicTeam = useAtomValue(publicState);
 	const members = activeTeam?.members || [];
 	const currentMember = members.find((m) => {
@@ -140,7 +141,7 @@ function UserNavMenu() {
 	const name = user?.name || user?.firstName || user?.lastName || user?.username;
 	const timerStatus = useAtomValue(timerStatusState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const isTeamMember = useAtomValue(isTeamMemberState);
 
 	const publicTeam = useAtomValue(publicState);

--- a/apps/web/core/components/users/user-profile-plans.tsx
+++ b/apps/web/core/components/users/user-profile-plans.tsx
@@ -1,26 +1,30 @@
 'use client';
-import { useAtomValue } from 'jotai';
 import { AlertPopup, Container } from '@/core/components';
-import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
-import { useEffect, useMemo, useState } from 'react';
-import { useCanSeeActivityScreen, useDailyPlan, useTimer, useUserProfilePage } from '@/core/hooks';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
-import { filterDailyPlan } from '@/core/hooks/daily-plans/use-filter-date-range';
-import { useLocalStorageState } from '@/core/hooks/common/use-local-storage-state';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/core/components/common/select';
+import { Button } from '@/core/components/duplicated-components/_button';
 import {
 	DAILY_PLAN_SUGGESTION_MODAL_DATE,
 	HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL,
 	HAS_VISITED_OUTSTANDING_TASKS
 } from '@/core/constants/config/constants';
-import { TUser } from '@/core/types/schemas';
-import { activeTeamState } from '@/core/stores';
-import { fullWidthState } from '@/core/stores/common/full-width';
+import { useCanSeeActivityScreen, useDailyPlan, useTimer, useUserProfilePage } from '@/core/hooks';
+import { useLocalStorageState } from '@/core/hooks/common/use-local-storage-state';
+import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
+import { filterDailyPlan } from '@/core/hooks/daily-plans/use-filter-date-range';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { clsxm } from '@/core/lib/utils';
-import { Button } from '@/core/components/duplicated-components/_button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/core/components/common/select';
+import { fullWidthState } from '@/core/stores/common/full-width';
+import { TUser } from '@/core/types/schemas';
 import { ReloadIcon, StarIcon } from '@radix-ui/react-icons';
+import { useAtomValue } from 'jotai';
+import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
+import { useEffect, useMemo, useState } from 'react';
 
+import { AllPlans, EmptyPlans } from '@/core/components/daily-plan';
+import { IconsCalendarMonthOutline } from '@/core/components/icons';
+import moment from 'moment';
+import { usePathname } from 'next/navigation';
+import { VerticalSeparator } from '../duplicated-components/separator';
 import {
 	estimatedTotalTime,
 	getTotalTasks,
@@ -31,11 +35,7 @@ import {
 } from '../tasks/daily-plan';
 import { FutureTasks } from '../tasks/daily-plan/future-tasks';
 import ViewsHeaderTabs from '../tasks/daily-plan/views-header-tabs';
-import moment from 'moment';
-import { usePathname } from 'next/navigation';
-import { IconsCalendarMonthOutline } from '@/core/components/icons';
-import { VerticalSeparator } from '../duplicated-components/separator';
-import { AllPlans, EmptyPlans } from '@/core/components/daily-plan';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 export type FilterTabs = 'Today Tasks' | 'Future Tasks' | 'Past Tasks' | 'All Tasks' | 'Outstanding';
 type FilterOutstanding = 'ALL' | 'DATE';
@@ -88,7 +88,9 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 
 	const screenOutstanding = {
 		ALL: <OutstandingAll profile={profile} user={user} outstandingPlans={outstandingPlans} />,
-		DATE: <OutstandingFilterDate profile={profile} user={user} outstandingPlans={outstandingPlans} filterByEmployee/>
+		DATE: (
+			<OutstandingFilterDate profile={profile} user={user} outstandingPlans={outstandingPlans} filterByEmployee />
+		)
 	};
 	const tabsScreens = {
 		'Today Tasks': <AllPlans profile={profile} currentTab={currentTab} user={user} employeeId={targetEmployeeId} />,
@@ -102,7 +104,7 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 	const haveSeenDailyPlanSuggestionModal = window?.localStorage.getItem(HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL);
 	const { hasPlan } = useTimer();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 	const [popupOpen, setPopupOpen] = useState(false);
 	const canSeeActivity = useCanSeeActivityScreen();
@@ -160,7 +162,9 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 				outstandingPlans.map((plan) => {
 					const tasks = plan.tasks ?? [];
 					// Filter by user if user exists (privacy/security - same as OutstandingAll)
-					return user ? tasks.filter((task) => task.members?.some((member) => member.userId === user.id)) : tasks;
+					return user
+						? tasks.filter((task) => task.members?.some((member) => member.userId === user.id))
+						: tasks;
 				})
 			).totalTasks
 		};

--- a/apps/web/core/hooks/activities/use-start-stop-timer-handler.ts
+++ b/apps/web/core/hooks/activities/use-start-stop-timer-handler.ts
@@ -1,14 +1,15 @@
+import { estimatedTotalTime } from '@/core/components/tasks/daily-plan';
+import {
+	DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE,
+	DAILY_PLAN_SUGGESTION_MODAL_DATE,
+	TASKS_ESTIMATE_HOURS_MODAL_DATE
+} from '@/core/constants/config/constants';
+import { activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
 import { useCallback, useMemo } from 'react';
 import { useModal } from '../common/use-modal';
-import {
-	DAILY_PLAN_SUGGESTION_MODAL_DATE,
-	TASKS_ESTIMATE_HOURS_MODAL_DATE,
-	DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE
-} from '@/core/constants/config/constants';
-import { estimatedTotalTime } from '@/core/components/tasks/daily-plan';
 import { useTimer } from './use-timer';
-import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export function useStartStopTimerHandler() {
 	const {
@@ -39,7 +40,7 @@ export function useStartStopTimerHandler() {
 	const { timerStatusFetching, startTimer, stopTimer, hasPlan, canRunTimer } = useTimer();
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 

--- a/apps/web/core/hooks/activities/use-today-worked-time.ts
+++ b/apps/web/core/hooks/activities/use-today-worked-time.ts
@@ -1,8 +1,7 @@
-import { useMemo } from 'react';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
 import { secondsToTime } from '@/core/lib/helpers/date-and-time';
 import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { useMemo } from 'react';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
 
 /**
@@ -22,7 +21,7 @@ import { useUserQuery } from '../queries/user-user.query';
  * @returns Object with hours, minutes, seconds, and total seconds worked today
  */
 export function useTodayWorkedTime(memberInfo?: { member?: { id?: string }; id?: string }) {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 
 	// Find the current member in the active team

--- a/apps/web/core/hooks/common/use-collaborative.ts
+++ b/apps/web/core/hooks/common/use-collaborative.ts
@@ -1,17 +1,18 @@
-import { activeTeamState, collaborativeMembersState, collaborativeSelectState } from '@/core/stores';
-import { useCallback } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
 import { BOARD_APP_DOMAIN } from '@/core/constants/config/constants';
-import { useRouter } from 'next/navigation';
-import { nanoid } from 'nanoid';
-import capitalize from 'lodash/capitalize';
+import { collaborativeMembersState, collaborativeSelectState } from '@/core/stores';
 import { TUser } from '@/core/types/schemas';
+import { useAtom } from 'jotai';
+import capitalize from 'lodash/capitalize';
+import { nanoid } from 'nanoid';
+import { useRouter } from 'next/navigation';
+import { useCallback } from 'react';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
 
 export function useCollaborative(user?: TUser) {
 	const meetType = process.env.NEXT_PUBLIC_MEET_TYPE || 'Jitsi';
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { data: authUser } = useUserQuery();
 	const [collaborativeSelect, setCollaborativeSelect] = useAtom(collaborativeSelectState);
 	const [collaborativeMembers, setCollaborativeMembers] = useAtom(collaborativeMembersState);

--- a/apps/web/core/hooks/daily-plans/use-daily-plan.ts
+++ b/apps/web/core/hooks/daily-plans/use-daily-plan.ts
@@ -1,17 +1,12 @@
 'use client';
 
-import { useAtom, useAtomValue } from 'jotai';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { activeTeamState, dailyPlanListState, tasksByTeamState } from '@/core/stores';
+import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { queryKeys } from '@/core/query/keys';
+import { dailyPlanListState, tasksByTeamState } from '@/core/stores';
 import {
 	IDailyPlanTasksUpdate,
 	IRemoveTaskFromManyPlansRequest
 } from '@/core/types/interfaces/task/daily-plan/daily-plan';
-import { useFirstLoad } from '../common/use-first-load';
-import { dailyPlanService, taskService } from '../../services/client/api';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '@/core/query/keys';
-import { TTask } from '@/core/types/schemas/task/task.schema';
 import {
 	TCreateDailyPlan,
 	TDailyPlan,
@@ -19,10 +14,16 @@ import {
 	TRemoveTaskFromPlansRequest,
 	TUpdateDailyPlan
 } from '@/core/types/schemas/task/daily-plan.schema';
-import { useConditionalUpdateEffect, useQueryCall } from '../common';
-import { useUserQuery } from '../queries/user-user.query';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { dailyPlanService, taskService } from '../../services/client/api';
+import { useConditionalUpdateEffect, useQueryCall } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useUserQuery } from '../queries/user-user.query';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export type FilterTabs = 'Today Tasks' | 'Future Tasks' | 'Past Tasks' | 'All Tasks' | 'Outstanding';
 
@@ -48,7 +49,7 @@ export interface UseDailyPlanOptions {
  */
 export function useDailyPlan(defaultEmployeeId: string | null = null, options?: UseDailyPlanOptions) {
 	const { data: user } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const targetEmployeeId = defaultEmployeeId || user?.employee?.id;
 	const [employeeId, setEmployeeId] = useState(targetEmployeeId || '');
 	const queryClient = useQueryClient();

--- a/apps/web/core/hooks/organizations/teams/use-active-team-managers.ts
+++ b/apps/web/core/hooks/organizations/teams/use-active-team-managers.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useCurrentTeam } from './use-current-team';
+import { ERoleName } from '@/core/types/generics/enums/role';
+
+// const { managers: activeTeamManagers } = useActiveTeamManagers();
+export const useActiveTeamManagers = () => {
+	const activeTeam = useCurrentTeam();
+
+	const managers = useMemo(() => {
+		const members = activeTeam?.members;
+		return (
+			members?.filter(
+				(member) =>
+					member?.role?.name === ERoleName.MANAGER ||
+					member?.role?.name === ERoleName.SUPER_ADMIN ||
+					member?.role?.name === ERoleName.ADMIN
+			) || []
+		);
+	}, [activeTeam]);
+
+	return { managers };
+};

--- a/apps/web/core/hooks/organizations/teams/use-active-team.ts
+++ b/apps/web/core/hooks/organizations/teams/use-active-team.ts
@@ -1,17 +1,18 @@
 'use client';
 
-import { useCallback } from 'react';
 import { TeamItem } from '@/core/components/teams/team-item';
 import { useTranslations } from 'next-intl';
-import { useOrganizationTeams } from './use-organization-teams';
-import { useTimer } from '../../activities';
+import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { useTimer } from '../../activities';
+import { useSetActiveTeam } from './use-set-active-team';
+import { useGetOrganizationTeamQuery } from './use-get-organization-teams-query';
 
 export const useActiveTeam = () => {
-	const activeTeam = useAtomValue(activeTeamState);
-	const { setActiveTeam } = useOrganizationTeams();
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
+
+	const setActiveTeam = useSetActiveTeam();
 	const { timerStatus, stopTimer } = useTimer();
 	const t = useTranslations();
 	const onChangeActiveTeam = useCallback(

--- a/apps/web/core/hooks/organizations/teams/use-auth-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-auth-team-tasks.ts
@@ -1,17 +1,18 @@
-import { useDailyPlan } from '@/core/hooks';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
-import { useMemo } from 'react';
-import { useAtomValue } from 'jotai';
 import { getTotalTasks } from '@/core/components/tasks/daily-plan';
+import { useDailyPlan } from '@/core/hooks';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { tasksByTeamState } from '@/core/stores';
 import { TUser } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useAtomValue } from 'jotai';
+import { useMemo } from 'react';
+import { useCurrentTeam } from './use-current-team';
 
 export function useAuthTeamTasks(user: TUser | undefined) {
 	const tasks = useAtomValue(tasksByTeamState);
 	const { data: authenticatedUser } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	// Use provided user or fallback to authenticated user
 	const targetUser = user || authenticatedUser;
 	const currentMember = activeTeam?.members?.find((member) => member.employee?.userId === targetUser?.id);

--- a/apps/web/core/hooks/organizations/teams/use-current-team.ts
+++ b/apps/web/core/hooks/organizations/teams/use-current-team.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useGetOrganizationTeamQuery } from './use-get-organization-teams-query';
+
+export const useCurrentTeam = () => {
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
+
+	return activeTeam;
+};

--- a/apps/web/core/hooks/organizations/teams/use-delete-organization-team-mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-delete-organization-team-mutation.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamService } from '@/core/services/client/api/organizations/teams';
+import { ZodValidationError } from '@/core/types/schemas/utils/validation';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+import { useAuthenticateUser } from '../../auth';
+
+export const useDeleteOrganizationTeamMutation = () => {
+	const queryClient = useQueryClient();
+
+	const { logOut } = useAuthenticateUser();
+
+	const deleteOrganizationTeamTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+	const clearDeleteTimeout = useCallback(() => {
+		if (deleteOrganizationTeamTimeoutRef.current) {
+			clearTimeout(deleteOrganizationTeamTimeoutRef.current);
+			deleteOrganizationTeamTimeoutRef.current = null;
+		}
+	}, []);
+
+	useEffect(() => {
+		return () => clearDeleteTimeout();
+	}, [clearDeleteTimeout]);
+
+	return useMutation({
+		mutationFn: (id: string) => {
+			return organizationTeamService.deleteOrganizationTeam(id);
+		},
+		mutationKey: queryKeys.organizationTeams.mutations.delete(null),
+		onSuccess: async (response) => {
+			// Preserve critical side-effect - loadTeamsData() for complete refetch
+			toast.success('Team deleted successfully', {
+				description: `Team "${response.data.name}" has been deleted. You will be logged out of the application to choose a new workspace.`
+			});
+
+			// Clear previous timeout if any
+			clearDeleteTimeout();
+
+			// Set a new timeout
+			deleteOrganizationTeamTimeoutRef.current = setTimeout(() => {
+				logOut();
+
+				queryClient.invalidateQueries({
+					queryKey: queryKeys.organizationTeams.all
+				});
+
+				// Clear ref after execution
+				deleteOrganizationTeamTimeoutRef.current = null;
+			}, 3000);
+		},
+		onError: (error) => {
+			// Enhanced error handling
+			if (error instanceof ZodValidationError) {
+				toast.error('Delete team validation failed', {
+					description: JSON.stringify({
+						message: error.message,
+						issues: error.issues
+					})
+				});
+				console.error('Delete team validation failed:', {
+					message: error.message,
+					issues: error.issues
+				});
+				return;
+			}
+			toast.error('Delete team validation failed');
+			// Original error will be thrown and handled by calling code
+		}
+	});
+};

--- a/apps/web/core/hooks/organizations/teams/use-edit-organization-team-mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-edit-organization-team-mutation.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamService } from '@/core/services/client/api/organizations/teams';
+import { organizationTeamsState } from '@/core/stores';
+import { TOrganizationTeamUpdate } from '@/core/types/schemas';
+import { ZodValidationError } from '@/core/types/schemas/utils/validation';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+import { toast } from 'sonner';
+import { useGetOrganizationTeamById } from './use-get-organization-teams-query';
+
+export const useEditOrganizationTeamMutation = () => {
+	const queryClient = useQueryClient();
+	const setTeams = useSetAtom(organizationTeamsState);
+
+	const getTeamById = useGetOrganizationTeamById();
+
+	return useMutation({
+		mutationFn: (data: Partial<TOrganizationTeamUpdate>) => {
+			return organizationTeamService.editOrganizationTeam(data);
+		},
+		mutationKey: queryKeys.organizationTeams.mutations.edit(null),
+		onSuccess: async (response) => {
+			const { data: teamUpdated } = await getTeamById(response.data.id);
+			setTeams((currentTeams) => {
+				return (currentTeams ?? []).map((old) => (old.id == teamUpdated.id ? teamUpdated : old));
+			});
+
+			// Invalidate queries for cache consistency
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.organizationTeams.all
+			});
+		},
+		onError: (error) => {
+			// Enhanced error handling
+			if (error instanceof ZodValidationError) {
+				toast.error('Edit team validation failed:', {
+					description: JSON.stringify({
+						message: error.message,
+						issues: error.issues
+					})
+				});
+				console.error('Edit team validation failed:', {
+					message: error.message,
+					issues: error.issues
+				});
+				return;
+			}
+			toast.error('Edit team validation failed');
+			// Original error will be thrown and handled by calling code
+		}
+	});
+};

--- a/apps/web/core/hooks/organizations/teams/use-get-organization-teams-query.ts
+++ b/apps/web/core/hooks/organizations/teams/use-get-organization-teams-query.ts
@@ -1,0 +1,144 @@
+'use client';
+import { setActiveProjectIdCookie } from '@/core/lib/helpers/cookies';
+
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamService } from '@/core/services/client/api/organizations/teams';
+import {
+	activeTeamIdState,
+	isTeamMemberJustDeletedState,
+	isTeamMemberState,
+	organizationTeamsState
+} from '@/core/stores';
+import { TOrganizationTeam } from '@/core/types/schemas';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useEffect } from 'react';
+
+const buildTeamListSignature = (teams: TOrganizationTeam[]) => {
+	// CRITICAL FIX: Create a signature based on ALL mutable fields
+	// This ensures we detect changes in team properties even when members are undefined
+	// Includes: id, updatedAt, name, settings (shareProfileView, requirePlanToTrack, public),
+	// visual properties (color, emoji, prefix), members count, AND member roles
+	// NOTE: Including member roles is essential to detect when roles are loaded/changed
+	return teams
+		.map((t) => {
+			// Include member role information to detect role changes
+			const memberRolesSignature = t.members?.map((m) => `${m.id}:${m.role?.name ?? 'none'}`).join(',') || '';
+			return `${t.id}:${t.updatedAt ?? ''}:${t.name}:${t.shareProfileView ?? ''}:${t.requirePlanToTrack ?? ''}:${t.public ?? ''}:${t.color ?? ''}:${t.emoji ?? ''}:${t.prefix ?? ''}:${t.members?.length ?? 0}:${memberRolesSignature}`;
+		})
+		.sort()
+		.join('|');
+};
+
+export const useGetOrganizationTeamsQuery = () => {
+	const { data: user } = useUserQuery();
+
+	const setTeams = useSetAtom(organizationTeamsState);
+	const setIsTeamMemberJustDeleted = useSetAtom(isTeamMemberJustDeletedState);
+	const setIsTeamMember = useSetAtom(isTeamMemberState);
+
+	const teamsQuery = useQuery({
+		queryKey: queryKeys.organizationTeams.all,
+		queryFn: async () => {
+			return await organizationTeamService.getOrganizationTeams();
+		},
+		enabled: !!(user?.employee?.organizationId && user?.employee?.tenantId),
+		staleTime: 1000 * 60 * 10, // PERFORMANCE FIX: Increased to 10 minutes to reduce refetching
+		gcTime: 1000 * 60 * 30, // PERFORMANCE FIX: Increased to 30 minutes
+		refetchOnWindowFocus: false, // PERFORMANCE FIX: Disable aggressive refetching
+		refetchOnReconnect: false // PERFORMANCE FIX: Disable aggressive refetching
+	});
+
+	// ===== SYNCHRONIZATION WITH JOTAI (Backward Compatibility) =====
+	// Sync organization teams data with Jotai state
+	useEffect(() => {
+		if (teamsQuery.data?.data?.items) {
+			setTeams((currentTeams) => {
+				const currentSignature = buildTeamListSignature(currentTeams);
+				const updatedSignature = buildTeamListSignature(teamsQuery.data.data.items);
+
+				return currentSignature == updatedSignature ? currentTeams : teamsQuery.data.data.items;
+			});
+
+			// Handle case where user might be removed from all teams
+			if (teamsQuery.data?.data?.items.length === 0) {
+				setIsTeamMember(false);
+				setIsTeamMemberJustDeleted(true);
+			}
+		}
+		// NOTE: Do NOT include teamsQuery.data in dependencies
+		// It causes infinite loops because React Query returns new references
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [teamsQuery.dataUpdatedAt, setTeams, setIsTeamMemberJustDeleted, setIsTeamMember]);
+
+	return teamsQuery;
+};
+
+export const useGetOrganizationTeamQuery = () => {
+	const { data: user } = useUserQuery();
+
+	const activeTeamId = useAtomValue(activeTeamIdState);
+	const setTeams = useSetAtom(organizationTeamsState);
+
+	const teamQuery = useQuery({
+		queryKey: queryKeys.organizationTeams.detail(activeTeamId),
+		queryFn: async () => {
+			if (!activeTeamId) {
+				throw new Error('Team ID is required');
+			}
+			return await organizationTeamService.getOrganizationTeam(activeTeamId);
+		},
+		enabled: !!(activeTeamId && user?.employee?.organizationId && user?.employee?.tenantId),
+		staleTime: 1000 * 60 * 10, // PERFORMANCE FIX: Increased to 10 minutes
+		gcTime: 1000 * 60 * 30, // PERFORMANCE FIX: Increased to 30 minutes
+		refetchOnWindowFocus: false, // PERFORMANCE FIX: Disable aggressive refetching
+		refetchOnReconnect: false // PERFORMANCE FIX: Disable aggressive refetching
+	});
+
+	// ===== SYNCHRONIZATION WITH JOTAI (Backward Compatibility) =====
+	// Sync specific team data with Jotai state
+	useEffect(() => {
+		if (teamQuery.data?.data) {
+			setTeams((currentTeams) => {
+				const targetedTeam = currentTeams.find((team) => team?.id == teamQuery.data.data?.id);
+				if (!targetedTeam) return [...currentTeams, teamQuery.data?.data];
+
+				const currentSignature = buildTeamListSignature([targetedTeam]);
+				const updatedSignature = buildTeamListSignature([teamQuery.data.data]);
+
+				const updatedTeamList =
+					currentSignature == updatedSignature
+						? currentTeams
+						: currentTeams.map((team) => (team.id == targetedTeam.id ? teamQuery.data.data : team));
+
+				return updatedTeamList;
+			});
+
+			// Set Project Id to cookie
+			if (teamQuery.data?.data?.projects?.length) {
+				setActiveProjectIdCookie(teamQuery.data.data.projects[0].id);
+			}
+		}
+		// NOTE: Do NOT include organizationTeamQuery.data in dependencies
+		// It causes infinite loops because React Query returns new references
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [teamQuery.dataUpdatedAt]);
+
+	return teamQuery;
+};
+
+export const useGetOrganizationTeamById = () => {
+	const queryClient = useQueryClient();
+
+	const query = async (teamId: string) => {
+		return queryClient.fetchQuery({
+			queryKey: queryKeys.organizationTeams.detail(teamId),
+			queryFn: () => organizationTeamService.getOrganizationTeam(teamId),
+			staleTime: 1000 * 60 * 1,
+			gcTime: 1000 * 60 * 30 // PERFORMANCE FIX: Increased to 30 minutes
+		});
+	};
+
+	return query;
+};

--- a/apps/web/core/hooks/organizations/teams/use-is-team-manager.ts
+++ b/apps/web/core/hooks/organizations/teams/use-is-team-manager.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useMemo } from 'react';
+import { useGetOrganizationTeamQuery } from './use-get-organization-teams-query';
+
+export const useIsTeamManager = () => {
+	const { data: user } = useUserQuery();
+	const { data: activeTeam } = useGetOrganizationTeamQuery();
+
+	const isTeamManager = useMemo(() => {
+		const members = activeTeam?.data?.members || [];
+		return members.some((member) => {
+			const $u = user;
+			const isUser = member.employee?.userId === $u?.id;
+			return isUser && member.role && member.role.name === 'MANAGER';
+		});
+	}, [user, activeTeam?.data?.members]);
+
+	return isTeamManager;
+};

--- a/apps/web/core/hooks/organizations/teams/use-load-teams-data.ts
+++ b/apps/web/core/hooks/organizations/teams/use-load-teams-data.ts
@@ -1,0 +1,97 @@
+'use client';
+import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
+
+import { LAST_WORKSPACE_AND_TEAM } from '@/core/constants/config/constants';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamService } from '@/core/services/client/api/organizations/teams';
+import { activeTeamIdState, isTeamMemberJustDeletedState, isTeamMemberState } from '@/core/stores';
+import { useQueryClient } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+import { useCallback } from 'react';
+import { useSetActiveTeam } from './use-set-active-team';
+
+export const useLoadTeamsData = () => {
+	const { data: user } = useUserQuery();
+	const setActiveTeamId = useSetAtom(activeTeamIdState);
+	const setIsTeamMemberJustDeleted = useSetAtom(isTeamMemberJustDeletedState);
+	const setIsTeamMember = useSetAtom(isTeamMemberState);
+	const setActiveTeam = useSetActiveTeam();
+
+	const queryClient = useQueryClient();
+
+	const loadTeamsData = useCallback(async () => {
+		if (!user?.employee?.organizationId || !user?.employee?.tenantId) {
+			return;
+		}
+
+		// TEAM SELECTION PRIORITY LOGIC
+		// 1. Try cookie first (current session)
+		let teamId = getActiveTeamIdCookie();
+
+		// 2. Fallback to localStorage (user's last selected team)
+		if (!teamId && typeof window !== 'undefined') {
+			teamId = window.localStorage.getItem(LAST_WORKSPACE_AND_TEAM) || '';
+		}
+
+		// 3. Fallback to user's last team from server
+		if (!teamId && user?.lastTeamId) {
+			teamId = user.lastTeamId;
+		}
+
+		setActiveTeamId(teamId);
+
+		try {
+			// Trigger React Query refetch for teams
+			const teamsResult = await queryClient.fetchQuery({
+				queryKey: queryKeys.organizationTeams.all,
+				queryFn: async () => {
+					return await organizationTeamService.getOrganizationTeams();
+				}
+			});
+
+			const latestTeams = teamsResult.data?.items || [];
+
+			if (latestTeams.length === 0) {
+				setIsTeamMember(false);
+				setIsTeamMemberJustDeleted(true);
+			}
+
+			// Handle case where user might be removed from selected team
+			const selectedTeamExists = latestTeams.find((team: any) => team.id === teamId);
+
+			if (!selectedTeamExists && teamId && latestTeams.length) {
+				setIsTeamMemberJustDeleted(true);
+				// Only fallback to first team if the selected team truly doesn't exist
+				setActiveTeam(latestTeams[0]);
+			} else if (!latestTeams.length) {
+				teamId = '';
+			}
+
+			// Fetch specific team details if teamId exists
+			if (teamId) {
+				await queryClient.fetchQuery({
+					queryKey: queryKeys.organizationTeams.detail(teamId),
+					queryFn: async () => {
+						return await organizationTeamService.getOrganizationTeam(teamId);
+					}
+				});
+			}
+
+			return teamsResult;
+		} catch (error) {
+			console.error('Error loading teams data:', error);
+			throw error;
+		}
+	}, [
+		queryClient,
+		user?.employee?.organizationId,
+		user?.employee?.tenantId,
+		setActiveTeamId,
+		setIsTeamMember,
+		setIsTeamMemberJustDeleted,
+		setActiveTeam
+	]);
+
+	return loadTeamsData;
+};

--- a/apps/web/core/hooks/organizations/teams/use-organisation-teams.ts
+++ b/apps/web/core/hooks/organizations/teams/use-organisation-teams.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react';
+import { useGetOrganizationTeamsQuery } from './use-get-organization-teams-query';
+
+// const { teams } = useOrganisationTeams();
+export const useOrganisationTeams = () => {
+	const { data: teamsResult } = useGetOrganizationTeamsQuery();
+	const teams = useMemo(() => teamsResult?.data?.items ?? [], [teamsResult]);
+
+	return { teams };
+};

--- a/apps/web/core/hooks/organizations/teams/use-organization-teams-employee.ts
+++ b/apps/web/core/hooks/organizations/teams/use-organization-teams-employee.ts
@@ -1,14 +1,14 @@
-import { useCallback } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useOrganizationTeams } from './use-organization-teams';
-import { organizationTeamEmployeeService } from '@/core/services/client/api/organizations/teams';
-import { queryKeys } from '@/core/query/keys';
-import { toast } from 'sonner';
-import { TOrganizationTeamEmployee, TOrganizationTeamEmployeeUpdate } from '@/core/types/schemas';
 import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamEmployeeService } from '@/core/services/client/api/organizations/teams';
+import { TOrganizationTeamEmployee, TOrganizationTeamEmployeeUpdate } from '@/core/types/schemas';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useLoadTeamsData } from './use-load-teams-data';
 
 export function useOrganizationEmployeeTeams() {
-	const { loadTeamsData } = useOrganizationTeams();
+	const loadTeamsData = useLoadTeamsData();
 	const queryClient = useQueryClient();
 
 	// React Query mutation for delete organization employee team

--- a/apps/web/core/hooks/organizations/teams/use-organization-teams-managers.ts
+++ b/apps/web/core/hooks/organizations/teams/use-organization-teams-managers.ts
@@ -1,8 +1,8 @@
-import { useAtomValue } from 'jotai';
 import { filterValue } from '@/core/stores/teams/all-teams';
+import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
-import { useOrganizationTeams } from './use-organization-teams';
 import { useAuthenticateUser } from '../../auth';
+import { useGetOrganizationTeamsQuery } from './use-get-organization-teams-query';
 /**
  * Provides a hook that returns the teams managed by the authenticated user, along with the ability to filter those teams based on the timer status of their members.
  *
@@ -12,7 +12,10 @@ import { useAuthenticateUser } from '../../auth';
  */
 export function useOrganizationAndTeamManagers() {
 	const { user } = useAuthenticateUser();
-	const { teams } = useOrganizationTeams();
+
+	const { data: teamsResult } = useGetOrganizationTeamsQuery();
+	const teams = useMemo(() => teamsResult?.data?.items ?? [], [teamsResult]);
+
 	const { value: filtered } = useAtomValue(filterValue);
 
 	/**

--- a/apps/web/core/hooks/organizations/teams/use-public-organization-teams.ts
+++ b/apps/web/core/hooks/organizations/teams/use-public-organization-teams.ts
@@ -1,27 +1,29 @@
+import { queryKeys } from '@/core/query/keys';
+import { publicOrganizationTeamService } from '@/core/services/client/api/organizations';
 import {
+	organizationTeamsState,
 	publicActiveTeamState,
-	activeTeamState,
 	taskLabelsListState,
 	taskPrioritiesListState,
 	taskSizesListState,
 	taskStatusesState,
-	teamTasksState,
-	organizationTeamsState
+	teamTasksState
 } from '@/core/stores';
-import isEqual from 'lodash/isEqual';
-import cloneDeep from 'lodash/cloneDeep';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useOrganizationTeams } from './use-organization-teams';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '@/core/query/keys';
-import { publicOrganizationTeamService } from '@/core/services/client/api/organizations';
+import { useAtom, useSetAtom } from 'jotai';
+import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCurrentTeam } from './use-current-team';
+import { useOrganisationTeams } from './use-organisation-teams';
+import { useGetOrganizationTeamsQuery } from './use-get-organization-teams-query';
 
 export function usePublicOrganizationTeams() {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
-	const [teams, setTeams] = useAtom(organizationTeamsState);
-	const { getOrganizationTeamsLoading } = useOrganizationTeams();
+	const [, setTeams] = useAtom(organizationTeamsState);
+	const { teams } = useOrganisationTeams();
+	const { isPending: getOrganizationTeamsLoading } = useGetOrganizationTeamsQuery();
 	const setAllTasks = useSetAtom(teamTasksState);
 	const setTaskStatuses = useSetAtom(taskStatusesState);
 	const setTaskSizes = useSetAtom(taskSizesListState);

--- a/apps/web/core/hooks/organizations/teams/use-remove-user-from-all-team-mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-remove-user-from-all-team-mutation.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamService } from '@/core/services/client/api/organizations/teams';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useAuthenticateUser } from '../../auth';
+import { useLoadTeamsData } from './use-load-teams-data';
+
+export const useRemoveUserFromAllTeamMutation = () => {
+	const queryClient = useQueryClient();
+	const { refreshUserData, refreshToken } = useAuthenticateUser();
+
+	const loadTeamsData = useLoadTeamsData();
+
+	return useMutation({
+		mutationFn: (userId: string) => {
+			return organizationTeamService.removeUserFromAllTeams(userId);
+		},
+		mutationKey: queryKeys.organizationTeams.mutations.removeUser(null),
+		onSuccess: async (response) => {
+			// Service returns simple DeleteResponse, no complex validation needed
+			// Just ensure response exists
+
+			// Preserve ALL critical side-effects in exact order
+			// 1. First: Reload teams data
+			await loadTeamsData();
+
+			// 2. Then: Critical auth refresh sequence
+			try {
+				await refreshToken();
+				// 3. Finally: Update user data from API
+				refreshUserData();
+			} catch (error) {
+				toast.error('Failed to refresh token after removing user from team');
+				console.error('Failed to refresh token after removing user from team:', error);
+			}
+
+			// Invalidate queries for cache consistency
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.organizationTeams.all
+			});
+		},
+		onError: (error) => {
+			// Enhanced error handling
+			toast.error('Remove user from all teams failed', {
+				description: error.message
+			});
+			console.error('Remove user from all teams failed:', error);
+			// Original error will be thrown and handled by calling code
+		}
+	});
+};

--- a/apps/web/core/hooks/organizations/teams/use-set-active-team.ts
+++ b/apps/web/core/hooks/organizations/teams/use-set-active-team.ts
@@ -1,0 +1,41 @@
+'use client';
+import { setActiveProjectIdCookie, setActiveTeamIdCookie, setOrganizationIdCookie } from '@/core/lib/helpers/cookies';
+
+import { LAST_WORKSPACE_AND_TEAM } from '@/core/constants/config/constants';
+import { activeTeamIdState } from '@/core/stores';
+import { TOrganizationTeam } from '@/core/types/schemas';
+import { useSetAtom } from 'jotai';
+import { useCallback } from 'react';
+import { useAuthenticateUser } from '../../auth';
+import { useSettings } from '../../users';
+
+export const useSetActiveTeam = () => {
+	const { user } = useAuthenticateUser();
+	const setActiveTeamId = useSetAtom(activeTeamIdState);
+	const { updateAvatar: updateUserLastTeam } = useSettings();
+
+	const setActiveTeam = useCallback(
+		(team: TOrganizationTeam) => {
+			setActiveTeamIdCookie(team?.id);
+			setOrganizationIdCookie(team?.organizationId || '');
+
+			// Set Project Id to cookie
+			// TODO: Make it dynamic when we add Dropdown in Navbar
+			if (team && team?.projects && team.projects.length) {
+				setActiveProjectIdCookie(team.projects[0].id);
+			}
+			window && window?.localStorage.setItem(LAST_WORKSPACE_AND_TEAM, team.id);
+			// Only update user last team if it's different to avoid unnecessary API calls
+			if (user && user.lastTeamId !== team.id) {
+				updateUserLastTeam({ id: user.id, lastTeamId: team.id });
+			}
+
+			// Set active team ID AFTER teams are updated to ensure proper synchronization
+			// This must be called at the end (Update store)
+			setActiveTeamId(team?.id);
+		},
+		[setActiveTeamId, updateUserLastTeam, user]
+	);
+
+	return setActiveTeam;
+};

--- a/apps/web/core/hooks/organizations/teams/use-team-invitations.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-invitations.ts
@@ -1,27 +1,23 @@
 'use client';
 
-import {
-	fetchingTeamInvitationsState,
-	getTeamInvitationsState,
-	myInvitationsState,
-	teamInvitationsState
-} from '@/core/stores';
+import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
+import { queryKeys } from '@/core/query/keys';
+import { fetchingTeamInvitationsState, myInvitationsState, teamInvitationsState } from '@/core/stores';
+import { EInviteAction } from '@/core/types/generics/enums/invite';
+import { IInviteVerifyCode, InviteUserParams, TeamInvitationsQueryParams } from '@/core/types/interfaces/user/invite';
+import { TAcceptInvitationRequest, TValidateInviteRequest } from '@/core/types/schemas/user/invite.schema';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useSetAtom } from 'jotai';
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo } from 'react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../../common/use-first-load';
+import { toast } from 'sonner';
 import { inviteService } from '../../../services/client/api/organizations/teams/invites';
 import { useAuthenticateUser } from '../../auth';
-import { EInviteAction } from '@/core/types/generics/enums/invite';
-import { toast } from 'sonner';
-import { queryKeys } from '@/core/query/keys';
-import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
-import { IInviteVerifyCode, InviteUserParams, TeamInvitationsQueryParams } from '@/core/types/interfaces/user/invite';
 import { useQueryCall } from '../../common';
-import { TAcceptInvitationRequest, TValidateInviteRequest } from '@/core/types/schemas/user/invite.schema';
-import { useIsMemberManager } from './use-team-member';
+import { useFirstLoad } from '../../common/use-first-load';
 import { useUserQuery } from '../../queries/user-user.query';
-import { useRouter } from 'next/navigation';
+import { useIsMemberManager } from './use-team-member';
+import { useTeamMemberInvitation } from './use-team-member-invitations';
 
 export function useTeamInvitations() {
 	const queryClient = useQueryClient();
@@ -29,7 +25,7 @@ export function useTeamInvitations() {
 
 	const setTeamInvitations = useSetAtom(teamInvitationsState);
 	const [myInvitationsList, setMyInvitationsList] = useAtom(myInvitationsState);
-	const teamInvitations = useAtomValue(getTeamInvitationsState);
+	const teamInvitations = useTeamMemberInvitation();
 	const [fetchingInvitations, setFetchingInvitations] = useAtom(fetchingTeamInvitationsState);
 
 	const activeTeamId = getActiveTeamIdCookie();

--- a/apps/web/core/hooks/organizations/teams/use-team-member-card.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-member-card.ts
@@ -1,10 +1,9 @@
 'use client';
-import { activeTeamState, activeTeamTaskState, allTaskStatisticsState } from '@/core/stores';
+import { activeTeamTaskState, allTaskStatisticsState } from '@/core/stores';
 import { getPublicState } from '@/core/stores/common/public';
 import { useCallback, useMemo, useState } from 'react';
 import { useAtomValue } from 'jotai';
 import { useSyncRef } from '../../common/use-sync-ref';
-import { useOrganizationTeams } from './use-organization-teams';
 import { useIsMemberManager } from './use-team-member';
 import cloneDeep from 'lodash/cloneDeep';
 import { useTeamTasks } from './use-team-tasks';
@@ -14,6 +13,8 @@ import { Nullable } from '@/core/types/generics/utils';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { ERoleName } from '@/core/types/generics/enums/role';
+import { useUpdateOrganizationTeam } from './use-update-organization-team';
+import { useGetOrganizationTeamQuery } from './use-get-organization-teams-query';
 
 /**
  * It returns a bunch of data about a team member, including whether or not the user is the team
@@ -32,8 +33,10 @@ export function useTeamMemberCard(member: TOrganizationTeamEmployee | undefined)
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const { updateOrganizationTeam, updateOTeamLoading } = useOrganizationTeams();
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
+
+	const { updateOrganizationTeam, loading: updateOTeamLoading } = useUpdateOrganizationTeam();
 
 	const activeTeamRef = useSyncRef(activeTeam);
 

--- a/apps/web/core/hooks/organizations/teams/use-team-member-invitations.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-member-invitations.ts
@@ -1,0 +1,14 @@
+import { teamInvitationsState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
+import { useCurrentTeam } from './use-current-team';
+import { useMemo } from 'react';
+
+export const useTeamMemberInvitation = () => {
+	const invitations = useAtomValue(teamInvitationsState);
+	const activeTeam = useCurrentTeam();
+	const members = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
+
+	return invitations.filter((invite) => {
+		return !members.find((me: any) => me?.employee?.user?.email === invite?.email);
+	});
+};

--- a/apps/web/core/hooks/organizations/teams/use-team-member.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-member.ts
@@ -1,13 +1,12 @@
 'use client';
-import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 
-import { activeTeamState } from '@/core/stores';
 import { ERoleName } from '@/core/types/generics/enums/role';
 import { TUser } from '@/core/types/schemas';
+import { useCurrentTeam } from './use-current-team';
 
 export function useIsMemberManager(user?: TUser | null) {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const activeManager = useMemo(() => {
 		if (!user || !activeTeam?.members) return undefined;

--- a/apps/web/core/hooks/organizations/teams/use-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-tasks.ts
@@ -1,39 +1,39 @@
 'use client';
 /* eslint-disable no-mixed-spaces-and-tabs */
+import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
 import {
 	getActiveTaskIdCookie,
 	getActiveUserTaskCookie,
 	setActiveTaskIdCookie,
 	setActiveUserTaskCookie
 } from '@/core/lib/helpers/index';
-import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { queryKeys } from '@/core/query/keys';
 import { taskService } from '@/core/services/client/api';
 import {
-	activeTeamState,
 	activeTeamTaskId,
+	activeTeamTaskState,
 	detailedTaskState,
 	memberActiveTaskIdState,
-	activeTeamTaskState,
 	tasksByTeamState,
-	teamTasksState,
-	taskStatusesState
+	taskStatusesState,
+	teamTasksState
 } from '@/core/stores';
-import isEqual from 'lodash/isEqual';
-import { useCallback, useRef, useState } from 'react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useOrganizationEmployeeTeams } from './use-organization-teams-employee';
-import { useAuthenticateUser } from '../../auth';
-import { useFirstLoad, useConditionalUpdateEffect, useSyncRef, useQueryCall } from '../../common';
+import { EIssueType, ETaskPriority, ETaskSize } from '@/core/types/generics/enums/task';
+import { PaginationResponse } from '@/core/types/interfaces/common/data-response';
 import { ITaskStatusField } from '@/core/types/interfaces/task/task-status/task-status-field';
 import { ITaskStatusStack } from '@/core/types/interfaces/task/task-status/task-status-stack';
 import { ETaskStatusName, TEmployee, TOrganizationTeamEmployee, TTag } from '@/core/types/schemas';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '@/core/query/keys';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { PaginationResponse } from '@/core/types/interfaces/common/data-response';
-import { useUserQuery } from '../../queries/user-user.query';
-import { EIssueType, ETaskPriority, ETaskSize } from '@/core/types/generics/enums/task';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import isEqual from 'lodash/isEqual';
+import { useCallback, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { useAuthenticateUser } from '../../auth';
+import { useConditionalUpdateEffect, useFirstLoad, useQueryCall, useSyncRef } from '../../common';
+import { useUserQuery } from '../../queries/user-user.query';
+import { useOrganizationEmployeeTeams } from './use-organization-teams-employee';
+import { useCurrentTeam } from './use-current-team';
 
 /**
  * A React hook that provides functionality for managing team tasks, including creating, updating, deleting, and fetching tasks.
@@ -83,7 +83,7 @@ export function useTeamTasks() {
 	const memberActiveTaskId = useAtomValue(memberActiveTaskIdState);
 	const $memberActiveTaskId = useSyncRef(memberActiveTaskId);
 	const taskStatuses = useAtomValue(taskStatusesState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const activeTeamRef = useSyncRef(activeTeam);
 	const [selectedEmployeeId, setSelectedEmployeeId] = useState(user?.employee?.id);
 	const [selectedOrganizationTeamId, setSelectedOrganizationTeamId] = useState(activeTeam?.id);

--- a/apps/web/core/hooks/organizations/teams/use-teams-state.ts
+++ b/apps/web/core/hooks/organizations/teams/use-teams-state.ts
@@ -1,10 +1,11 @@
 'use client';
-import { organizationTeamsState } from '@/core/stores';
-import { useCallback } from 'react';
-import { useAtom } from 'jotai';
-import { useSyncRef } from '../../common';
-import { TOrganizationTeam } from '@/core/types/schemas';
 import { mergePreservingOrder } from '@/core/lib/utils/team-members.utils';
+import { organizationTeamsState } from '@/core/stores';
+import { TOrganizationTeam } from '@/core/types/schemas';
+import { useAtom } from 'jotai';
+import { useCallback } from 'react';
+import { useSyncRef } from '../../common';
+import { useOrganisationTeams } from './use-organisation-teams';
 
 /**
  * It updates the `teams` state with the `members` status from the `team` status API
@@ -14,7 +15,8 @@ import { mergePreservingOrder } from '@/core/lib/utils/team-members.utils';
  * setTeamUpdate: A function that can be used to update the teams state.
  */
 export function useTeamsState() {
-	const [teams, setTeams] = useAtom(organizationTeamsState);
+	const [, setTeams] = useAtom(organizationTeamsState);
+	const { teams } = useOrganisationTeams();
 	const teamsRef = useSyncRef(teams);
 
 	const setTeamsUpdate = useCallback(

--- a/apps/web/core/hooks/queries/user-user.query.ts
+++ b/apps/web/core/hooks/queries/user-user.query.ts
@@ -1,14 +1,17 @@
+'use client';
+
 import { queryKeys } from '@/core/query/keys';
 import { userService } from '@/core/services/client/api';
 import { useQuery } from '@tanstack/react-query';
 
 import { getAccessTokenCookie } from '@/core/lib/helpers/cookies';
-import { useCallback } from 'react';
+
 export const useUserQuery = () => {
-	const checkTokenExist = useCallback((): boolean => {
+	const checkTokenExist = (): boolean => {
 		const token = getAccessTokenCookie();
 		return typeof token === 'string' && token.length > 0;
-	}, [getAccessTokenCookie]);
+	};
+
 	return useQuery({
 		queryKey: queryKeys.users.me,
 		queryFn: async () => {

--- a/apps/web/core/hooks/tasks/use-active-team-task.ts
+++ b/apps/web/core/hooks/tasks/use-active-team-task.ts
@@ -1,13 +1,14 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { queryKeys } from '@/core/query/keys';
+import { taskService } from '@/core/services/client/api';
+import { activeTeamTaskState, getPublicState, tasksByTeamState } from '@/core/stores';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useQuery } from '@tanstack/react-query';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { activeTeamState, activeTeamTaskState, getPublicState, tasksByTeamState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { taskService } from '@/core/services/client/api';
-import { queryKeys } from '@/core/query/keys';
-import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useEffect, useMemo } from 'react';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 /**
  * Result interface for the useActiveTeamTask hook
@@ -39,7 +40,7 @@ export const useActiveTeamTask = (): UseActiveTeamTaskResult => {
 	// Jotai state - instant updates
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const setActiveTeamTask = useSetAtom(activeTeamTaskState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const tasks = useAtomValue(tasksByTeamState);
 	const publicTeam = useAtomValue(getPublicState);
 

--- a/apps/web/core/hooks/tasks/use-auto-assign-task.ts
+++ b/apps/web/core/hooks/tasks/use-auto-assign-task.ts
@@ -1,11 +1,12 @@
 'use client';
 
+import { activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState, timerStatusState } from '@/core/stores';
 import { useCallback, useEffect } from 'react';
 import { useFirstLoad, useSyncRef } from '../common';
 import { useTeamTasks } from '../organizations';
-import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
 
 /**
@@ -13,7 +14,7 @@ import { useUserQuery } from '../queries/user-user.query';
  */
 export function useAutoAssignTask() {
 	const { firstLoad, firstLoadData } = useFirstLoad();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const timerStatus = useAtomValue(timerStatusState);
 	const { data: authUser } = useUserQuery();

--- a/apps/web/core/hooks/tasks/use-issue-types.ts
+++ b/apps/web/core/hooks/tasks/use-issue-types.ts
@@ -1,20 +1,21 @@
 'use client';
-import { issueTypesListState, activeTeamIdState, activeTeamState } from '@/core/stores';
-import { useCallback, useMemo } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
-import { issueTypeService } from '@/core/services/client/api/tasks/issue-type.service';
-import { IIssueTypesCreate } from '@/core/types/interfaces/task/issue-type';
 import { queryKeys } from '@/core/query/keys';
+import { issueTypeService } from '@/core/services/client/api/tasks/issue-type.service';
+import { activeTeamIdState, issueTypesListState } from '@/core/stores';
+import { IIssueTypesCreate } from '@/core/types/interfaces/task/issue-type';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useMemo } from 'react';
 import { useConditionalUpdateEffect } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
 
 export function useIssueType() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 	const { data: authUser } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const queryClient = useQueryClient();
 
 	const [issueTypes, setIssueTypes] = useAtom(issueTypesListState);

--- a/apps/web/core/hooks/tasks/use-task-filter.ts
+++ b/apps/web/core/hooks/tasks/use-task-filter.ts
@@ -1,16 +1,18 @@
-import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
-import { I_UserProfilePage } from '../users';
-import { useDailyPlan, useLocalStorageState, useOutsideClick } from '@/core/hooks';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { usePathname } from 'next/navigation';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { DAILY_PLAN_SUGGESTION_MODAL_DATE } from '@/core/constants/config/constants';
-import { estimatedTotalTime, getTotalTasks } from '@/core/components/tasks/daily-plan';
-import intersection from 'lodash/intersection';
 import { ITab } from '@/core/components/pages/profile/task-filters';
-import { timeLogsDailyReportState, activeTeamManagersState, activeTeamState } from '@/core/stores';
+import { estimatedTotalTime, getTotalTasks } from '@/core/components/tasks/daily-plan';
+import { DAILY_PLAN_SUGGESTION_MODAL_DATE } from '@/core/constants/config/constants';
+import { useDailyPlan, useLocalStorageState, useOutsideClick } from '@/core/hooks';
+import { timeLogsDailyReportState } from '@/core/stores';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
+import intersection from 'lodash/intersection';
+import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useActiveTeamManagers } from '../organizations/teams/use-active-team-managers';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
+import { I_UserProfilePage } from '../users';
 
 type IStatusType = 'status' | 'size' | 'priority' | 'label';
 type FilterType = 'status' | 'search' | undefined;
@@ -54,8 +56,8 @@ export function useTaskFilter(profile: I_UserProfilePage, options: UseTaskFilter
 	// 	[]
 	// );
 
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
+	const activeTeam = useCurrentTeam();
 
 	const { data: user } = useUserQuery();
 

--- a/apps/web/core/hooks/tasks/use-task-labels.ts
+++ b/apps/web/core/hooks/tasks/use-task-labels.ts
@@ -1,27 +1,28 @@
 'use client';
-import { taskLabelsListState, activeTeamIdState, activeTeamState } from '@/core/stores';
-import { useCallback, useMemo, useOptimistic, startTransition } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
 import {
 	generateDefaultColor,
 	getActiveTeamIdCookie,
 	getOrganizationIdCookie,
 	getTenantIdCookie
 } from '@/core/lib/helpers/index';
-import { taskLabelService } from '@/core/services/client/api/tasks/task-label.service';
-import { ITagCreate } from '@/core/types/interfaces/tag/tag';
-import { queryKeys } from '@/core/query/keys';
-import { useConditionalUpdateEffect } from '../common';
-import { useUserQuery } from '../queries/user-user.query';
 import { mergeTaskLabelData } from '@/core/lib/helpers/task';
+import { queryKeys } from '@/core/query/keys';
+import { taskLabelService } from '@/core/services/client/api/tasks/task-label.service';
+import { activeTeamIdState, taskLabelsListState } from '@/core/stores';
+import { ITagCreate } from '@/core/types/interfaces/tag/tag';
 import { OptimisticAction, TTag } from '@/core/types/schemas';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { startTransition, useCallback, useMemo, useOptimistic } from 'react';
+import { useConditionalUpdateEffect } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useUserQuery } from '../queries/user-user.query';
 
 export function useTaskLabels() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 	const { data: authUser } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const queryClient = useQueryClient();
 

--- a/apps/web/core/hooks/tasks/use-task-priorities.ts
+++ b/apps/web/core/hooks/tasks/use-task-priorities.ts
@@ -1,20 +1,21 @@
 'use client';
-import { taskPrioritiesListState, activeTeamIdState, activeTeamState } from '@/core/stores';
-import { useCallback, useMemo } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
 import { getActiveTeamIdCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
-import { taskPriorityService } from '@/core/services/client/api/tasks/task-priority.service';
-import { ITaskPrioritiesCreate } from '@/core/types/interfaces/task/task-priority';
 import { queryKeys } from '@/core/query/keys';
+import { taskPriorityService } from '@/core/services/client/api/tasks/task-priority.service';
+import { activeTeamIdState, taskPrioritiesListState } from '@/core/stores';
+import { ITaskPrioritiesCreate } from '@/core/types/interfaces/task/task-priority';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useMemo } from 'react';
 import { useConditionalUpdateEffect } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
 import { useUserQuery } from '../queries/user-user.query';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export function useTaskPriorities() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 	const { data: authUser } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const queryClient = useQueryClient();
 
 	const [taskPriorities, setTaskPriorities] = useAtom(taskPrioritiesListState);

--- a/apps/web/core/hooks/tasks/use-task-related-issue-type.ts
+++ b/apps/web/core/hooks/tasks/use-task-related-issue-type.ts
@@ -1,20 +1,21 @@
 'use client';
-import { activeTeamState, taskRelatedIssueTypeListState, activeTeamIdState } from '@/core/stores';
-import { useCallback, useMemo } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
 import { getActiveTeamIdCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
-import { taskRelatedIssueTypeService } from '@/core/services/client/api/tasks/task-related-issue-type.service';
-import { ITaskRelatedIssueTypeCreate } from '@/core/types/interfaces/task/related-issue-type';
 import { queryKeys } from '@/core/query/keys';
+import { taskRelatedIssueTypeService } from '@/core/services/client/api/tasks/task-related-issue-type.service';
+import { activeTeamIdState, taskRelatedIssueTypeListState } from '@/core/stores';
+import { ITaskRelatedIssueTypeCreate } from '@/core/types/interfaces/task/related-issue-type';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useMemo } from 'react';
 import { useConditionalUpdateEffect } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
 import { useUserQuery } from '../queries/user-user.query';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export function useTaskRelatedIssueType() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 	const { data: authUser } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const queryClient = useQueryClient();
 
 	const [taskRelatedIssueType, setTaskRelatedIssueType] = useAtom(taskRelatedIssueTypeListState);

--- a/apps/web/core/hooks/tasks/use-task-sizes.ts
+++ b/apps/web/core/hooks/tasks/use-task-sizes.ts
@@ -1,21 +1,22 @@
 'use client';
-import { activeTeamIdState, activeTeamState } from '@/core/stores';
-import { taskSizesListState } from '@/core/stores/tasks/task-sizes';
-import { useCallback } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
-import { taskSizeService } from '@/core/services/client/api/tasks/task-size.service';
-import { ITaskSizesCreate } from '@/core/types/interfaces/task/task-size';
 import { queryKeys } from '@/core/query/keys';
+import { taskSizeService } from '@/core/services/client/api/tasks/task-size.service';
+import { activeTeamIdState } from '@/core/stores';
+import { taskSizesListState } from '@/core/stores/tasks/task-sizes';
+import { ITaskSizesCreate } from '@/core/types/interfaces/task/task-size';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback } from 'react';
 import { useConditionalUpdateEffect } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export function useTaskSizes() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 	const [taskSizes, setTaskSizes] = useAtom(taskSizesListState);
 	const { firstLoadData: firstLoadTaskSizesData } = useFirstLoad();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const queryClient = useQueryClient();
 
 	const teamId = activeTeam?.id || activeTeamId;

--- a/apps/web/core/hooks/tasks/use-task-statistics.ts
+++ b/apps/web/core/hooks/tasks/use-task-statistics.ts
@@ -1,24 +1,24 @@
 'use client';
+import { statisticsService } from '@/core/services/client/api/timesheets/statistic.service';
 import {
 	activeTaskStatisticsState,
-	activeTeamState,
 	activeTeamTaskState,
 	allTaskStatisticsState,
 	tasksFetchingState,
 	tasksStatisticsState,
 	timerStatusState
 } from '@/core/stores';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useFirstLoad } from '../common/use-first-load';
-import debounce from 'lodash/debounce';
-import { useSyncRef } from '../common/use-sync-ref';
-import { statisticsService } from '@/core/services/client/api/timesheets/statistic.service';
-import { useRefreshIntervalV2 } from '../common';
 import { Nullable } from '@/core/types/generics/utils';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useUserQuery } from '../queries/user-user.query';
 import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import debounce from 'lodash/debounce';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useRefreshIntervalV2 } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useSyncRef } from '../common/use-sync-ref';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useUserQuery } from '../queries/user-user.query';
 
 export function useTaskStatistics(addSeconds = 0) {
 	const { data: user } = useUserQuery();
@@ -29,7 +29,7 @@ export function useTaskStatistics(addSeconds = 0) {
 
 	const { firstLoad, firstLoadData: firstLoadtasksStatisticsData } = useFirstLoad();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	// Refs
 	const initialLoad = useRef(false);
@@ -208,7 +208,12 @@ export function useTaskStatistics(addSeconds = 0) {
 
 		// Add local timer seconds (addSeconds) to the total worked time
 		// This ensures the progress bar updates in real-time as the timer runs locally
-		const estimation = getEstimation(null, activeTeamTask, totalWorkedTasksTimer + addSeconds, activeTeamTask?.estimate || 0);
+		const estimation = getEstimation(
+			null,
+			activeTeamTask,
+			totalWorkedTasksTimer + addSeconds,
+			activeTeamTask?.estimate || 0
+		);
 		return estimation;
 	}, [activeTeam?.members, activeTeamTask, getEstimation, addSeconds]);
 

--- a/apps/web/core/hooks/tasks/use-task-status.ts
+++ b/apps/web/core/hooks/tasks/use-task-status.ts
@@ -1,21 +1,22 @@
 'use client';
-import { taskStatusesState, activeTeamState, activeTeamIdState } from '@/core/stores';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
 import { getActiveTeamIdCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
+import { queryKeys } from '@/core/query/keys';
 import { taskStatusService } from '@/core/services/client/api/tasks/task-status.service';
-import { useCallbackRef, useConditionalUpdateEffect, useSyncRef } from '../common';
+import { activeTeamIdState, taskStatusesState } from '@/core/stores';
 import { TStatus, TStatusItem } from '@/core/types/interfaces/task/task-card';
 import { ITaskStatusCreate } from '@/core/types/interfaces/task/task-status/task-status';
-import { queryKeys } from '@/core/query/keys';
-import { ITaskStatusOrder } from '@/core/types/interfaces/task/task-status/task-status-order';
 import { ITaskStatusField } from '@/core/types/interfaces/task/task-status/task-status-field';
+import { ITaskStatusOrder } from '@/core/types/interfaces/task/task-status/task-status-order';
 import { ITaskStatusStack } from '@/core/types/interfaces/task/task-status/task-status-stack';
-import { useMapToTaskStatusValues } from './use-map-to-task-status-values';
-import { useUserQuery } from '../queries/user-user.query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import { useCallbackRef, useConditionalUpdateEffect, useSyncRef } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useUserQuery } from '../queries/user-user.query';
+import { useMapToTaskStatusValues } from './use-map-to-task-status-values';
 
 export function useTaskStatus() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
@@ -23,7 +24,7 @@ export function useTaskStatus() {
 	const { firstLoadData: firstLoadTaskStatusesData } = useFirstLoad();
 	const { data: user } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const queryClient = useQueryClient();
 
 	const teamId = activeTeam?.id || getActiveTeamIdCookie() || activeTeamId;

--- a/apps/web/core/hooks/users/use-profile-validation.ts
+++ b/apps/web/core/hooks/users/use-profile-validation.ts
@@ -1,13 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useAtomValue } from 'jotai';
-import { useRouter, usePathname } from 'next/navigation';
-import { toast } from 'sonner';
-import { useTranslations } from 'next-intl';
-import { activeTeamState } from '@/core/stores';
-import { useUserQuery } from '../queries/user-user.query';
 import { TOrganizationTeam } from '@/core/types/schemas/team/organization-team.schema';
+import { useTranslations } from 'next-intl';
+import { usePathname, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { useUserQuery } from '../queries/user-user.query';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export type ProfileValidationState = 'loading' | 'valid' | 'not-found' | 'timeout' | 'unauthorized';
 
@@ -26,7 +25,7 @@ export interface ProfileValidationResult {
  */
 export function useProfileValidation(memberId: string | null) {
 	const { data: user } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const router = useRouter();
 	const pathname = usePathname();
 	const t = useTranslations();

--- a/apps/web/core/hooks/users/use-user-details.ts
+++ b/apps/web/core/hooks/users/use-user-details.ts
@@ -1,16 +1,17 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
-import { useAuthTeamTasks } from '../organizations/teams/use-auth-team-tasks';
-import { useTeamTasks } from '../organizations';
-import { useAuthenticateUser } from '../auth';
-import { useGetTasksStatsData } from '../tasks';
+import { activeTeamTaskState } from '@/core/stores';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { activeTeamState, activeTeamTaskState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
+import { useCallback, useMemo } from 'react';
+import { useAuthenticateUser } from '../auth';
+import { useTeamTasks } from '../organizations';
+import { useAuthTeamTasks } from '../organizations/teams/use-auth-team-tasks';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useGetTasksStatsData } from '../tasks';
 
 export function useUserDetails(memberId: string) {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 
 	const { updateTask, tasks } = useTeamTasks();

--- a/apps/web/core/hooks/users/use-user-profile-page.ts
+++ b/apps/web/core/hooks/users/use-user-profile-page.ts
@@ -1,15 +1,16 @@
 'use client';
-import { activeTeamState, userDetailAccordion } from '@/core/stores';
+import { userDetailAccordion } from '@/core/stores';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
 import { useParams } from 'next/navigation';
 import { useCallback, useMemo } from 'react';
 import { useAuthTeamTasks, useTeamTasks } from '../organizations';
-import { useGetTasksStatsData } from '../tasks';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
+import { useGetTasksStatsData } from '../tasks';
 
 export function useUserProfilePage() {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { activeTeamTask, updateTask, tasks } = useTeamTasks();
 	const userMemberId = useAtomValue(userDetailAccordion);
 

--- a/apps/web/core/hooks/users/use-user-selected-page.ts
+++ b/apps/web/core/hooks/users/use-user-selected-page.ts
@@ -1,15 +1,14 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
-import { useAuthTeamTasks, useTeamTasks } from '../organizations';
-import { useAuthenticateUser } from '../auth';
-import { useGetTasksStatsData } from '../tasks';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { useCallback, useMemo } from 'react';
+import { useAuthenticateUser } from '../auth';
+import { useAuthTeamTasks, useTeamTasks } from '../organizations';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useGetTasksStatsData } from '../tasks';
 
-export function useUserSelectedPage(memberId='') {
-	const activeTeam = useAtomValue(activeTeamState);
+export function useUserSelectedPage(memberId = '') {
+	const activeTeam = useCurrentTeam();
 	const { activeTeamTask, updateTask, tasks } = useTeamTasks();
 
 	const { user: auth } = useAuthenticateUser();

--- a/apps/web/core/stores/auth/invitations.ts
+++ b/apps/web/core/stores/auth/invitations.ts
@@ -1,14 +1,18 @@
-import { atom } from 'jotai';
-import { activeTeamState } from '../teams/organization-team';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { TInvite } from '@/core/types/schemas';
+import { atom } from 'jotai';
 
 export const teamInvitationsState = atom<TInvite[]>([]);
 
 export const myInvitationsState = atom<TInvite[]>([]);
 
+/**
+ * Keep for backward compatibility
+ * @deprecated use `useTeamMemberInvitation()` hooks, that is partialy in sync with tanstack
+ */
 export const getTeamInvitationsState = atom<TInvite[]>((get) => {
 	const invitations = get(teamInvitationsState);
-	const activeTeam = get(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const members = activeTeam?.members || [];
 
 	return invitations.filter((invite) => {

--- a/apps/web/core/stores/teams/organization-team.ts
+++ b/apps/web/core/stores/teams/organization-team.ts
@@ -2,6 +2,10 @@ import { atom } from 'jotai';
 import { ERoleName } from '@/core/types/generics/enums/role';
 import { TOrganizationTeam, TOrganizationTeamEmployee } from '@/core/types/schemas';
 
+/**
+ * Keep for backward compatibility
+ * @deprecated use `useOrganisationTeams()` hook. That is in sync with tanstack-query !
+ */
 export const organizationTeamsState = atom<TOrganizationTeam[]>([]);
 
 export const activeTeamIdState = atom<string | null>(null);
@@ -17,6 +21,10 @@ export const isTeamJustDeletedState = atom<boolean>(false);
 export const isOTRefreshingState = atom<boolean>(false);
 export const OTRefreshIntervalState = atom<number>();
 
+/**
+ * Keep for backward compatibility
+ * @deprecated use `useCurrentTeam()` hook. That is in sync with tanstack-query !
+ */
 export const activeTeamState = atom<
 	TOrganizationTeam | null,
 	[((prev: TOrganizationTeam) => TOrganizationTeam) | TOrganizationTeam],
@@ -59,6 +67,10 @@ export const memberActiveTaskIdState = atom<string | null>(null);
 
 export const publicActiveTeamState = atom<TOrganizationTeam | undefined>(undefined);
 
+/**
+ * Keep for backward compatibility
+ * @deprecate use `useActiveTeamManagers()` hook. That is in sync with tanstack-query !
+ */
 export const activeTeamManagersState = atom<TOrganizationTeamEmployee[]>((get) => {
 	const activeTeam = get(activeTeamState);
 	const members = activeTeam?.members;


### PR DESCRIPTION

# Refactor useOrganizationTeams - Separate Read Operations from CUD Operations

## Description

This PR refactors the `useOrganizationTeams` hook by separating read operations from CUD (Create, Update, Delete) operations following the single responsibility principle.

## What Was Changed

### Major Changes

- **New Query Hooks:**
  - `useOrganizationTeamsQuery` - Fetch teams with React Query caching
  - `useGetTeamInvitationsQuery` - Fetch team invitations
  - `useCurrentTeam` - Access current active team
  - `useLoadTeamsData` - Centralized data loading orchestration

- **New Mutation Hooks:**
  - `useCreateTeamMutation` - Create new teams
  - `useInviteMemberMutation` - Invite members to teams
  - `useAcceptInviteMutation` - Accept team invitations
  - `useRemoveUserFromAllTeamMutation` - Remove user from all teams
  - `useSetActiveTeam` - Set the current active team

- **New Utility Hooks:**
  - `useTeamMemberInvitation` - Combined member invitation operations
  - `useSyncInvitationsWithAtom` - Sync React Query state with Jotai atoms
  - `useInitializeInvitations` - Initialize invitations on mount

## How to Test This PR


> 1. Run the app with `yarn dev`
> 2. Open the browser at `http://localhost:3000`
> 3. Test the following scenarios:
> - Create a new team → Should work and update the list
> - Switch between teams → Active team should update correctly
> - View team list → Should load from cache on subsequent visits
> - Invite a member to a team → Should send invitation
> - Accept an invitation → Should add user to team

**React Query DevTools (if enabled):**
> - Check that queries are cached properly
> - Verify mutations invalidate correct queries
> - Confirm no unnecessary refetches

## Screenshots (if needed)

| Before | After |
| ------ | ----- |
| N/A - No UI changes | N/A - No UI changes |

> This is a refactoring PR - no visual changes expected.

## Related Issues

> - Related to [ETP-170](https://evertech.atlassian.net/browse/ETP-170) - [Task]-[Web] Refactor useOrganizationTeams - Separate Read Operations from CUD Operations

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

- **Backward Compatibility**: Original hook (`useOrganizationTeams`) still work but is marked `@deprecated`. Existing components were migrated.

- **Jotai Sync**: All Jotai atoms (`organizationTeamsAtom`, `activeTeamAtom`, etc.) are automatically synchronized with React Query to maintain compatibility.

## ⚠️⚠️⚠️ Reviewers Suggested

- `@evereq` for architecture validation
- `@ndekocode` for integration review


[ETP-170]: https://evertech.atlassian.net/browse/ETP-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored team state into focused React Query hooks, separating reads from CUD operations to reduce re-renders and improve caching. Components now use useCurrentTeam and atomic mutations, meeting ETP-170.

- **Refactors**
  - Added query hooks: useGetOrganizationTeamsQuery, useGetOrganizationTeamQuery, useCurrentTeam, useLoadTeamsData.
  - Added mutation hooks: useCreateOrganizationTeam, useEditOrganizationTeamMutation, useDeleteOrganizationTeamMutation, useRemoveUserFromAllTeamMutation, useSetActiveTeam.
  - Added helpers: useActiveTeamManagers, useIsTeamManager, useTeamMemberInvitation.
  - Replaced activeTeamState reads with useCurrentTeam across pages and components.
  - Deprecated useOrganizationTeams; data flow now driven by TanStack Query with targeted cache invalidation.

- **Migration**
  - Read teams: switch to useGetOrganizationTeamsQuery/useGetOrganizationTeamQuery and useCurrentTeam.
  - Set active team: use useSetActiveTeam.
  - Team mutations: use the new mutation hooks (create/edit/delete/remove).
  - No UI changes required.

<sup>Written for commit 9113486e17835e9707ba7f410d20118eda6954ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

