### PR TITLE
Refactor useDailyPlan hook - Separate Read Operations from CUD Operations

### DIFF
--- a/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
+++ b/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
@@ -12,8 +12,8 @@ import StatusBadge from '@/core/components/pages/teams/team/tasks/status-badge';
 import { TaskTable } from '@/core/components/pages/teams/team/tasks/task-table';
 import { usePagination } from '@/core/hooks/common/use-pagination';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useSortedTasksByCreation } from '@/core/hooks/organizations/teams/use-sorted-tasks';
 import { cn, getStatusColor } from '@/core/lib/helpers';
-import { tasksByTeamState } from '@/core/stores';
 import { fullWidthState } from '@/core/stores/common/full-width';
 import { ETaskStatusName } from '@/core/types/generics/enums/task';
 import { TTask } from '@/core/types/schemas/task/task.schema';
@@ -42,7 +42,7 @@ const TeamTask = () => {
 		[activeTeam?.name, currentLocale, t]
 	);
 
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasksByCreation();
 	const [searchTaskTerm, setSearchTaskTerm] = useState('');
 	const filteredTasks = useMemo(
 		() => tasks.filter((el) => el.title.toLowerCase().includes(searchTaskTerm.toLowerCase())),

--- a/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
+++ b/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
@@ -1,29 +1,29 @@
 'use client';
 import { Container } from '@/core/components';
-import { MainLayout } from '@/core/components/layouts/default-layout';
-import { useParams } from 'next/navigation';
-import { useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { useAtomValue } from 'jotai';
-import { fullWidthState } from '@/core/stores/common/full-width';
-import { withAuthentication } from '@/core/components/layouts/app/authenticator';
-import { getCoreRowModel, getFilteredRowModel, useReactTable, VisibilityState } from '@tanstack/react-table';
-import { cn, getStatusColor } from '@/core/lib/helpers';
 import { Input } from '@/core/components/common/input';
-import { Check, Search, Settings2 } from 'lucide-react';
-import { usePagination } from '@/core/hooks/common/use-pagination';
-import { Menu, Transition } from '@headlessui/react';
+import { Button } from '@/core/components/duplicated-components/_button';
+import { Paginate } from '@/core/components/duplicated-components/_pagination';
+import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
+import { withAuthentication } from '@/core/components/layouts/app/authenticator';
+import { MainLayout } from '@/core/components/layouts/default-layout';
+import { TeamTasksPageSkeleton } from '@/core/components/layouts/skeletons/team-tasks-page-skeleton';
 import { columns, hidableColumnNames } from '@/core/components/pages/teams/team/tasks/columns';
 import StatusBadge from '@/core/components/pages/teams/team/tasks/status-badge';
 import { TaskTable } from '@/core/components/pages/teams/team/tasks/task-table';
-import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
-import { Paginate } from '@/core/components/duplicated-components/_pagination';
-import { Button } from '@/core/components/duplicated-components/_button';
+import { usePagination } from '@/core/hooks/common/use-pagination';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { cn, getStatusColor } from '@/core/lib/helpers';
+import { tasksByTeamState } from '@/core/stores';
+import { fullWidthState } from '@/core/stores/common/full-width';
 import { ETaskStatusName } from '@/core/types/generics/enums/task';
-import { ColumnDef } from '@tanstack/react-table';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { TeamTasksPageSkeleton } from '@/core/components/layouts/skeletons/team-tasks-page-skeleton';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
+import { Menu, Transition } from '@headlessui/react';
+import { ColumnDef, getCoreRowModel, getFilteredRowModel, useReactTable, VisibilityState } from '@tanstack/react-table';
+import { useAtomValue } from 'jotai';
+import { Check, Search, Settings2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useParams } from 'next/navigation';
+import { useMemo, useState } from 'react';
 
 const TeamTask = () => {
 	const t = useTranslations();
@@ -31,7 +31,8 @@ const TeamTask = () => {
 	const fullWidth = useAtomValue(fullWidthState);
 	const currentLocale = params ? params.locale : null;
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
+
 	const breadcrumbPath = useMemo(
 		() => [
 			{ title: JSON.parse(t('pages.home.BREADCRUMB')), href: '/' },

--- a/apps/web/app/[locale]/(main)/calendar/page.tsx
+++ b/apps/web/app/[locale]/(main)/calendar/page.tsx
@@ -25,7 +25,8 @@ import {
 	LazySetupTimeSheet,
 	LazyAddManualTimeModal
 } from '@/core/components/optimized-components/calendar';
-import { activeTeamState, isTrackingEnabledState } from '@/core/stores';
+import { isTrackingEnabledState } from '@/core/stores';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const CalendarPage = () => {
 	const t = useTranslations();
@@ -33,7 +34,7 @@ const CalendarPage = () => {
 
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const [calendarTimeSheet, setCalendarTimeSheet] = useLocalStorageState<timesheetCalendar>(
 		'calendar-timesheet',
 		'Calendar'

--- a/apps/web/app/[locale]/(main)/kanban/page.tsx
+++ b/apps/web/app/[locale]/(main)/kanban/page.tsx
@@ -44,8 +44,9 @@ import {
 	LazyKanbanSearch,
 	LazyInviteFormModal
 } from '@/core/components/optimized-components/kanban';
-import { activeTeamState, isTrackingEnabledState } from '@/core/stores';
+import { isTrackingEnabledState } from '@/core/stores';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const Kanban = () => {
 	// Get all required hooks and states
@@ -64,7 +65,7 @@ const Kanban = () => {
 
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const t = useTranslations();
 	const params = useParams<{ locale: string }>();
 	const fullWidth = useAtomValue(fullWidthState);

--- a/apps/web/app/[locale]/(main)/profile/[memberId]/page.tsx
+++ b/apps/web/app/[locale]/(main)/profile/[memberId]/page.tsx
@@ -1,36 +1,38 @@
 'use client';
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { useLocalStorageState, useUserProfilePage } from '@/core/hooks';
-import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { Container } from '@/core/components';
-import { ArrowLeftIcon } from 'assets/svg';
+import { ProfileErrorBoundary } from '@/core/components/common/profile-error-boundary';
+import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { MainHeader, MainLayout } from '@/core/components/layouts/default-layout';
+import { useLocalStorageState, useUserProfilePage } from '@/core/hooks';
+import { useProfileValidation } from '@/core/hooks/users/use-profile-validation';
+import { ArrowLeftIcon } from 'assets/svg';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import React, { Suspense, useCallback, useMemo } from 'react';
-import { useTranslations } from 'next-intl';
-import { useProfileValidation } from '@/core/hooks/users/use-profile-validation';
-import { ProfileErrorBoundary } from '@/core/components/common/profile-error-boundary';
 
-import { useAtomValue, useSetAtom } from 'jotai';
-import { fullWidthState } from '@/core/stores/common/full-width';
-import { activityTypeState } from '@/core/stores/timer/activity-type';
-import { cn } from '@/core/lib/helpers';
-import { useTaskFilter } from '@/core/hooks/tasks/use-task-filter';
-import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
-import { VerticalSeparator } from '@/core/components/duplicated-components/separator';
 import { ProfilePageSkeleton } from '@/core/components/common/skeleton/profile-page-skeleton';
 import { TimerSkeleton } from '@/core/components/common/skeleton/timer-skeleton';
+import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
+import { VerticalSeparator } from '@/core/components/duplicated-components/separator';
 import {
 	LazyAppsTab,
 	LazyScreenshootTab,
-	LazyUserProfileTask,
-	LazyUserProfileDetail,
-	LazyVisitedSitesTab,
+	LazyTaskFilter,
 	LazyTimer,
-	LazyTaskFilter
+	LazyUserProfileDetail,
+	LazyUserProfileTask,
+	LazyVisitedSitesTab
 } from '@/core/components/optimized-components';
-import { activeTeamManagersState, activeTeamState, isTrackingEnabledState } from '@/core/stores';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTaskFilter } from '@/core/hooks/tasks/use-task-filter';
+import { cn } from '@/core/lib/helpers';
+import { isTrackingEnabledState } from '@/core/stores';
+import { fullWidthState } from '@/core/stores/common/full-width';
+import { activityTypeState } from '@/core/stores/timer/activity-type';
+import { useAtomValue, useSetAtom } from 'jotai';
 
 export type FilterTab = 'Tasks' | 'Screenshots' | 'Apps' | 'Visited Sites';
 
@@ -44,11 +46,12 @@ const Profile = React.memo(function ProfilePage({ params }: { params: { memberId
 	const profileValidation = useProfileValidation(unwrappedParams.memberId);
 
 	// const { filteredTeams, userManagedTeams } = useOrganizationAndTeamManagers();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const profileUser = profileValidation.member?.employee?.user ?? null;
 
 	const profile = useUserProfilePage();
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
+
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
 	const fullWidth = useAtomValue(fullWidthState);
 	const [activityFilter, setActivityFilter] = useLocalStorageState<FilterTab>('activity-filter', 'Tasks');

--- a/apps/web/app/[locale]/(main)/reports/weekly-limit/page.tsx
+++ b/apps/web/app/[locale]/(main)/reports/weekly-limit/page.tsx
@@ -1,36 +1,37 @@
 'use client';
+import { ReportsPageSkeleton } from '@/core/components/common/skeleton/reports-page-skeleton';
+import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
 import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { MainLayout } from '@/core/components/layouts/default-layout';
-import { useEffect, useMemo, useState } from 'react';
-import { getAccessTokenCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
-import { useTimeLimits } from '@/core/hooks/activities/use-time-limits';
-import { DateRange } from 'react-day-picker';
-import { endOfMonth, startOfMonth } from 'date-fns';
-import moment from 'moment';
-import { usePagination } from '@/core/hooks/common/use-pagination';
-import { getUserOrganizationsRequest } from '@/core/services/server/requests';
-import { useTranslations } from 'next-intl';
+import { TGroupByOption } from '@/core/components/pages/reports/weekly-limit/group-by-select';
 import { groupDataByEmployee } from '@/core/components/pages/reports/weekly-limit/time-report-table';
-import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
+import { useTimeLimits } from '@/core/hooks/activities/use-time-limits';
+import { usePagination } from '@/core/hooks/common/use-pagination';
+import { getAccessTokenCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
+import { getUserOrganizationsRequest } from '@/core/services/server/requests';
 import { IOrganization } from '@/core/types/interfaces/organization/organization';
 import { TTimeLimitReportList } from '@/core/types/schemas';
-import { TGroupByOption } from '@/core/components/pages/reports/weekly-limit/group-by-select';
-import { ReportsPageSkeleton } from '@/core/components/common/skeleton/reports-page-skeleton';
+import { endOfMonth, startOfMonth } from 'date-fns';
+import moment from 'moment';
+import { useTranslations } from 'next-intl';
+import { useEffect, useMemo, useState } from 'react';
+import { DateRange } from 'react-day-picker';
 // Skeletons are now handled by optimized components
 
 // Import optimized components from centralized location
 import {
-	LazyGroupBySelect,
-	LazyWeeklyLimitExportMenu,
-	LazyTimeReportTable,
 	LazyDatePickerWithRange,
+	LazyGroupBySelect,
 	LazyMembersSelect,
+	LazyPaginate,
+	LazyTimeReportTable,
 	LazyTimeReportTableByMember,
-	LazyPaginate
+	LazyWeeklyLimitExportMenu
 } from '@/core/components/optimized-components/reports';
-import { activeTeamState, isTrackingEnabledState, myPermissionsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { isTrackingEnabledState, myPermissionsState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
 
 function WeeklyLimitReport() {
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
@@ -58,7 +59,7 @@ function WeeklyLimitReport() {
 			},
 		[organization]
 	);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const [member, setMember] = useState<string>('all');
 	const [dateRange, setDateRange] = useState<DateRange>({
 		from: startOfMonth(new Date()),

--- a/apps/web/app/[locale]/(main)/settings/team/page.tsx
+++ b/apps/web/app/[locale]/(main)/settings/team/page.tsx
@@ -1,35 +1,36 @@
 'use client';
 
-import { withAuthentication } from '@/core/components/layouts/app/authenticator';
-import { useAuthenticateUser } from '@/core/hooks';
-import { activeTeamState, fetchingTeamInvitationsState, isTeamMemberState, teamInvitationsState } from '@/core/stores';
-import Link from 'next/link';
-import { useTranslations } from 'next-intl';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { Accordian } from '@/core/components/common/accordian';
-import { activeSettingTeamTab } from '@/core/stores/common/setting';
-import { InteractionObserverVisible } from '@/core/components/pages/settings/interaction-observer';
-import NoTeam from '@/core/components/common/no-team';
-import { TeamAvatar } from '@/core/components/teams/team-avatar';
 import { EverCard } from '@/core/components/common/ever-card';
+import NoTeam from '@/core/components/common/no-team';
+import { withAuthentication } from '@/core/components/layouts/app/authenticator';
+import { InteractionObserverVisible } from '@/core/components/pages/settings/interaction-observer';
+import { TeamAvatar } from '@/core/components/teams/team-avatar';
+import { useAuthenticateUser } from '@/core/hooks';
+import { fetchingTeamInvitationsState, isTeamMemberState, teamInvitationsState } from '@/core/stores';
+import { activeSettingTeamTab } from '@/core/stores/common/setting';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 // Import optimized components from centralized location
 import {
-	LazyTeamSettingForm,
-	LazyInvitationSetting,
-	LazyMemberSetting,
-	LazyIntegrationSetting,
-	LazyIssuesSettings,
-	LazyDangerZoneTeam
-} from '@/core/components/optimized-components/settings';
-import { Suspense } from 'react';
-import {
-	TeamSettingFormSkeleton,
-	InvitationSettingSkeleton,
-	MemberSettingSkeleton,
+	DangerZoneTeamSkeleton,
 	IntegrationSettingSkeleton,
+	InvitationSettingSkeleton,
 	IssuesSettingsSkeleton,
-	DangerZoneTeamSkeleton
+	MemberSettingSkeleton,
+	TeamSettingFormSkeleton
 } from '@/core/components/common/skeleton/settings-skeletons';
+import {
+	LazyDangerZoneTeam,
+	LazyIntegrationSetting,
+	LazyInvitationSetting,
+	LazyIssuesSettings,
+	LazyMemberSetting,
+	LazyTeamSettingForm
+} from '@/core/components/optimized-components/settings';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { Suspense } from 'react';
 
 const Team = () => {
 	const t = useTranslations();
@@ -38,7 +39,7 @@ const Team = () => {
 	const [isFetchingTeamInvitations] = useAtom(fetchingTeamInvitationsState);
 	const { user, isTeamManager } = useAuthenticateUser();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const isTeamMember = useAtomValue(isTeamMemberState);
 	const teamInvitations = useAtomValue(teamInvitationsState);
 

--- a/apps/web/app/[locale]/(main)/task/[id]/page.tsx
+++ b/apps/web/app/[locale]/(main)/task/[id]/page.tsx
@@ -19,7 +19,8 @@ import Link from 'next/link';
 
 // Import optimized components from centralized location
 import { LazyTaskDetailsComponent } from '@/core/components/optimized-components';
-import { activeTeamState, detailedTaskState, isTrackingEnabledState } from '@/core/stores';
+import { detailedTaskState, isTrackingEnabledState } from '@/core/stores';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const TaskDetails = () => {
 	const profile = useUserProfilePage();
@@ -27,7 +28,7 @@ const TaskDetails = () => {
 	const router = useRouter();
 	const params = useParams();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 	const detailedTask = useAtomValue(detailedTaskState);
 	const { getTaskById, getTasksByIdLoading } = useTeamTasks();

--- a/apps/web/app/[locale]/page-component.tsx
+++ b/apps/web/app/[locale]/page-component.tsx
@@ -1,54 +1,55 @@
 'use client';
 import React, { Suspense, useEffect } from 'react';
 
-import { useDailyPlan, useIsMemberManager, useTeamInvitations } from '@/core/hooks';
-import { clsxm } from '@/core/lib/utils';
-import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { Container } from '@/core/components';
+import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { MainLayout } from '@/core/components/layouts/default-layout';
 import { IssuesView, LAST_SELECTED_TEAM_MEMBERS_VIEW_MODE } from '@/core/constants/config/constants';
+import { useDailyPlan, useIsMemberManager, useTeamInvitations } from '@/core/hooks';
+import { clsxm } from '@/core/lib/utils';
 import { useTranslations } from 'next-intl';
 
 import { Analytics } from '@vercel/analytics/react';
 
-import 'react-loading-skeleton/dist/skeleton.css';
 import '@/styles/globals.css';
+import 'react-loading-skeleton/dist/skeleton.css';
 
-import { useAtom, useAtomValue } from 'jotai';
-import { fullWidthState } from '@/core/stores/common/full-width';
 import HeaderTabs from '@/core/components/common/header-tabs';
+import { fullWidthState } from '@/core/stores/common/full-width';
 import { headerTabs } from '@/core/stores/common/header-tabs';
-import { usePathname } from 'next/navigation';
 import { PeoplesIcon } from 'assets/svg';
+import { useAtom, useAtomValue } from 'jotai';
+import { usePathname } from 'next/navigation';
 // TeamMemberHeader and NoTeam now lazy-loaded below
 import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
 
 // Import skeleton components
-import TeamMembersSkeleton from '@/core/components/common/skeleton/team-members-skeleton';
+import { NoTeamSkeleton } from '@/core/components/common/skeleton/no-team-skeleton';
+import { TaskTimerSectionSkeleton } from '@/core/components/common/skeleton/task-timer-section-skeleton';
 import TeamInvitationsSkeleton from '@/core/components/common/skeleton/team-invitations-skeleton';
+import { TeamMemberHeaderSkeleton } from '@/core/components/common/skeleton/team-member-header-skeleton';
+import TeamMembersSkeleton from '@/core/components/common/skeleton/team-members-skeleton';
 import TeamNotificationsSkeleton from '@/core/components/common/skeleton/team-notifications-skeleton';
 import UnverifiedEmailSkeleton from '@/core/components/common/skeleton/unverified-email-skeleton';
-import { TaskTimerSectionSkeleton } from '@/core/components/common/skeleton/task-timer-section-skeleton';
 import { TaskTimerSection } from '@/core/components/pages/dashboard/task-timer-section';
-import { TeamMemberHeaderSkeleton } from '@/core/components/common/skeleton/team-member-header-skeleton';
-import { NoTeamSkeleton } from '@/core/components/common/skeleton/no-team-skeleton';
 // Import optimized components from centralized location
+import { LazyChatwootWidget, LazyNoTeam, LazyUnverifiedEmail } from '@/core/components/optimized-components/common';
 import {
-	LazyTeamOutstandingNotifications,
-	LazyTeamMembers,
 	LazyTeamInvitations,
-	LazyTeamMemberHeader
+	LazyTeamMemberHeader,
+	LazyTeamMembers,
+	LazyTeamOutstandingNotifications
 } from '@/core/components/optimized-components/teams';
-import { LazyChatwootWidget, LazyUnverifiedEmail, LazyNoTeam } from '@/core/components/optimized-components/common';
-import { activeTeamState, isTeamMemberState, isTrackingEnabledState, myInvitationsState } from '@/core/stores';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { isTeamMemberState, isTrackingEnabledState, myInvitationsState } from '@/core/stores';
 
 function MainPage() {
 	const t = useTranslations();
 
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const isTeamMember = useAtomValue(isTeamMemberState);
 
@@ -75,7 +76,8 @@ function MainPage() {
 		}
 		const lastTeamMembersViewMode = localStorage?.getItem(LAST_SELECTED_TEAM_MEMBERS_VIEW_MODE);
 		if (lastTeamMembersViewMode && path == '/') {
-			if (Object.values(IssuesView).includes(lastTeamMembersViewMode as IssuesView) &&
+			if (
+				Object.values(IssuesView).includes(lastTeamMembersViewMode as IssuesView) &&
 				lastTeamMembersViewMode != IssuesView.KANBAN
 			) {
 				setView(lastTeamMembersViewMode as IssuesView);

--- a/apps/web/app/[locale]/page-component.tsx
+++ b/apps/web/app/[locale]/page-component.tsx
@@ -5,7 +5,7 @@ import { Container } from '@/core/components';
 import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { MainLayout } from '@/core/components/layouts/default-layout';
 import { IssuesView, LAST_SELECTED_TEAM_MEMBERS_VIEW_MODE } from '@/core/constants/config/constants';
-import { useDailyPlan, useIsMemberManager, useTeamInvitations } from '@/core/hooks';
+import { useIsMemberManager, useTeamInvitations } from '@/core/hooks';
 import { clsxm } from '@/core/lib/utils';
 import { useTranslations } from 'next-intl';
 
@@ -40,6 +40,8 @@ import {
 	LazyTeamMembers,
 	LazyTeamOutstandingNotifications
 } from '@/core/components/optimized-components/teams';
+import { useOutstandingPlans } from '@/core/hooks/daily-plans/derived';
+import { useAllDailyPlansQuery } from '@/core/hooks/daily-plans/queries';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { isTeamMemberState, isTrackingEnabledState, myInvitationsState } from '@/core/stores';
@@ -54,8 +56,9 @@ function MainPage() {
 	const isTeamMember = useAtomValue(isTeamMemberState);
 
 	const { data: user } = useUserQuery();
-	const employeeId = user?.employee?.id ?? user?.employeeId ?? '';
-	const { dailyPlan, outstandingPlans } = useDailyPlan(employeeId);
+	const employeeId: string = user?.employee?.id ?? user?.employeeId ?? '';
+	const outstandingPlans = useOutstandingPlans(employeeId);
+	const { data: dailyPlan } = useAllDailyPlansQuery();
 
 	const { isTeamManager } = useIsMemberManager(user);
 
@@ -137,7 +140,7 @@ function MainPage() {
 											<Suspense fallback={<TeamNotificationsSkeleton />}>
 												<LazyTeamOutstandingNotifications
 													outstandingPlans={outstandingPlans}
-													dailyPlan={dailyPlan}
+													dailyPlan={dailyPlan ?? { items: [] }}
 													isTeamManager={isTeamManager}
 													user={user!}
 												/>

--- a/apps/web/core/components/auth/must-be-a-manager.tsx
+++ b/apps/web/core/components/auth/must-be-a-manager.tsx
@@ -1,9 +1,9 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { useAuthenticateUser } from '@/core/hooks';
-import { useOrganizationTeams } from '@/core/hooks/organizations';
 import GlobalSkeleton from '../common/global-skeleton';
 import { useRouter } from 'next/navigation';
+import { useGetOrganizationTeamsQuery } from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
 
 type Props = {
 	children: React.ReactNode;
@@ -14,7 +14,7 @@ type Props = {
 export default function MustBeAManager({ children, redirectTo = '/', useRedirect = true }: Props) {
 	// All hooks must be called before any conditional returns
 	const { userLoading: isUserLoading, isTeamManager } = useAuthenticateUser();
-	const { getOrganizationTeamsLoading: isTeamsLoading } = useOrganizationTeams();
+	const { isPending: isTeamsLoading } = useGetOrganizationTeamsQuery();
 	const router = useRouter();
 	const [checked, setChecked] = useState(false);
 	const [isRedirecting, setIsRedirecting] = useState(false);

--- a/apps/web/core/components/collaborate/index.tsx
+++ b/apps/web/core/components/collaborate/index.tsx
@@ -1,7 +1,4 @@
-import { imgTitle } from '@/core/lib/helpers/index';
-import { useCollaborative, useModal } from '@/core/hooks';
-import { TUser } from '@/core/types/schemas';
-import { clsxm, isValidUrl } from '@/core/lib/utils';
+import { Button } from '@/core/components/common/button';
 import {
 	Command,
 	CommandEmpty,
@@ -19,19 +16,21 @@ import {
 	DialogTitle,
 	DialogTrigger
 } from '@/core/components/common/dialog';
+import { ScrollArea } from '@/core/components/common/scroll-bar';
+import { useCollaborative, useModal } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { imgTitle } from '@/core/lib/helpers/index';
+import { clsxm, isValidUrl } from '@/core/lib/utils';
+import { TUser } from '@/core/types/schemas';
 import { useJitsu } from '@jitsu/jitsu-react';
-import { Button } from '@/core/components/common/button';
+import { BrushSquareIcon, PhoneUpArrowIcon, UserLinearIcon } from 'assets/svg';
 import { Check } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { useCallback, useMemo } from 'react';
 import stc from 'string-to-color';
-import { useTranslations } from 'next-intl';
-import { BrushSquareIcon, PhoneUpArrowIcon, UserLinearIcon } from 'assets/svg';
-import { ScrollArea } from '@/core/components/common/scroll-bar';
 import { JitsuAnalytics } from '../analytics/jitsu-analytics';
 import { Avatar } from '../duplicated-components/avatar';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
 const Collaborate = () => {
 	const { onMeetClick, onBoardClick, collaborativeMembers, setCollaborativeMembers } = useCollaborative();
@@ -41,7 +40,7 @@ const Collaborate = () => {
 
 	const { data: user } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const members = useMemo(
 		() =>
 			activeTeam?.members && activeTeam?.members.length

--- a/apps/web/core/components/common/image-overlapper.tsx
+++ b/apps/web/core/components/common/image-overlapper.tsx
@@ -1,33 +1,32 @@
-import { useCallback, useMemo, useState } from 'react';
+import { Divider, Modal, SpinnerLoader } from '@/core/components';
 import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
-import Image from 'next/image';
-import Link from 'next/link';
-import Skeleton from 'react-loading-skeleton';
 import { ScrollArea } from '@/core/components/common/scroll-bar';
-import { useModal, useTeamTasks } from '@/core/hooks';
-import { Modal, Divider, SpinnerLoader } from '@/core/components';
-import { useTranslations } from 'next-intl';
-import { toast } from 'sonner';
-import { TaskAssignButton } from '@/core/components/tasks/task-assign-button';
-import { clsxm } from '@/core/lib/utils';
-import TeamMember from '@/core/components/teams/team-member';
-import { Url } from 'next/dist/shared/lib/router/router';
-import { IconsCheck, IconsPersonAddRounded, IconsPersonRounded } from '@/core/components/icons';
-import { cn } from '../../lib/helpers';
-import { TaskAvatars } from '../tasks/task-items';
-import { Tooltip } from '../duplicated-components/tooltip';
 import {
 	Tooltip as ShadcnTooltip,
+	TooltipArrow,
 	TooltipContent,
 	TooltipProvider,
-	TooltipTrigger,
-	TooltipArrow
+	TooltipTrigger
 } from '@/core/components/common/tooltip';
+import { IconsCheck, IconsPersonAddRounded, IconsPersonRounded } from '@/core/components/icons';
+import { TaskAssignButton } from '@/core/components/tasks/task-assign-button';
+import TeamMember from '@/core/components/teams/team-member';
+import { useModal, useTeamTasks } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { clsxm } from '@/core/lib/utils';
 import { ITimerStatus } from '@/core/types/interfaces/timer/timer-status';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
 import { TEmployee, TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useTranslations } from 'next-intl';
+import { Url } from 'next/dist/shared/lib/router/router';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useCallback, useMemo, useState } from 'react';
+import Skeleton from 'react-loading-skeleton';
+import { toast } from 'sonner';
+import { cn } from '../../lib/helpers';
+import { Tooltip } from '../duplicated-components/tooltip';
+import { TaskAvatars } from '../tasks/task-items';
 
 export interface ImageOverlapperProps {
 	id: string;
@@ -75,7 +74,7 @@ export default function ImageOverlapper({
 	const imageLength = images?.length;
 	const { isOpen, openModal, closeModal } = useModal();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const allMembers = useMemo(() => activeTeam?.members || [], [activeTeam]);
 	const [assignedMembers, setAssignedMembers] = useState<TEmployee[]>([...(item?.members || [])]);
 	const [unassignedMembers, setUnassignedMembers] = useState<TEmployee[]>([]);

--- a/apps/web/core/components/common/no-team.tsx
+++ b/apps/web/core/components/common/no-team.tsx
@@ -1,15 +1,14 @@
 'use client';
-import { useModal } from '@/core/hooks';
-import { clsxm } from '@/core/lib/utils';
+import { NoTeamIcon } from '@/assets/svg';
 import { Button, Text } from '@/core/components';
-import React, { PropsWithChildren } from 'react';
+import { useModal } from '@/core/hooks';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { clsxm } from '@/core/lib/utils';
 import { useTranslations } from 'next-intl';
+import React, { PropsWithChildren } from 'react';
 import { Tooltip } from '../duplicated-components/tooltip';
 import { CreateTeamModal } from '../features/teams/create-team-modal';
-import { organizationTeamsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { NoTeamIcon } from '@/assets/svg';
 
 type Props = PropsWithChildren & React.ComponentPropsWithRef<'div'>;
 const NoTeam = ({ className, ...rest }: Props) => {
@@ -17,7 +16,7 @@ const NoTeam = ({ className, ...rest }: Props) => {
 	const { isOpen, closeModal, openModal } = useModal();
 	const { data: user } = useUserQuery();
 
-	const teams = useAtomValue(organizationTeamsState);
+	const { teams } = useOrganisationTeams();
 
 	React.useEffect(() => {
 		closeModal();

--- a/apps/web/core/components/common/switch.tsx
+++ b/apps/web/core/components/common/switch.tsx
@@ -1,13 +1,13 @@
-import { Switch } from '@headlessui/react';
-import { useCallback, useEffect, useState } from 'react';
-import { Text } from './typography';
-import { useTranslations } from 'next-intl';
 import { DAILY_PLAN_SUGGESTION_MODAL_DATE } from '@/core/constants/config/constants';
-import { useOrganizationEmployeeTeams, useOrganizationTeams } from '../../hooks/organizations';
-import { IEmployee } from '@/core/types/interfaces/organization/employee';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { ERoleName } from '@/core/types/generics/enums/role';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { IEmployee } from '@/core/types/interfaces/organization/employee';
+import { Switch } from '@headlessui/react';
+import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useState } from 'react';
+import { useOrganizationEmployeeTeams } from '../../hooks/organizations';
+import { Text } from './typography';
+import { useEditOrganizationTeamMutation } from '@/core/hooks/organizations/teams/use-edit-organization-team-mutation';
 
 export default function TimeTrackingToggle({ activeManager }: { activeManager: IEmployee | undefined }) {
 	const t = useTranslations();
@@ -15,7 +15,7 @@ export default function TimeTrackingToggle({ activeManager }: { activeManager: I
 
 	const { updateOrganizationTeamEmployee } = useOrganizationEmployeeTeams();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const handleChange = useCallback(() => {
 		if (activeManager && activeTeam) {
@@ -57,13 +57,13 @@ export default function TimeTrackingToggle({ activeManager }: { activeManager: I
 export function ShareProfileViewsToggle() {
 	const t = useTranslations();
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const { editOrganizationTeam } = useOrganizationTeams();
+	const activeTeam = useCurrentTeam();
+	const editOrganizationTeam = useEditOrganizationTeamMutation();
 	const [enabled, setEnabled] = useState<boolean | undefined>(activeTeam?.shareProfileView);
 
 	const handleChange = useCallback(async () => {
 		if (activeTeam && typeof enabled != 'undefined') {
-			await editOrganizationTeam({
+			await editOrganizationTeam.mutateAsync({
 				...activeTeam,
 				shareProfileView: !enabled,
 				memberIds: activeTeam.members
@@ -112,13 +112,13 @@ export function ShareProfileViewsToggle() {
 
 export function RequireDailyPlanToTrack() {
 	const t = useTranslations();
-	const activeTeam = useAtomValue(activeTeamState);
-	const { editOrganizationTeam } = useOrganizationTeams();
+	const activeTeam = useCurrentTeam();
+	const editOrganizationTeam = useEditOrganizationTeamMutation();
 	const [enabled, setEnabled] = useState<boolean | undefined>(activeTeam?.requirePlanToTrack);
 
 	const handleChange = useCallback(async () => {
 		if (activeTeam && typeof enabled != 'undefined') {
-			await editOrganizationTeam({
+			await editOrganizationTeam.mutateAsync({
 				...activeTeam,
 				requirePlanToTrack: !enabled,
 				memberIds: activeTeam.members

--- a/apps/web/core/components/common/team-member.tsx
+++ b/apps/web/core/components/common/team-member.tsx
@@ -1,18 +1,23 @@
 import InviteCard from '@/core/components/teams/invite/invite-card';
 import { InvitedCard } from '@/core/components/teams/invite/invited-card';
 import UsersCard from '@/core/components/teams/members-card/members-card';
-import { useTranslations } from 'next-intl';
 import { useAuthenticateUser } from '@/core/hooks/auth';
-import { useOrganizationTeams } from '@/core/hooks/organizations';
-import { activeTeamState, getTeamInvitationsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import {
+	useGetOrganizationTeamQuery,
+	useGetOrganizationTeamsQuery
+} from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
+import { useTeamMemberInvitation } from '@/core/hooks/organizations/teams/use-team-member-invitations';
+import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
 
 export const TeamMemberSection = () => {
 	const { isTeamManager, user } = useAuthenticateUser();
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const { getOrganizationTeamsLoading } = useOrganizationTeams();
-	const teamInvitations = useAtomValue(getTeamInvitationsState);
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, []);
+
+	const { isPending: getOrganizationTeamsLoading } = useGetOrganizationTeamsQuery();
+	const teamInvitations = useTeamMemberInvitation();
 	const members = activeTeam?.members || [];
 	// const style = { width: `${100 / members.length}%` };
 

--- a/apps/web/core/components/common/team-member.tsx
+++ b/apps/web/core/components/common/team-member.tsx
@@ -14,7 +14,7 @@ export const TeamMemberSection = () => {
 	const { isTeamManager, user } = useAuthenticateUser();
 
 	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
-	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, []);
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult?.data]);
 
 	const { isPending: getOrganizationTeamsLoading } = useGetOrganizationTeamsQuery();
 	const teamInvitations = useTeamMemberInvitation();

--- a/apps/web/core/components/daily-plan/all-plans-modal.tsx
+++ b/apps/web/core/components/daily-plan/all-plans-modal.tsx
@@ -1,25 +1,25 @@
-import { Modal, NoData, SpinnerLoader } from '@/core/components';
-import { Dispatch, memo, SetStateAction, useCallback, useMemo, useRef, useState } from 'react';
-import { clsxm } from '@/core/lib/utils';
-import { Text } from '@/core/components';
-import { ChevronRightIcon } from 'assets/svg';
-import { AddTasksEstimationHoursModal } from '../features/daily-plan/add-task-estimation-hours-modal';
-import { useDailyPlan } from '@/core/hooks';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { useIsMemberManager } from '@/core/hooks/organizations/teams/use-team-member';
-import { Button } from '@/core/components/duplicated-components/_button';
+import { Modal, NoData, SpinnerLoader, Text } from '@/core/components';
 import { Calendar } from '@/core/components/common/calendar';
-import moment from 'moment';
-import { ValueNoneIcon } from '@radix-ui/react-icons';
+import { Button } from '@/core/components/duplicated-components/_button';
+import { usePastPlans, useProfileDailyPlans } from '@/core/hooks/daily-plans/derived';
+import { useCreateDailyPlanMutation } from '@/core/hooks/daily-plans/mutations';
+import { useIsMemberManager } from '@/core/hooks/organizations/teams/use-team-member';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { checkPastDate } from '@/core/lib/helpers';
-import { useTranslations } from 'next-intl';
-import { ActiveModifiers } from 'react-day-picker';
-import { EverCard } from '../common/ever-card';
-import { Tooltip } from '../duplicated-components/tooltip';
-import { VerticalSeparator } from '../duplicated-components/separator';
+import { clsxm } from '@/core/lib/utils';
 import { EDailyPlanStatus } from '@/core/types/generics/enums/daily-plan';
 import { ERoleName } from '@/core/types/generics/enums/role';
 import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
+import { ValueNoneIcon } from '@radix-ui/react-icons';
+import { ChevronRightIcon } from 'assets/svg';
+import moment from 'moment';
+import { useTranslations } from 'next-intl';
+import { Dispatch, memo, SetStateAction, useCallback, useMemo, useRef, useState } from 'react';
+import { ActiveModifiers } from 'react-day-picker';
+import { EverCard } from '../common/ever-card';
+import { VerticalSeparator } from '../duplicated-components/separator';
+import { Tooltip } from '../duplicated-components/tooltip';
+import { AddTasksEstimationHoursModal } from '../features/daily-plan/add-task-estimation-hours-modal';
 
 interface IAllPlansModal {
 	closeModal: () => void;
@@ -51,8 +51,10 @@ export const AllPlansModal = memo(function AllPlansModal(props: IAllPlansModal) 
 	const [showCustomPlan, setShowCustomPlan] = useState(false);
 	const [customDate, setCustomDate] = useState<Date>(moment().toDate());
 
-	//  Use useDailyPlan with employeeId to get the correct employee's plans
-	const { profileDailyPlans, pastPlans, createDailyPlan, createDailyPlanLoading } = useDailyPlan(employeeId);
+	const profileDailyPlans = useProfileDailyPlans(employeeId ?? undefined);
+	const pastPlans = usePastPlans(employeeId ?? undefined);
+	const { mutateAsync: createDailyPlan, isPending: createDailyPlanLoading } = useCreateDailyPlanMutation();
+
 	const t = useTranslations();
 	const [navigationMode, setNavigationMode] = useState<TNavigationMode>('PLAN');
 	const sortedPlans = useMemo(

--- a/apps/web/core/components/daily-plan/all-plans.tsx
+++ b/apps/web/core/components/daily-plan/all-plans.tsx
@@ -1,23 +1,24 @@
 'use client';
-import { useAtomValue } from 'jotai';
-import { useEffect, useRef, useState, useMemo } from 'react';
 import { DragDropContext, Draggable, Droppable, DroppableProvided, DroppableStateSnapshot } from '@hello-pangea/dnd';
+import { useAtomValue } from 'jotai';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { formatDayPlanDate } from '@/core/lib/helpers/index';
-import { handleDragAndDrop } from '@/core/lib/helpers/drag-and-drop';
-import { FilterTabs, useDailyPlan } from '@/core/hooks';
-import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
-import { filterDailyPlan, filterDailyPlansByEmployee } from '@/core/hooks/daily-plans/use-filter-date-range';
-import { TDailyPlan, TUser } from '@/core/types/schemas';
-import { dailyPlanViewHeaderTabs } from '@/core/stores';
-import { clsxm } from '@/core/lib/utils';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/core/components/common/accordion';
-import TaskBlockCard from '@/core/components/tasks/task-block-card';
+import { HorizontalSeparator } from '@/core/components/duplicated-components/separator';
 import { LazyTaskCard } from '@/core/components/optimized-components';
 import DailyPlanTasksTableView from '@/core/components/tasks/daily-plan/table-view';
-import { HorizontalSeparator } from '@/core/components/duplicated-components/separator';
-import { PlanHeader } from './plan-header';
+import TaskBlockCard from '@/core/components/tasks/task-block-card';
+import { FilterTabs } from '@/core/hooks';
+import { useSortedPlan, useTodayPlan } from '@/core/hooks/daily-plans/derived';
+import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
+import { filterDailyPlan, filterDailyPlansByEmployee } from '@/core/hooks/daily-plans/use-filter-date-range';
+import { handleDragAndDrop } from '@/core/lib/helpers/drag-and-drop';
+import { formatDayPlanDate } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { dailyPlanViewHeaderTabs } from '@/core/stores';
+import { TDailyPlan, TUser } from '@/core/types/schemas';
 import { EmptyPlans } from './empty-plans';
+import { PlanHeader } from './plan-header';
 
 /**
  *
@@ -42,8 +43,9 @@ export function AllPlans({
 	const filteredPlans = useRef<TDailyPlan[]>([]);
 
 	// Use employeeId from props if provided, otherwise calculate from user
-	const targetEmployeeId = employeeId ?? user?.employee?.id ?? user?.employeeId ?? '';
-	const { sortedPlans, todayPlan } = useDailyPlan(targetEmployeeId);
+	const targetEmployeeId: string = employeeId ?? user?.employee?.id ?? user?.employeeId ?? '';
+	const sortedPlans = useSortedPlan(targetEmployeeId);
+	const todayPlan = useTodayPlan(targetEmployeeId);
 
 	const { date } = useDateRange(currentTab);
 
@@ -78,7 +80,7 @@ export function AllPlans({
 	useEffect(() => {
 		setDragPlans(plans);
 	}, [plans]);
-	if(!dragPlans) return null;
+	if (!dragPlans) return null;
 	return (
 		<div className="flex flex-col gap-6">
 			{Array.isArray(dragPlans) && dragPlans?.length > 0 ? (

--- a/apps/web/core/components/daily-plan/plan-header.tsx
+++ b/apps/web/core/components/daily-plan/plan-header.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { useCallback, useMemo, useState } from 'react';
 
 import { formatIntegerToHour, hoursToHMM, parseStringInputToHours } from '@/core/lib/helpers/index';
-import { FilterTabs, useAuthenticateUser, useDailyPlan, useCanSeeActivityScreen } from '@/core/hooks';
+import { FilterTabs, useAuthenticateUser, useCanSeeActivityScreen } from '@/core/hooks';
 import { TDailyPlan } from '@/core/types/schemas';
 import { clsxm } from '@/core/lib/utils';
 import { ReloadIcon } from '@radix-ui/react-icons';
@@ -17,13 +17,15 @@ import { Button } from '../duplicated-components/_button';
 import { AlertPopup } from '../common/alert-popup';
 import { toast } from 'sonner';
 import { useGetTimeLogs } from '@/core/hooks/activities/time-logs/use-get-time-logs';
+import { useDeleteDailyPlanMutation, useUpdateDailyPlanMutation } from '@/core/hooks/daily-plans/mutations';
 
 export function PlanHeader({ plan, planMode }: { plan: TDailyPlan; planMode: FilterTabs }) {
 	const [editTime, setEditTime] = useState<boolean>(false);
 	const [time, setTime] = useState<number>(plan.workTimePlanned || 0);
 	const [inputValue, setInputValue] = useState<string>(hoursToHMM(plan.workTimePlanned || 0));
 	const [popupOpen, setPopupOpen] = useState(false);
-	const { updateDailyPlan, updateDailyPlanLoading, deleteDailyPlan, deleteDailyPlanLoading } = useDailyPlan();
+	const { mutateAsync: updateDailyPlan, isPending: updateDailyPlanLoading } = useUpdateDailyPlanMutation();
+	const { mutateAsync: deleteDailyPlan, isPending: deleteDailyPlanLoading } = useDeleteDailyPlanMutation();
 	const { isTeamManager } = useAuthenticateUser();
 	const canSeeActivity = useCanSeeActivityScreen();
 	const t = useTranslations();
@@ -78,7 +80,10 @@ export function PlanHeader({ plan, planMode }: { plan: TDailyPlan; planMode: Fil
 			setTime(hours);
 
 			// Server requires employeeId in the payload, to correctly check permissions
-			await updateDailyPlan({ workTimePlanned: hours, employeeId: plan.employeeId || undefined }, plan.id ?? '');
+			await updateDailyPlan({
+				data: { workTimePlanned: hours, employeeId: plan.employeeId || undefined },
+				dailyPlanId: plan.id ?? ''
+			});
 
 			setEditTime(false);
 			toast.success('Plan updated successfully');

--- a/apps/web/core/components/duplicated-components/teams-dropdown.tsx
+++ b/apps/web/core/components/duplicated-components/teams-dropdown.tsx
@@ -1,21 +1,30 @@
+import { useCreateOrganizationTeam } from '@/core/hooks/organizations/teams/use-create-organization-team';
+import {
+	useGetOrganizationTeamQuery,
+	useGetOrganizationTeamsQuery
+} from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
+import { useSetActiveTeam } from '@/core/hooks/organizations/teams/use-set-active-team';
 import { imgTitle } from '@/core/lib/helpers/img-title';
+import { clsxm } from '@/core/lib/utils';
 import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { PlusIcon } from '@heroicons/react/24/solid';
-import { useState } from 'react';
-import { Spinner } from '../common/spinner';
 import { useTranslations } from 'next-intl';
-import { useOrganizationTeams } from '@/core/hooks/organizations';
-import { clsxm } from '@/core/lib/utils';
-import { activeTeamState, organizationTeamsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { useMemo, useState } from 'react';
+import { Spinner } from '../common/spinner';
+
 export const TeamsDropDown = () => {
 	const [edit, setEdit] = useState<boolean>(false);
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const teams = useAtomValue(organizationTeamsState);
-	const { setActiveTeam, getOrganizationTeamsLoading } = useOrganizationTeams();
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
+
+	const { data: teamsResult, isPending: getOrganizationTeamsLoading } = useGetOrganizationTeamsQuery();
+	const teams = useMemo(() => teamsResult?.data?.items ?? [], [teamsResult]);
+
+	const setActiveTeam = useSetActiveTeam();
+
 	const t = useTranslations();
 	return (
 		<div className="w-[290px] max-w-sm">
@@ -117,7 +126,8 @@ export const TeamsDropDown = () => {
 };
 
 function CreateNewTeam({ setEdit }: { setEdit: (value: React.SetStateAction<boolean>) => void }) {
-	const { createOTeamLoading, createOrganizationTeam } = useOrganizationTeams();
+	const { createOrganizationTeam, loading: createOTeamLoading } = useCreateOrganizationTeam();
+
 	const [error, setError] = useState<string | null>(null);
 	const t = useTranslations();
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {

--- a/apps/web/core/components/features/daily-plan/active-task-handler-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/active-task-handler-modal.tsx
@@ -1,15 +1,15 @@
 import { Modal, Text } from '@/core/components';
 import { Button } from '@/core/components/duplicated-components/_button';
+import { DEFAULT_PLANNED_TASK_ID } from '@/core/constants/config/constants';
+import { useDailyPlan, useTimerView } from '@/core/hooks';
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
+import { useSetActiveTask } from '@/core/hooks/organizations/teams/use-set-active-task';
 import { clsxm } from '@/core/lib/utils';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { RadioGroup } from '@headlessui/react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useMemo, useState } from 'react';
-import { useDailyPlan, useTeamTasks, useTimerView } from '@/core/hooks';
-import { RadioGroup } from '@headlessui/react';
-import { DEFAULT_PLANNED_TASK_ID } from '@/core/constants/config/constants';
 import { EverCard } from '../../common/ever-card';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtomValue } from 'jotai';
-import { activeTeamTaskState } from '@/core/stores';
 
 /**
  * A Modal that suggests the user to change the active task to a task from the today's plan.
@@ -33,8 +33,9 @@ export function ActiveTaskHandlerModal({
 	const t = useTranslations();
 	const { startTimer, hasPlan: todayPlan } = useTimerView();
 
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
-	const { setActiveTask } = useTeamTasks();
+	const { task: activeTeamTask } = useCurrentActiveTask();
+
+	const { setActiveTask } = useSetActiveTask();
 	// Use default useDailyPlan() so it targets the current user's own plans (todayPlan)
 	const { addTaskToPlan } = useDailyPlan();
 
@@ -52,7 +53,7 @@ export function ActiveTaskHandlerModal({
 				description: 'Change to planned default task',
 				action: async () => {
 					if (defaultPlannedTask) {
-						setActiveTask(defaultPlannedTask);
+						await setActiveTask(defaultPlannedTask);
 					}
 				}
 			},

--- a/apps/web/core/components/features/daily-plan/active-task-handler-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/active-task-handler-modal.tsx
@@ -1,7 +1,7 @@
 import { Modal, Text } from '@/core/components';
 import { Button } from '@/core/components/duplicated-components/_button';
 import { DEFAULT_PLANNED_TASK_ID } from '@/core/constants/config/constants';
-import { useDailyPlan, useTimerView } from '@/core/hooks';
+import { useTimerView } from '@/core/hooks';
 import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
 import { useSetActiveTask } from '@/core/hooks/organizations/teams/use-set-active-task';
 import { clsxm } from '@/core/lib/utils';
@@ -10,6 +10,7 @@ import { RadioGroup } from '@headlessui/react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useMemo, useState } from 'react';
 import { EverCard } from '../../common/ever-card';
+import { useAddTaskToPlanMutation } from '@/core/hooks/daily-plans/mutations';
 
 /**
  * A Modal that suggests the user to change the active task to a task from the today's plan.
@@ -36,8 +37,7 @@ export function ActiveTaskHandlerModal({
 	const { task: activeTeamTask } = useCurrentActiveTask();
 
 	const { setActiveTask } = useSetActiveTask();
-	// Use default useDailyPlan() so it targets the current user's own plans (todayPlan)
-	const { addTaskToPlan } = useDailyPlan();
+	const { mutateAsync: addTaskToPlan } = useAddTaskToPlanMutation();
 
 	const [selectedOption, setSelectedOption] = useState<number>();
 
@@ -63,16 +63,16 @@ export function ActiveTaskHandlerModal({
 				action: async () => {
 					try {
 						if (todayPlan && todayPlan.id && activeTeamTask) {
-							await addTaskToPlan(
-								{
+							await addTaskToPlan({
+								data: {
 									// Always use the plan owner for auto-assignment
 									// todayPlan comes from `useTimerView` which uses `useTimer` (current user's myDailyPlans)
 									// so this is effectively a "self-plan" scenario
 									employeeId: todayPlan.employeeId ?? undefined,
 									taskId: activeTeamTask.id
 								},
-								todayPlan.id
-							);
+								dailyPlanId: todayPlan.id
+							});
 						}
 
 						activeTeamTask &&
@@ -89,14 +89,14 @@ export function ActiveTaskHandlerModal({
 				action: async () => {
 					try {
 						if (todayPlan && todayPlan.id && activeTeamTask) {
-							await addTaskToPlan(
-								{
+							await addTaskToPlan({
+								dailyPlanId: todayPlan.id,
+								data: {
 									// Same rule here: assign the plan owner, not whoever clicked
 									employeeId: todayPlan.employeeId ?? undefined,
 									taskId: activeTeamTask.id
-								},
-								todayPlan.id
-							);
+								}
+							});
 						}
 						if (defaultPlannedTask) {
 							setActiveTask(defaultPlannedTask);

--- a/apps/web/core/components/features/daily-plan/add-daily-plan-work-hours-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/add-daily-plan-work-hours-modal.tsx
@@ -1,14 +1,13 @@
 import { Modal, SpinnerLoader, Text } from '@/core/components';
 import { Button } from '@/core/components/duplicated-components/_button';
-import { useCallback, useMemo, useState } from 'react';
 import { DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE } from '@/core/constants/config/constants';
 import { useDailyPlan, useTimerView } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
 import { useTranslations } from 'next-intl';
+import { useCallback, useMemo, useState } from 'react';
 import { EverCard } from '../../common/ever-card';
 import { InputField } from '../../duplicated-components/_input';
-import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
 
 interface IAddDailyPlanWorkHoursModalProps {
 	closeModal: () => void;
@@ -23,7 +22,7 @@ export function AddDailyPlanWorkHourModal(props: IAddDailyPlanWorkHoursModalProp
 	const { updateDailyPlan } = useDailyPlan();
 	const { startTimer } = useTimerView();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const [workTimePlanned, setworkTimePlanned] = useState<number | undefined>(plan.workTimePlanned);
 	const currentDate = useMemo(() => new Date().toISOString().split('T')[0], []);
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);

--- a/apps/web/core/components/features/daily-plan/add-daily-plan-work-hours-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/add-daily-plan-work-hours-modal.tsx
@@ -1,13 +1,14 @@
 import { Modal, SpinnerLoader, Text } from '@/core/components';
 import { Button } from '@/core/components/duplicated-components/_button';
 import { DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE } from '@/core/constants/config/constants';
-import { useDailyPlan, useTimerView } from '@/core/hooks';
+import { useTimerView } from '@/core/hooks';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
 import { useTranslations } from 'next-intl';
 import { useCallback, useMemo, useState } from 'react';
 import { EverCard } from '../../common/ever-card';
 import { InputField } from '../../duplicated-components/_input';
+import { useUpdateDailyPlanMutation } from '@/core/hooks/daily-plans/mutations';
 
 interface IAddDailyPlanWorkHoursModalProps {
 	closeModal: () => void;
@@ -19,7 +20,7 @@ export function AddDailyPlanWorkHourModal(props: IAddDailyPlanWorkHoursModalProp
 	const { closeModal, isOpen, plan } = props;
 
 	const t = useTranslations();
-	const { updateDailyPlan } = useDailyPlan();
+	const { mutateAsync: updateDailyPlan } = useUpdateDailyPlanMutation();
 	const { startTimer } = useTimerView();
 
 	const activeTeam = useCurrentTeam();
@@ -41,7 +42,10 @@ export function AddDailyPlanWorkHourModal(props: IAddDailyPlanWorkHoursModalProp
 			// Update the plan work time only if the user changed it
 			if (plan && plan.workTimePlanned !== workTimePlanned) {
 				// Server requires employeeId in the payload, to correctly check permissions
-				await updateDailyPlan({ workTimePlanned, employeeId: plan.employeeId || undefined }, plan.id ?? '');
+				await updateDailyPlan({
+					data: { workTimePlanned, employeeId: plan.employeeId || undefined },
+					dailyPlanId: plan.id ?? ''
+				});
 			}
 
 			startTimer();

--- a/apps/web/core/components/features/daily-plan/add-task-estimation-hours-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/add-task-estimation-hours-modal.tsx
@@ -2,7 +2,7 @@ import { Modal, SpinnerLoader, Text } from '@/core/components';
 import { Button } from '@/core/components/duplicated-components/_button';
 import { IconsErrorWarningFill } from '@/core/components/icons';
 import { DEFAULT_PLANNED_TASK_ID, TASKS_ESTIMATE_HOURS_MODAL_DATE } from '@/core/constants/config/constants';
-import { useDailyPlan, useModal, useTimerView } from '@/core/hooks';
+import { useModal, useTimerView } from '@/core/hooks';
 import { useCreateTaskMutation } from '@/core/hooks/organizations/teams/use-create-task.mutation';
 import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
 import { useSetActiveTask } from '@/core/hooks/organizations/teams/use-set-active-task';
@@ -36,6 +36,14 @@ import { TaskNameInfoDisplay } from '../../tasks/task-displays';
 import { TaskEstimate } from '../../tasks/task-estimate';
 import { ActiveTaskHandlerModal } from './active-task-handler-modal';
 import { UnplanActiveTaskModal } from './unplan-active-task-modal';
+import {
+	useAddTaskToPlanMutation,
+	useCreateDailyPlanMutation,
+	useRemoveTaskFromManyPlansMutation,
+	useRemoveTaskFromPlanMutation,
+	useUpdateDailyPlanMutation
+} from '@/core/hooks/daily-plans/mutations';
+import { useFuturePlans, useProfileDailyPlans, useTodayPlan } from '@/core/hooks/daily-plans/derived';
 
 /**
  * A modal that allows user to add task estimation / planned work time, etc.
@@ -80,10 +88,11 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 
 	const t = useTranslations();
 
-	// Use useDailyPlan with employeeId to get the correct employee's plans.
+	// Use useProfileDailyPlans with employeeId to get the correct employee's plans.
 	// NOTE: This replaces profileDailyPlanListState/myDailyPlanListState atoms
 	// so AllPlans modal and Profile "Plans" tab stay in sync
-	const { profileDailyPlans, updateDailyPlan } = useDailyPlan(employeeId);
+	const profileDailyPlans = useProfileDailyPlans(employeeId ?? undefined);
+	const { mutateAsync: updateDailyPlan } = useUpdateDailyPlanMutation();
 
 	// Get the updated plan from the hook instead of relying only on props
 	const plan = useMemo(() => {
@@ -179,7 +188,10 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 			// Update the plan work time only if the user changed it
 			if (plan && plan.workTimePlanned !== workTimePlanned) {
 				// Server requires employeeId in the payload, to correctly check permissions
-				await updateDailyPlan({ workTimePlanned, employeeId: plan.employeeId || undefined }, plan.id ?? '');
+				await updateDailyPlan({
+					dailyPlanId: plan.id ?? '',
+					data: { workTimePlanned, employeeId: plan.employeeId || undefined }
+				});
 				toast.success('Plan updated successfully', {
 					description: `Work time planned updated to ${workTimePlanned} hours`,
 					duration: 3000
@@ -234,7 +246,10 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 			// Update the plan work time only if the user changed it
 			if (plan && plan.workTimePlanned !== workTimePlanned) {
 				// Server requires employeeId in the payload, to correctly check permissions
-				await updateDailyPlan({ workTimePlanned, employeeId: plan.employeeId || undefined }, plan.id ?? '');
+				await updateDailyPlan({
+					data: { workTimePlanned, employeeId: plan.employeeId || undefined },
+					dailyPlanId: plan.id ?? ''
+				});
 				toast.success('Plan updated successfully', {
 					description: `Work time planned updated to ${workTimePlanned} hours`,
 					duration: 3000
@@ -835,7 +850,8 @@ function TaskCard(props: ITaskCardProps) {
 		canEdit = true
 	} = props;
 	const { setDetailedTaskId } = useDetailedTask();
-	const { addTaskToPlan, createDailyPlan } = useDailyPlan(employeeId);
+	const { mutateAsync: createDailyPlan } = useCreateDailyPlanMutation();
+	const { mutateAsync: addTaskToPlan } = useAddTaskToPlanMutation();
 	const { data: user } = useUserQuery();
 	const [addToPlanLoading, setAddToPlanLoading] = useState(false);
 
@@ -880,15 +896,15 @@ function TaskCard(props: ITaskCardProps) {
 					throw new Error('Cannot add task to plan without employeeId');
 				}
 
-				await addTaskToPlan(
-					{
+				await addTaskToPlan({
+					dailyPlanId: plan.id,
+					data: {
 						taskId: task.id,
 						// Use the plan owner, not the current user, to avoid incorrect auto-assignment when managers edit others' plans
 						employeeId: plan.employeeId,
 						organizationId: user?.employee?.organizationId
-					},
-					plan.id
-				);
+					}
+				});
 				toast.success('Task added to plan', {
 					description: `"${task.title}" has been added to your daily plan`,
 					duration: 3000
@@ -898,7 +914,7 @@ function TaskCard(props: ITaskCardProps) {
 			} else {
 				const planDate = plan ? plan.date : selectedDate;
 
-				if (planDate && employeeId) {
+				if (planDate && employeeId && user?.tenantId) {
 					await createDailyPlan({
 						workTimePlanned: 0,
 						taskId: task.id,
@@ -1043,7 +1059,9 @@ interface ITaskCardActionsProps {
 function TaskCardActions(props: ITaskCardActionsProps) {
 	const { task, selectedPlan, openTaskDetailsModal, openUnplanActiveTaskModal, employeeId, canEdit = true } = props;
 	const { data: user } = useUserQuery();
-	const { futurePlans, todayPlan, removeTaskFromPlan, removeTaskFromPlanLoading } = useDailyPlan(employeeId);
+	const futurePlans = useFuturePlans(employeeId ?? undefined);
+	const todayPlan = useTodayPlan(employeeId ?? undefined);
+	const { mutateAsync: removeTaskFromPlan, isPending: removeTaskFromPlanLoading } = useRemoveTaskFromPlanMutation();
 
 	const { task: activeTeamTask } = useCurrentActiveTask();
 
@@ -1079,14 +1097,15 @@ function TaskCardActions(props: ITaskCardActionsProps) {
 						openUnplanActiveTaskModal();
 					} else {
 						if (selectedPlan?.id) {
-							await removeTaskFromPlan(
-								{
+							await removeTaskFromPlan({
+								dailyPlanId: selectedPlan?.id,
+								data: {
+									// @ts-ignore : check api payload !!
 									taskId: task.id,
 									employeeId: employeeId ?? user?.employee?.id,
 									organizationId: user?.employee?.organizationId
-								},
-								selectedPlan?.id
-							);
+								}
+							});
 							toast.success('Task removed from plan', {
 								description: `"${task.title}" has been removed from your daily plan`,
 								duration: 3000
@@ -1094,14 +1113,15 @@ function TaskCardActions(props: ITaskCardActionsProps) {
 						}
 					}
 				} else if (selectedPlan?.id) {
-					await removeTaskFromPlan(
-						{
+					await removeTaskFromPlan({
+						dailyPlanId: selectedPlan?.id,
+						data: {
+							// @ts-ignore : check api payload !!
 							taskId: task.id,
 							employeeId: employeeId ?? user?.employee?.id,
 							organizationId: user?.employee?.organizationId
-						},
-						selectedPlan?.id
-					);
+						}
+					});
 					toast.success('Task removed from plan', {
 						description: `"${task.title}" has been removed from your daily plan`,
 						duration: 3000
@@ -1251,7 +1271,9 @@ function UnplanTask(props: IUnplanTaskProps) {
 		canEdit = true
 	} = props;
 	const { data: user } = useUserQuery();
-	const { todayPlan, removeManyTaskPlans, removeManyTaskFromPlanLoading } = useDailyPlan(employeeId);
+	const todayPlan = useTodayPlan(employeeId ?? undefined);
+	const { mutateAsync: removeManyTaskPlans, isPending: removeManyTaskFromPlanLoading } =
+		useRemoveTaskFromManyPlansMutation();
 
 	const { task: activeTeamTask } = useCurrentActiveTask();
 
@@ -1277,28 +1299,28 @@ function UnplanTask(props: IUnplanTaskProps) {
 						openUnplanActiveTaskModal();
 						// TODO: Unplan from all plans after clicks 'YES'
 					} else {
-						await removeManyTaskPlans(
-							{
+						await removeManyTaskPlans({
+							data: {
 								plansIds: planIds,
 								employeeId: employeeId ?? user?.employee?.id,
 								organizationId: user?.employee?.organizationId
 							},
-							taskId!
-						);
+							taskId: taskId!
+						});
 						toast.success('Task removed from all plans', {
 							description: 'Task has been removed from all daily plans',
 							duration: 3000
 						});
 					}
 				} else {
-					await removeManyTaskPlans(
-						{
+					await removeManyTaskPlans({
+						data: {
 							plansIds: planIds,
 							employeeId: employeeId ?? user?.employee?.id,
 							organizationId: user?.employee?.organizationId
 						},
-						taskId
-					);
+						taskId: taskId
+					});
 					toast.success('Task removed from all plans', {
 						description: 'Task has been removed from all daily plans',
 						duration: 3000

--- a/apps/web/core/components/features/daily-plan/add-task-to-plan.tsx
+++ b/apps/web/core/components/features/daily-plan/add-task-to-plan.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Check } from 'lucide-react';
-import { useDailyPlan } from '@/core/hooks';
+import { useAuthenticateUser } from '@/core/hooks';
 import { EDailyPlanStatus } from '@/core/types/generics/enums/daily-plan';
 import {
 	Command,
@@ -24,6 +24,9 @@ import { InputField } from '../../duplicated-components/_input';
 import { IEmployee } from '@/core/types/interfaces/organization/employee';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
+import { useAddTaskToPlanMutation, useCreateDailyPlanMutation } from '@/core/hooks/daily-plans/mutations';
+import { useProfileDailyPlans } from '@/core/hooks/daily-plans/derived';
+import { useEmployeeDailyPlansQueryLazy } from '@/core/hooks/daily-plans/queries';
 export function AddTaskToPlan({
 	open,
 	closeModal,
@@ -35,9 +38,11 @@ export function AddTaskToPlan({
 	task: TTask;
 	employee?: IEmployee;
 }) {
-	// Use useDailyPlan with employee?.id to get the correct employee's plans
-	const { profileDailyPlans, createDailyPlan, addTaskToPlan, getEmployeeDayPlans, addTaskToPlanLoading } =
-		useDailyPlan(employee?.id ?? null);
+	const { getPlanByEmployeeId } = useEmployeeDailyPlansQueryLazy();
+	const { user } = useAuthenticateUser();
+	const profileDailyPlans = useProfileDailyPlans(employee?.id ?? undefined);
+	const { mutateAsync: createDailyPlan } = useCreateDailyPlanMutation();
+	const { mutateAsync: addTaskToPlan, isPending: addTaskToPlanLoading } = useAddTaskToPlanMutation();
 	const [selectedPlan, setSelectedPlan] = useState<TDailyPlan | null>(null);
 	const [newPlan, setNewPlan] = useState<boolean>(false);
 	const [date, setDate] = useState<Date>(new Date());
@@ -48,28 +53,29 @@ export function AddTaskToPlan({
 	}, []);
 
 	const onSubmit = useCallback(async () => {
-		newPlan
-			? createDailyPlan({
-					workTimePlanned: workTimePlanned,
+		if (newPlan && user?.tenantId)
+			await createDailyPlan({
+				workTimePlanned: workTimePlanned,
+				taskId: task.id,
+				date: moment(date).format('YYYY-MM-DD'),
+				status: EDailyPlanStatus.OPEN,
+				tenantId: employee?.tenantId,
+				employeeId: employee?.employeeId,
+				organizationId: employee?.organizationId
+			}).then(() => {
+				closeModal();
+			});
+		else if (!newPlan)
+			await addTaskToPlan({
+				dailyPlanId: selectedPlan?.id ?? '',
+				data: {
 					taskId: task.id,
-					date: moment(date).format('YYYY-MM-DD'),
-					status: EDailyPlanStatus.OPEN,
-					tenantId: employee?.tenantId,
 					employeeId: employee?.employeeId,
 					organizationId: employee?.organizationId
-				}).then(() => {
-					closeModal();
-				})
-			: addTaskToPlan(
-					{
-						taskId: task.id,
-						employeeId: employee?.employeeId,
-						organizationId: employee?.organizationId
-					},
-					selectedPlan?.id ?? ''
-				).then(() => {
-					closeModal();
-				});
+				}
+			}).then(() => {
+				closeModal();
+			});
 	}, [
 		addTaskToPlan,
 		closeModal,
@@ -87,8 +93,8 @@ export function AddTaskToPlan({
 	]);
 
 	useEffect(() => {
-		getEmployeeDayPlans(employee?.employeeId ?? '');
-	}, [employee?.employeeId, getEmployeeDayPlans]);
+		if (employee?.employeeId) getPlanByEmployeeId(employee?.employeeId ?? '');
+	}, [employee?.employeeId, getPlanByEmployeeId]);
 
 	return (
 		<Modal isOpen={open} closeModal={closeModal} className="w-[98%] md:w-[530px] relative">

--- a/apps/web/core/components/features/daily-plan/create-daily-plan-form-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/create-daily-plan-form-modal.tsx
@@ -1,12 +1,5 @@
-import { Dispatch, memo, SetStateAction, useCallback, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useDailyPlan } from '@/core/hooks';
 import { Modal, Text } from '@/core/components';
-import { imgTitle, tomorrowDate, yesterdayDate } from '@/core/lib/helpers/index';
-import { ReloadIcon } from '@radix-ui/react-icons';
-import moment from 'moment';
 import { Calendar } from '@/core/components/common/calendar';
-import { Button } from '@/core/components/duplicated-components/_button';
 import {
 	Command,
 	CommandEmpty,
@@ -16,19 +9,26 @@ import {
 	CommandList
 } from '@/core/components/common/command';
 import { ScrollArea } from '@/core/components/common/scroll-bar';
-import { clsxm, isValidUrl } from '@/core/lib/utils';
-import stc from 'string-to-color';
-import { Check, ChevronDown } from 'lucide-react';
-import { cn } from '@/core/lib/helpers';
+import { Button } from '@/core/components/duplicated-components/_button';
 import { LAST_OPTION__CREATE_DAILY_PLAN_MODAL } from '@/core/constants/config/constants';
+import { useDailyPlan } from '@/core/hooks';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { cn } from '@/core/lib/helpers';
+import { imgTitle, tomorrowDate, yesterdayDate } from '@/core/lib/helpers/index';
+import { clsxm, isValidUrl } from '@/core/lib/utils';
+import { EDailyPlanMode, EDailyPlanStatus } from '@/core/types/generics/enums/daily-plan';
+import { TDailyPlan, TOrganizationTeam, TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { ReloadIcon } from '@radix-ui/react-icons';
+import { Check, ChevronDown } from 'lucide-react';
+import moment from 'moment';
 import { useTranslations } from 'next-intl';
+import { Dispatch, memo, SetStateAction, useCallback, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import stc from 'string-to-color';
 import { EverCard } from '../../common/ever-card';
 import { Avatar } from '../../duplicated-components/avatar';
-import { EDailyPlanStatus, EDailyPlanMode } from '@/core/types/generics/enums/daily-plan';
-import { TDailyPlan, TOrganizationTeam, TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { useAtomValue } from 'jotai';
-import { activeTeamManagersState, activeTeamState } from '@/core/stores';
 
 export function CreateDailyPlanFormModal({
 	open,
@@ -48,9 +48,9 @@ export function CreateDailyPlanFormModal({
 	const { handleSubmit, reset } = useForm();
 	const { data: user } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
 	// Use useDailyPlan with employeeId to get the correct employee's plans
 	const { profileDailyPlans, createDailyPlan, createDailyPlanLoading } = useDailyPlan(employeeId ?? null);

--- a/apps/web/core/components/features/daily-plan/create-daily-plan-form-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/create-daily-plan-form-modal.tsx
@@ -11,7 +11,6 @@ import {
 import { ScrollArea } from '@/core/components/common/scroll-bar';
 import { Button } from '@/core/components/duplicated-components/_button';
 import { LAST_OPTION__CREATE_DAILY_PLAN_MODAL } from '@/core/constants/config/constants';
-import { useDailyPlan } from '@/core/hooks';
 import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
@@ -29,6 +28,8 @@ import { useForm } from 'react-hook-form';
 import stc from 'string-to-color';
 import { EverCard } from '../../common/ever-card';
 import { Avatar } from '../../duplicated-components/avatar';
+import { useCreateDailyPlanMutation } from '@/core/hooks/daily-plans/mutations';
+import { useProfileDailyPlans } from '@/core/hooks/daily-plans/derived';
 
 export function CreateDailyPlanFormModal({
 	open,
@@ -52,8 +53,10 @@ export function CreateDailyPlanFormModal({
 
 	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
-	// Use useDailyPlan with employeeId to get the correct employee's plans
-	const { profileDailyPlans, createDailyPlan, createDailyPlanLoading } = useDailyPlan(employeeId ?? null);
+	// Use useProfileDailyPlans with employeeId to get the correct employee's plans
+	const profileDailyPlans = useProfileDailyPlans(employeeId ?? undefined);
+	const { mutateAsync: createDailyPlan, isPending: createDailyPlanLoading } = useCreateDailyPlanMutation();
+
 	const latestOption: 'Select' | 'Select & Close' | null = window.localStorage.getItem(
 		LAST_OPTION__CREATE_DAILY_PLAN_MODAL
 	) as 'Select' | 'Select & Close';
@@ -104,24 +107,25 @@ export function CreateDailyPlanFormModal({
 	const onSubmit = useCallback(
 		async (values: any) => {
 			const toDay = new Date();
-			createDailyPlan({
-				workTimePlanned: parseInt(values.workTimePlanned) || 0,
-				taskId,
-				date: String(
-					planMode == 'today'
-						? toDay
-						: planMode == 'tomorrow'
-							? tomorrowDate
-							: new Date(moment(date).format('YYYY-MM-DD'))
-				),
-				status: EDailyPlanStatus.OPEN,
-				tenantId: user?.tenantId ?? '',
-				employeeId: employeeId ?? selectedEmployee?.employeeId ?? undefined,
-				organizationId: user?.employee?.organizationId
-			}).then(() => {
-				reset();
-				setIsOpen(false);
-			});
+			if (user?.tenantId)
+				createDailyPlan({
+					workTimePlanned: parseInt(values.workTimePlanned) || 0,
+					taskId,
+					date: String(
+						planMode == 'today'
+							? toDay
+							: planMode == 'tomorrow'
+								? tomorrowDate
+								: new Date(moment(date).format('YYYY-MM-DD'))
+					),
+					status: EDailyPlanStatus.OPEN,
+					tenantId: user?.tenantId ?? '',
+					employeeId: employeeId ?? selectedEmployee?.employeeId ?? undefined,
+					organizationId: user?.employee?.organizationId
+				}).then(() => {
+					reset();
+					setIsOpen(false);
+				});
 		},
 		[
 			createDailyPlan,

--- a/apps/web/core/components/features/daily-plan/daily-plan-compare-estimate-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/daily-plan-compare-estimate-modal.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Separator from '@/core/components/common/separator';
 import { TaskNameInfoDisplay } from '../../tasks/task-displays';
 import { clsxm } from '@/core/lib/utils';
-import { useDailyPlan, useTeamMemberCard, useTimer, useTMCardTaskEdit } from '@/core/hooks';
+import { useTeamMemberCard, useTimer, useTMCardTaskEdit } from '@/core/hooks';
 import { dailyPlanCompareEstimated } from '@/core/lib/helpers/daily-plan-estimated';
 import { secondsToTime } from '@/core/lib/helpers/index';
 import { DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE } from '@/core/constants/config/constants';
@@ -15,6 +15,7 @@ import { TimePicker, TimePickerValue } from '../../duplicated-components/time-pi
 import { EverCard } from '../../common/ever-card';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
+import { useUpdateDailyPlanMutation } from '@/core/hooks/daily-plans/mutations';
 
 export interface IDailyPlanCompareEstimated {
 	difference?: boolean;
@@ -34,7 +35,8 @@ export function DailyPlanCompareEstimatedModal({
 	profile: any;
 }) {
 	const { difference, workTimePlanned, estimated, plan } = dailyPlanCompareEstimated(todayPlan);
-	const { updateDailyPlan, updateDailyPlanLoading } = useDailyPlan();
+
+	const { mutateAsync: updateDailyPlan, isPending: updateDailyPlanLoading } = useUpdateDailyPlanMutation();
 	const { hours: dh, minutes: dm } = secondsToTime(workTimePlanned || 0);
 	const { startTimer } = useTimer();
 	const hour = dh.toString()?.padStart(2, '0');
@@ -45,8 +47,8 @@ export function DailyPlanCompareEstimatedModal({
 		minute: '--'
 	});
 
-	const onClick = () => {
-		updateDailyPlan({ workTimePlanned: parseInt(times.hours) }, plan?.id ?? '');
+	const onClick = async () => {
+		await updateDailyPlan({ data: { workTimePlanned: parseInt(times.hours) }, dailyPlanId: plan?.id ?? '' });
 		if (!updateDailyPlanLoading) {
 			startTimer();
 			closeModal();

--- a/apps/web/core/components/features/daily-plan/enforce-planed-task-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/enforce-planed-task-modal.tsx
@@ -1,12 +1,11 @@
-import { useAuthenticateUser, useDailyPlan, useTimer } from '@/core/hooks';
 import { Button, Modal, Text } from '@/core/components';
+import { useAuthenticateUser, useDailyPlan, useTimer } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useTranslations } from 'next-intl';
 import { ReactNode, useCallback, useMemo } from 'react';
 import { EverCard } from '../../common/ever-card';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
 
 interface IEnforcePlannedTaskModalProps {
 	open: boolean;
@@ -26,7 +25,7 @@ export function EnforcePlanedTaskModal(props: IEnforcePlannedTaskModalProps) {
 
 	const { hasPlan } = useTimer();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 

--- a/apps/web/core/components/features/daily-plan/enforce-planed-task-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/enforce-planed-task-modal.tsx
@@ -1,11 +1,12 @@
 import { Button, Modal, Text } from '@/core/components';
-import { useAuthenticateUser, useDailyPlan, useTimer } from '@/core/hooks';
+import { useAuthenticateUser, useTimer } from '@/core/hooks';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useTranslations } from 'next-intl';
 import { ReactNode, useCallback, useMemo } from 'react';
 import { EverCard } from '../../common/ever-card';
+import { useAddTaskToPlanMutation } from '@/core/hooks/daily-plans/mutations';
 
 interface IEnforcePlannedTaskModalProps {
 	open: boolean;
@@ -19,7 +20,7 @@ interface IEnforcePlannedTaskModalProps {
 
 export function EnforcePlanedTaskModal(props: IEnforcePlannedTaskModalProps) {
 	const { closeModal, task, open, plan, content, onOK, openDailyPlanModal } = props;
-	const { addTaskToPlan, addTaskToPlanLoading } = useDailyPlan();
+	const { mutateAsync: addTaskToPlan, isPending: addTaskToPlanLoading } = useAddTaskToPlanMutation();
 	const { user } = useAuthenticateUser();
 	const t = useTranslations();
 
@@ -40,15 +41,15 @@ export function EnforcePlanedTaskModal(props: IEnforcePlannedTaskModalProps) {
 
 	const handleAddTaskToPlan = useCallback(() => {
 		if (user?.employee && task && plan.id && plan.employeeId) {
-			addTaskToPlan(
-				{
+			addTaskToPlan({
+				data: {
 					taskId: task.id,
 					// Always assign the plan owner, never fall back to the current user
 					employeeId: plan.employeeId,
 					organizationId: plan.organizationId ?? user.employee.organizationId
 				},
-				plan.id
-			).then(() => {
+				dailyPlanId: plan.id
+			}).then(() => {
 				closeModal();
 				if (requirePlan) {
 					if (hasWorkedHours && areAllTasksEstimated && task.estimate) {

--- a/apps/web/core/components/features/daily-plan/suggest-daily-plan-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/suggest-daily-plan-modal.tsx
@@ -1,18 +1,17 @@
 import { Modal, Text } from '@/core/components';
 import { Button } from '@/core/components/duplicated-components/_button';
-import { useCallback, useMemo } from 'react';
 import {
 	DAILY_PLAN_SUGGESTION_MODAL_DATE,
 	HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL
 } from '@/core/constants/config/constants';
+import { useTimer } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { useTimer } from '@/core/hooks';
 import { usePathname } from 'next/navigation';
+import { useCallback, useMemo } from 'react';
 import { EverCard } from '../../common/ever-card';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
 interface ISuggestDailyPlanModalProps {
 	closeModal: () => void;
@@ -23,7 +22,7 @@ export function SuggestDailyPlanModal(props: ISuggestDailyPlanModalProps) {
 	const { isOpen, closeModal } = props;
 	const { hasPlan } = useTimer();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 	const name = useMemo(
 		() => user?.name || user?.firstName || user?.lastName || user?.username || '',

--- a/apps/web/core/components/features/daily-plan/unplan-active-task-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/unplan-active-task-modal.tsx
@@ -1,4 +1,4 @@
-import { useDailyPlan, useTimerView } from '@/core/hooks';
+import { useTimerView } from '@/core/hooks';
 import { Button, Modal, Text } from '@/core/components';
 import { useCallback } from 'react';
 import { EverCard } from '../../common/ever-card';
@@ -6,6 +6,7 @@ import { TTask } from '@/core/types/schemas/task/task.schema';
 import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
 import { useAtomValue } from 'jotai';
 import { timerStatusState } from '@/core/stores';
+import { useRemoveTaskFromPlanMutation } from '@/core/hooks/daily-plans/mutations';
 
 interface UnplanActiveTaskModalProps {
 	open: boolean;
@@ -29,7 +30,7 @@ export function UnplanActiveTaskModal(props: UnplanActiveTaskModalProps) {
 	const { closeModal, task, open, plan } = props;
 	const timerStatus = useAtomValue(timerStatusState);
 
-	const { removeTaskFromPlan, removeTaskFromPlanLoading } = useDailyPlan();
+	const { mutateAsync: removeTaskFromPlan, isPending: removeTaskFromPlanLoading } = useRemoveTaskFromPlanMutation();
 	const { stopTimer } = useTimerView();
 
 	const handleCloseModal = useCallback(() => {
@@ -42,14 +43,15 @@ export function UnplanActiveTaskModal(props: UnplanActiveTaskModalProps) {
 		// other employees' plans as well
 		try {
 			if (plan.id) {
-				await removeTaskFromPlan(
-					{
+				await removeTaskFromPlan({
+					data: {
+						// @ts-ignore
 						taskId: task.id,
 						employeeId: plan.employeeId ?? undefined,
 						organizationId: plan.organizationId
 					},
-					plan.id
-				);
+					dailyPlanId: plan.id
+				});
 			}
 		} catch (error) {
 			console.log(error);

--- a/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
+++ b/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
@@ -10,18 +10,18 @@ import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 're
 import { DatePicker } from '@/core/components/common/date-picker';
 import { manualTimeReasons } from '@/core/constants/config/constants';
 import { useManualTime } from '@/core/hooks/activities/use-manual-time';
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
+import { useSortedTasksByCreation } from '@/core/hooks/organizations/teams/use-sorted-tasks';
 import { useIsMemberManager } from '@/core/hooks/organizations/teams/use-team-member';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { clsxm } from '@/core/lib/utils';
-import { activeTeamTaskState, tasksByTeamState } from '@/core/stores';
 import { IAddManualTimeRequest } from '@/core/types/interfaces/timer/time-slot/time-slot';
 import { TOrganizationTeam } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtomValue } from 'jotai';
 import { CustomSelect } from '../../common/multiple-select';
 import { getNestedValue, Item, ManageOrMemberComponent } from '../../teams/manage-member-component';
-import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
 
 /**
  * Interface for the properties of the `AddManualTimeModal` component.
@@ -55,8 +55,9 @@ export function AddManualTimeModal(props: Readonly<IAddManualTimeModalProps>) {
 	const [taskId, setTaskId] = useState<string>('');
 	const [timeDifference, setTimeDifference] = useState<string>('');
 
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
-	const tasks = useAtomValue(tasksByTeamState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
+
+	const tasks = useSortedTasksByCreation();
 	const activeTeam = useCurrentTeam();
 	const { teams } = useOrganisationTeams();
 	const { data: user } = useUserQuery();
@@ -234,7 +235,7 @@ export function AddManualTimeModal(props: Readonly<IAddManualTimeModalProps>) {
 				return [];
 			}
 
-			const validTasks = tasks.filter(isValidTask);
+			const validTasks = tasks.filter((task) => isValidTask(task));
 			const teamFilteredTasks = validTasks.filter((task) => filterByTeam(task, teamId));
 
 			const finalFilteredTasks = isTeamManager

--- a/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
+++ b/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
@@ -1,25 +1,27 @@
 import '@/styles/style.css';
 
-import { format } from 'date-fns';
 import { Button, Modal } from '@/core/components';
 import { cn } from '@/core/lib/helpers';
+import { format } from 'date-fns';
 import { CalendarDays, Clock7 } from 'lucide-react';
 import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { DatePicker } from '@/core/components/common/date-picker';
 import { manualTimeReasons } from '@/core/constants/config/constants';
 import { useManualTime } from '@/core/hooks/activities/use-manual-time';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useIsMemberManager } from '@/core/hooks/organizations/teams/use-team-member';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { clsxm } from '@/core/lib/utils';
-import { DatePicker } from '@/core/components/common/date-picker';
-import { getNestedValue, Item, ManageOrMemberComponent } from '../../teams/manage-member-component';
-import { CustomSelect } from '../../common/multiple-select';
+import { activeTeamTaskState, tasksByTeamState } from '@/core/stores';
 import { IAddManualTimeRequest } from '@/core/types/interfaces/timer/time-slot/time-slot';
 import { TOrganizationTeam } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState, organizationTeamsState, tasksByTeamState } from '@/core/stores';
+import { CustomSelect } from '../../common/multiple-select';
+import { getNestedValue, Item, ManageOrMemberComponent } from '../../teams/manage-member-component';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
 
 /**
  * Interface for the properties of the `AddManualTimeModal` component.
@@ -55,8 +57,8 @@ export function AddManualTimeModal(props: Readonly<IAddManualTimeModalProps>) {
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const tasks = useAtomValue(tasksByTeamState);
-	const activeTeam = useAtomValue(activeTeamState);
-	const teams = useAtomValue(organizationTeamsState);
+	const activeTeam = useCurrentTeam();
+	const { teams } = useOrganisationTeams();
 	const { data: user } = useUserQuery();
 	const { isTeamManager } = useIsMemberManager(user);
 

--- a/apps/web/core/components/features/projects/add-or-edit-project/steps/review-summary.tsx
+++ b/apps/web/core/components/features/projects/add-or-edit-project/steps/review-summary.tsx
@@ -1,24 +1,25 @@
 import { Button } from '@/core/components';
-import { Fragment, ReactNode, useCallback, useMemo } from 'react';
 import { Calendar, Clipboard } from 'lucide-react';
-import { Thumbnail } from './basic-information-form';
 import moment from 'moment';
+import { Fragment, ReactNode, useCallback, useMemo } from 'react';
+import { Thumbnail } from './basic-information-form';
 
-import { IStepElementProps } from '../container';
-import { useLocale, useTranslations } from 'next-intl';
-import { useOrganizationProjects } from '@/core/hooks/organizations';
 import { VerticalSeparator } from '@/core/components/duplicated-components/separator';
-import { ERoleName } from '@/core/types/generics/enums/role';
-import { IProjectRelation } from '@/core/types/interfaces/project/organization-project';
-import { ETaskStatusName } from '@/core/types/generics/enums/task';
-import { EProjectBudgetType } from '@/core/types/generics/enums/project';
-import { EProjectBilling } from '@/core/types/generics/enums/project';
-import { TCreateProjectRequest, TTag } from '@/core/types/schemas';
 import { DEFAULT_USER_IMAGE_URL } from '@/core/constants/data/mock-data';
-import { ECurrencies } from '@/core/types/generics/enums/currency';
-import { activeTeamState, organizationProjectsState, organizationTeamsState, rolesState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { useOrganizationProjects } from '@/core/hooks/organizations';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { organizationProjectsState, rolesState } from '@/core/stores';
+import { ECurrencies } from '@/core/types/generics/enums/currency';
+import { EProjectBilling, EProjectBudgetType } from '@/core/types/generics/enums/project';
+import { ERoleName } from '@/core/types/generics/enums/role';
+import { ETaskStatusName } from '@/core/types/generics/enums/task';
+import { IProjectRelation } from '@/core/types/interfaces/project/organization-project';
+import { TCreateProjectRequest, TTag } from '@/core/types/schemas';
+import { useAtomValue } from 'jotai';
+import { useLocale, useTranslations } from 'next-intl';
+import { IStepElementProps } from '../container';
 
 export default function FinalReview(props: IStepElementProps) {
 	const { goToPrevious, finish, currentData: finalData, mode } = props;
@@ -30,7 +31,7 @@ export default function FinalReview(props: IStepElementProps) {
 		setOrganizationProjects
 	} = useOrganizationProjects();
 	const t = useTranslations();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const rolesFromApi = useAtomValue(rolesState);
 	const { data: user } = useUserQuery();
@@ -423,7 +424,7 @@ function TeamAndRelations(props: ITeamAndRelationsProps) {
 
 	const organizationProjects = useAtomValue(organizationProjectsState);
 
-	const teams = useAtomValue(organizationTeamsState);
+	const { teams } = useOrganisationTeams();
 
 	// Deduplicated list of all team members to prevent user duplication
 	const allMembers = useMemo(() => {

--- a/apps/web/core/components/features/projects/add-or-edit-project/steps/team-and-relations-form.tsx
+++ b/apps/web/core/components/features/projects/add-or-edit-project/steps/team-and-relations-form.tsx
@@ -1,18 +1,20 @@
 import { Button } from '@/core/components';
-import { CheckIcon, Plus, X, LockIcon } from 'lucide-react';
-import { FormEvent, useCallback, useState, useMemo } from 'react';
-import { Identifiable, Select, Thumbnail } from './basic-information-form';
-import { IStepElementProps } from '../container';
+import { ROLES } from '@/core/constants/config/constants';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { cn } from '@/core/lib/helpers';
-import { useTranslations } from 'next-intl';
 import { getInitialValue } from '@/core/lib/helpers/create-project';
+import { organizationProjectsState, rolesState } from '@/core/stores';
 import { EProjectRelation } from '@/core/types/generics/enums/project';
 import { ERoleName } from '@/core/types/generics/enums/role';
 import { TProjectRelation } from '@/core/types/schemas';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, organizationProjectsState, organizationTeamsState, rolesState } from '@/core/stores';
-import { ROLES } from '@/core/constants/config/constants';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { CheckIcon, LockIcon, Plus, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { FormEvent, useCallback, useMemo, useState } from 'react';
+import { IStepElementProps } from '../container';
+import { Identifiable, Select, Thumbnail } from './basic-information-form';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
 
 export default function TeamAndRelationsForm(props: IStepElementProps) {
 	const { goToNext, goToPrevious, currentData } = props;
@@ -30,8 +32,8 @@ export default function TeamAndRelationsForm(props: IStepElementProps) {
 
 	// Get teams for multi-select
 	const organizationProjects = useAtomValue(organizationProjectsState);
-	const allTeams = useAtomValue(organizationTeamsState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const { teams: allTeams } = useOrganisationTeams();
+	const activeTeam = useCurrentTeam();
 
 	// Filter available teams based on user role:
 	// - Admin: Can see all teams

--- a/apps/web/core/components/features/projects/quick-create-project-modal.tsx
+++ b/apps/web/core/components/features/projects/quick-create-project-modal.tsx
@@ -1,13 +1,14 @@
-import { useOrganizationProjects } from '@/core/hooks';
 import { Button, Modal, Text } from '@/core/components';
-import { useTranslations } from 'next-intl';
-import { useCallback, useEffect, useState } from 'react';
-import { InputField } from '../../duplicated-components/_input';
-import { EverCard } from '../../common/ever-card';
+import { useOrganizationProjects } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { isTeamManagerState } from '@/core/stores';
 import { TOrganizationProject } from '@/core/types/schemas';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, isTeamManagerState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useState } from 'react';
+import { EverCard } from '../../common/ever-card';
+import { InputField } from '../../duplicated-components/_input';
 
 interface IQuickCreateProjectModalProps {
 	open: boolean;
@@ -35,7 +36,7 @@ export function QuickCreateProjectModal(props: IQuickCreateProjectModalProps) {
 	const [name, setName] = useState('');
 
 	// Get active team and current user info
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const isTeamManager = useAtomValue(isTeamManagerState);
 	const { data: user } = useUserQuery();
 

--- a/apps/web/core/components/features/tasks/delete-task.tsx
+++ b/apps/web/core/components/features/tasks/delete-task.tsx
@@ -18,7 +18,7 @@ const DeleteTask = ({ isOpen, closeModal, task }: IInviteProps) => {
 			await updateTask({
 				taskData: { ...task, status: ETaskStatusName.CLOSED },
 				taskId: task?.id
-			}).then((task) => setActiveTask(task));
+			});
 		}
 		closeModal();
 		if (activeTeamTask?.id === task?.id) {

--- a/apps/web/core/components/features/tasks/delete-task.tsx
+++ b/apps/web/core/components/features/tasks/delete-task.tsx
@@ -1,23 +1,24 @@
 import { Spinner } from '@/core/components/common/spinner';
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
+import { useSetActiveTask } from '@/core/hooks/organizations/teams/use-set-active-task';
+import { useUpdateTaskMutation } from '@/core/hooks/organizations/teams/use-update-task.mutation';
+import { ETaskStatusName } from '@/core/types/generics/enums/task';
 import { Dialog, DialogPanel, Transition, TransitionChild } from '@headlessui/react';
 import { useTranslations } from 'next-intl';
 import { useCallback } from 'react';
-import { useTeamTasks } from '@/core/hooks/organizations';
 import { IInviteProps } from '../teams/invite-modal';
-import { ETaskStatusName } from '@/core/types/generics/enums/task';
-import { useAtomValue } from 'jotai';
-import { activeTeamTaskState } from '@/core/stores';
 
 const DeleteTask = ({ isOpen, closeModal, task }: IInviteProps) => {
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
-	const { updateTask, updateLoading, setActiveTask } = useTeamTasks();
+	const { task: activeTeamTask } = useCurrentActiveTask();
+	const { mutateAsync: updateTask, isPending: updateLoading } = useUpdateTaskMutation();
+	const { setActiveTask } = useSetActiveTask();
 	const t = useTranslations();
 	const handleChange = useCallback(async () => {
 		if (task) {
 			await updateTask({
-				...task,
-				status: ETaskStatusName.CLOSED
-			});
+				taskData: { ...task, status: ETaskStatusName.CLOSED },
+				taskId: task?.id
+			}).then((task) => setActiveTask(task));
 		}
 		closeModal();
 		if (activeTeamTask?.id === task?.id) {

--- a/apps/web/core/components/features/tasks/edit-task-modal.tsx
+++ b/apps/web/core/components/features/tasks/edit-task-modal.tsx
@@ -1,22 +1,23 @@
 import { Modal, statusColor } from '@/core/components';
-import { DatePickerFilter } from '../../pages/timesheet/timesheet-filter-date';
-import { FormEvent, useCallback, useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { clsxm } from '@/core/lib/utils';
-import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components/teams/manage-member-component';
-import { statusTable } from '../../timesheet/timesheet-action';
-import { ITimeLog } from '@/core/types/interfaces/timer/time-log/time-log';
-import { differenceBetweenHours, formatTimeFromDate, secondsToTime, toDate } from '@/core/lib/helpers/index';
-import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
 import { ToastAction } from '@/core/components/common/toast';
+import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components/teams/manage-member-component';
+import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { differenceBetweenHours, formatTimeFromDate, secondsToTime, toDate } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { organizationProjectsState } from '@/core/stores';
+import { ITimeLog } from '@/core/types/interfaces/timer/time-log/time-log';
 import { ReloadIcon } from '@radix-ui/react-icons';
 import { addMinutes, format, parseISO } from 'date-fns';
-import { Clock7 } from 'lucide-react';
-import { CustomSelect } from '../../common/multiple-select';
-import { TaskNameInfoDisplay } from '../../tasks/task-displays';
-import { toast } from 'sonner';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, organizationProjectsState } from '@/core/stores';
+import { Clock7 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { FormEvent, useCallback, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { CustomSelect } from '../../common/multiple-select';
+import { DatePickerFilter } from '../../pages/timesheet/timesheet-filter-date';
+import { TaskNameInfoDisplay } from '../../tasks/task-displays';
+import { statusTable } from '../../timesheet/timesheet-action';
 
 export interface IEditTaskModalProps {
 	isOpen: boolean;
@@ -26,7 +27,7 @@ export interface IEditTaskModalProps {
 export function EditTaskModal({ isOpen, closeModal, dataTimesheet }: IEditTaskModalProps) {
 	const organizationProjects = useAtomValue(organizationProjectsState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const t = useTranslations();
 	const { updateTimesheet, loadingUpdateTimesheet } = useTimesheet({});
 	const initialTimeRange = {

--- a/apps/web/core/components/features/teams/create-team-modal.tsx
+++ b/apps/web/core/components/features/teams/create-team-modal.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useOrganizationTeams } from '@/core/hooks';
 import { BackButton, Button, Modal, Text } from '@/core/components';
+import { useCreateOrganizationTeam } from '@/core/hooks/organizations/teams/use-create-organization-team';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
+import { timerStatusState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
 import { Dispatch, SetStateAction, useMemo, useState } from 'react';
 import { EverCard } from '../../common/ever-card';
 import { InputField } from '../../duplicated-components/_input';
-import { organizationTeamsState, timerStatusState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
 
 /**
  * Create team modal
@@ -27,14 +28,14 @@ export function CreateTeamModal({
 	const timerRunningStatus = useMemo(() => {
 		return Boolean(timerStatus?.running);
 	}, [timerStatus]);
-	const teams = useAtomValue(organizationTeamsState);
-	const { createOTeamLoading, createOrganizationTeam } = useOrganizationTeams();
+	const { teams } = useOrganisationTeams();
+	const { createOrganizationTeam, loading: createOTeamLoading } = useCreateOrganizationTeam();
 	const [error, setError] = useState<string | null>(null);
 
 	const [name, setName] = useState('');
 
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		console.log("Team Submit");
+		console.log('Team Submit');
 		e.preventDefault();
 		setError(null);
 		const form = new FormData(e.currentTarget);

--- a/apps/web/core/components/features/teams/create-team-modal.tsx
+++ b/apps/web/core/components/features/teams/create-team-modal.tsx
@@ -35,7 +35,6 @@ export function CreateTeamModal({
 	const [name, setName] = useState('');
 
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		console.log('Team Submit');
 		e.preventDefault();
 		setError(null);
 		const form = new FormData(e.currentTarget);

--- a/apps/web/core/components/features/teams/invite-form-modal.tsx
+++ b/apps/web/core/components/features/teams/invite-form-modal.tsx
@@ -1,35 +1,37 @@
 'use client';
 
+import { BackButton, Button, Modal, Text } from '@/core/components';
+import { EverCard } from '@/core/components/common/ever-card';
+import { useTeamInvitations } from '@/core/hooks/organizations';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useTeamMemberInvitation } from '@/core/hooks/organizations/teams/use-team-member-invitations';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { rolesState, workingEmployeesState } from '@/core/stores';
+import { ERoleName } from '@/core/types/generics/enums/role';
 import { AxiosError } from 'axios';
 import { isEmail, isNotEmpty } from 'class-validator';
-import { BackButton, Button, Modal, Text } from '@/core/components';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
-import { InviteEmailDropdown } from '../../teams/invite/invite-email-dropdown';
-import { useTeamInvitations } from '@/core/hooks/organizations';
-import { EverCard } from '@/core/components/common/ever-card';
-import { InputField } from '../../duplicated-components/_input';
-import { IInviteEmail } from '../../teams/invite/invite-email-item';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '../../common/select';
-import { useAtomValue } from 'jotai';
-import { activeTeamState, getTeamInvitationsState, rolesState, workingEmployeesState } from '@/core/stores';
-import { ERoleName } from '@/core/types/generics/enums/role';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { InputField } from '../../duplicated-components/_input';
+import { InviteEmailDropdown } from '../../teams/invite/invite-email-dropdown';
+import { IInviteEmail } from '../../teams/invite/invite-email-item';
 
 export function InviteFormModal({ open, closeModal }: { open: boolean; closeModal: () => void }) {
 	const { data: user } = useUserQuery();
 	const roles = useAtomValue(rolesState);
 	const t = useTranslations();
 
-	const teamInvitations = useAtomValue(getTeamInvitationsState);
+	const teamInvitations = useTeamMemberInvitation();
 	const { inviteUser, inviteLoading, resendTeamInvitation, resendInviteLoading } = useTeamInvitations();
 
 	const [errors, setErrors] = useState<{ email?: string; name?: string; role?: string }>({});
 	const [selectedEmail, setSelectedEmail] = useState<IInviteEmail>();
 	const workingEmployees = useAtomValue(workingEmployeesState);
 	const [currentOrgEmails, setCurrentOrgEmails] = useState<IInviteEmail[]>([]);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const nameInputRef = useRef<HTMLInputElement>(null);
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 	const isLoading = inviteLoading || resendInviteLoading;

--- a/apps/web/core/components/features/teams/request-to-join-modal.tsx
+++ b/apps/web/core/components/features/teams/request-to-join-modal.tsx
@@ -1,18 +1,17 @@
 'use client';
 
-import { useAuthenticationPasscode, useRequestToJoinTeam } from '@/core/hooks';
-import { clsxm } from '@/core/lib/utils';
 import { Button, Modal, SpinnerLoader, Text } from '@/core/components';
-import { useCallback, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { ArrowLeftIcon } from 'assets/svg';
 import { AuthCodeInputField } from '@/core/components/auth/auth-code-input';
 import { EverCard } from '@/core/components/common/ever-card';
 import { InputField } from '@/core/components/duplicated-components/_input';
-import { PositionDropDown } from '../../layouts/default-layout/header/position-dropdown';
+import { useAuthenticationPasscode, useRequestToJoinTeam } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { clsxm } from '@/core/lib/utils';
 import { TJoinTeamRequest } from '@/core/types/schemas';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { ArrowLeftIcon } from 'assets/svg';
+import { useTranslations } from 'next-intl';
+import { useCallback, useState } from 'react';
+import { PositionDropDown } from '../../layouts/default-layout/header/position-dropdown';
 
 export const RequestToJoinModal = ({ open, closeModal }: { open: boolean; closeModal: () => void }) => {
 	const [currentTab, setCurrentTab] = useState<'ALREADY_MEMBER' | 'BECOME_MEMBER'>('ALREADY_MEMBER');
@@ -155,7 +154,7 @@ const BecomeMember = ({ closeModal }: { closeModal: any }) => {
 	const t = useTranslations();
 	const { formValues, setFormValues, errors, setErrors, sendCodeLoading, inputCodeRef } = useAuthenticationPasscode();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const {
 		requestToJoinTeam,
 		validateRequestToJoinTeam,

--- a/apps/web/core/components/features/teams/transfer-team-modal.tsx
+++ b/apps/web/core/components/features/teams/transfer-team-modal.tsx
@@ -1,23 +1,25 @@
-import { useOrganizationTeams } from '@/core/hooks';
-import { activeTeamManagersState, activeTeamState } from '@/core/stores';
 import { BackButton, Button, Modal, Text } from '@/core/components';
-import { useCallback, useState } from 'react';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { IOrganizationTeamEmployee } from '@/core/types/interfaces/team/organization-team-employee';
 import { useTranslations } from 'next-intl';
-import { useAtomValue } from 'jotai';
+import { useCallback, useState } from 'react';
 import { EverCard } from '../../common/ever-card';
 import { TransferTeamDropdown } from '../../teams/transfer-team/transfer-team-dropdown';
-import { IOrganizationTeamEmployee } from '@/core/types/interfaces/team/organization-team-employee';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useEditOrganizationTeamMutation } from '@/core/hooks/organizations/teams/use-edit-organization-team-mutation';
 
 /**
  * Transfer team modal
  */
 export function TransferTeamModal({ open, closeModal }: { open: boolean; closeModal: () => void }) {
 	const t = useTranslations();
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
-	const { editOrganizationTeam, editOrganizationTeamLoading } = useOrganizationTeams();
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const { mutateAsync: editOrganizationTeam, isPending: editOrganizationTeamLoading } =
+		useEditOrganizationTeamMutation();
+
+	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 
 	const [selectedMember, setSelectedMember] = useState<IOrganizationTeamEmployee>();

--- a/apps/web/core/components/features/timesheet/add-mask-modal.tsx
+++ b/apps/web/core/components/features/timesheet/add-mask-modal.tsx
@@ -1,8 +1,3 @@
-import React, { useCallback, useMemo } from 'react';
-import { TranslationHooks, useTranslations } from 'next-intl';
-import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components/teams/manage-member-component';
-import { useTimelogFilterOptions } from '@/core/hooks';
-import { clsxm } from '@/core/lib/utils';
 import { Modal } from '@/core/components';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/core/components/common/accordion';
 import {
@@ -13,16 +8,22 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@/core/components/common/select';
+import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components/teams/manage-member-component';
+import { useTimelogFilterOptions } from '@/core/hooks';
 import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { toUTC } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { ETimeLogSource, ETimeLogType } from '@/core/types/generics/enums/timer';
 import { PlusIcon, ReloadIcon } from '@radix-ui/react-icons';
+import { useAtomValue } from 'jotai';
+import { TranslationHooks, useTranslations } from 'next-intl';
+import React, { useCallback, useMemo } from 'react';
 import { CustomSelect } from '../../common/multiple-select';
+import { DatePickerFilter } from '../../pages/timesheet/timesheet-filter-date';
 import { TaskNameInfoDisplay } from '../../tasks/task-displays';
 import { ToggleButton } from '../tasks/edit-task-modal';
-import { DatePickerFilter } from '../../pages/timesheet/timesheet-filter-date';
-import { ETimeLogType, ETimeLogSource } from '@/core/types/generics/enums/timer';
-import { useAtomValue } from 'jotai';
-import { activeTeamState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
 
 export interface IAddTaskModalProps {
 	isOpen: boolean;
@@ -54,7 +55,7 @@ export function AddTaskModal({ closeModal, isOpen }: IAddTaskModalProps) {
 	const { generateTimeOptions } = useTimelogFilterOptions();
 	const organizationProjects = useAtomValue(organizationProjectsState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { createTimesheet, loadingCreateTimesheet } = useTimesheet({});
 
 	const timeOptions = generateTimeOptions(5);

--- a/apps/web/core/components/features/timesheet/add-mask-modal.tsx
+++ b/apps/web/core/components/features/timesheet/add-mask-modal.tsx
@@ -12,9 +12,10 @@ import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components
 import { useTimelogFilterOptions } from '@/core/hooks';
 import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useSortedTasksByCreation } from '@/core/hooks/organizations/teams/use-sorted-tasks';
 import { toUTC } from '@/core/lib/helpers/index';
 import { clsxm } from '@/core/lib/utils';
-import { organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { organizationProjectsState } from '@/core/stores';
 import { ETimeLogSource, ETimeLogType } from '@/core/types/generics/enums/timer';
 import { PlusIcon, ReloadIcon } from '@radix-ui/react-icons';
 import { useAtomValue } from 'jotai';
@@ -51,7 +52,7 @@ interface FormState {
 }
 
 export function AddTaskModal({ closeModal, isOpen }: IAddTaskModalProps) {
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasksByCreation();
 	const { generateTimeOptions } = useTimelogFilterOptions();
 	const organizationProjects = useAtomValue(organizationProjectsState);
 

--- a/apps/web/core/components/integration/calendar/time-sheet-filter-popover.tsx
+++ b/apps/web/core/components/integration/calendar/time-sheet-filter-popover.tsx
@@ -1,9 +1,10 @@
-import { Button } from '@/core/components/duplicated-components/_button';
 import { Modal } from '@/core/components';
-import { statusOptions } from '@/core/constants/config/constants';
-import { MultiSelect } from '@/core/components/common/multi-select';
 import { Input } from '@/core/components/common/input';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
+import { MultiSelect } from '@/core/components/common/multi-select';
+import { Button } from '@/core/components/duplicated-components/_button';
+import { statusOptions } from '@/core/constants/config/constants';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { tasksByTeamState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
 interface TimeSheetFilterProps {
 	isOpen: boolean;
@@ -11,7 +12,7 @@ interface TimeSheetFilterProps {
 }
 
 export function TimeSheetFilter({ closeModal, isOpen }: TimeSheetFilterProps) {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const tasks = useAtomValue(tasksByTeamState);
 	// const [taskId, setTaskId] = useState<TTask | TTask[] | null>([]);

--- a/apps/web/core/components/integration/calendar/time-sheet-filter-popover.tsx
+++ b/apps/web/core/components/integration/calendar/time-sheet-filter-popover.tsx
@@ -4,8 +4,7 @@ import { MultiSelect } from '@/core/components/common/multi-select';
 import { Button } from '@/core/components/duplicated-components/_button';
 import { statusOptions } from '@/core/constants/config/constants';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
-import { tasksByTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { useSortedTasksByCreation } from '@/core/hooks/organizations/teams/use-sorted-tasks';
 interface TimeSheetFilterProps {
 	isOpen: boolean;
 	closeModal: () => void;
@@ -14,7 +13,7 @@ interface TimeSheetFilterProps {
 export function TimeSheetFilter({ closeModal, isOpen }: TimeSheetFilterProps) {
 	const activeTeam = useCurrentTeam();
 
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasksByCreation();
 	// const [taskId, setTaskId] = useState<TTask | TTask[] | null>([]);
 	return (
 		<>

--- a/apps/web/core/components/layouts/app-sidebar.tsx
+++ b/apps/web/core/components/layouts/app-sidebar.tsx
@@ -1,54 +1,55 @@
-import * as React from 'react';
 import {
+	AudioWaveform,
+	Command,
+	FolderKanban,
+	GalleryVerticalEnd,
+	LoaderCircle,
 	MonitorSmartphone,
 	SquareActivity,
-	X,
-	Command,
-	AudioWaveform,
-	GalleryVerticalEnd,
-	FolderKanban,
-	LoaderCircle
+	X
 } from 'lucide-react';
 import Image from 'next/image';
+import * as React from 'react';
 
 import {
 	Sidebar,
 	SidebarContent,
-	SidebarHeader,
-	SidebarRail,
-	SidebarTrigger,
-	useSidebar,
-	SidebarMenuSubButton,
 	SidebarFooter,
-	SidebarSeparator
+	SidebarHeader,
+	SidebarMenuSubButton,
+	SidebarRail,
+	SidebarSeparator,
+	SidebarTrigger,
+	useSidebar
 } from '@/core/components/common/sidebar';
-import Link from 'next/link';
+import { useFavorites, useModal } from '@/core/hooks';
 import { cn } from '@/core/lib/helpers';
 import { isValidProjectForDisplay, projectBelongsToTeam, projectHasNoTeams } from '@/core/lib/helpers/type-guards';
-import { useFavorites, useModal } from '@/core/hooks';
 import { useTranslations } from 'next-intl';
-import { SidebarOptInForm } from './sidebar-opt-in-form';
+import Link from 'next/link';
 import { useMemo } from 'react';
+import { WorkspacesSwitcher } from '../common/workspace-switcher';
 import { DashboardIcon, FavoriteIcon, HomeIcon, InboxIcon, SidebarTaskIcon } from '../icons';
 import { TaskIssueStatus } from '../tasks/task-issue';
-import { WorkspacesSwitcher } from '../common/workspace-switcher';
+import { SidebarOptInForm } from './sidebar-opt-in-form';
 // Import optimized components from centralized location
+import { ModalSkeleton } from '@/core/components/common/skeleton/modal-skeleton';
 import { LazySidebarCommandModal } from '@/core/components/optimized-components/common';
 import { LazyCreateTeamModal } from '@/core/components/optimized-components/teams';
-import { NavHome } from '../nav-home';
-import { NavMain } from './nav-main';
-import { Suspense } from 'react';
-import { ModalSkeleton } from '@/core/components/common/skeleton/modal-skeleton';
+import { APP_NAME } from '@/core/constants/config/constants';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { isTeamManagerState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { currentEmployeeFavoritesState } from '@/core/stores/common/favorites';
 import { EBaseEntityEnum } from '@/core/types/generics/enums/entity';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
-import { currentEmployeeFavoritesState } from '@/core/stores/common/favorites';
-import { activeTeamState, isTeamManagerState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { APP_NAME } from '@/core/constants/config/constants';
+import { Suspense } from 'react';
 import { GlobalAllPlansModal } from '../daily-plan';
-import { GlobalAssignTaskModal } from '../features/tasks/global-assign-task-modal';
 import { GlobalProjectActionModal } from '../features/projects/global-project-action-modal';
+import { GlobalAssignTaskModal } from '../features/tasks/global-assign-task-modal';
+import { NavHome } from '../nav-home';
+import { NavMain } from './nav-main';
 type AppSidebarProps = React.ComponentProps<typeof Sidebar> & { publicTeam: boolean | undefined };
 export function AppSidebar({ publicTeam, ...props }: AppSidebarProps) {
 	const { data: user } = useUserQuery();
@@ -61,7 +62,7 @@ export function AppSidebar({ publicTeam, ...props }: AppSidebarProps) {
 	const { isOpen, closeModal } = useModal();
 	const t = useTranslations();
 	const organizationProjects = useAtomValue(organizationProjectsState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	// Filter projects based on active team context:
 	// - "All Teams" mode (no active team): show ALL projects

--- a/apps/web/core/components/layouts/app-sidebar.tsx
+++ b/apps/web/core/components/layouts/app-sidebar.tsx
@@ -38,8 +38,9 @@ import { LazySidebarCommandModal } from '@/core/components/optimized-components/
 import { LazyCreateTeamModal } from '@/core/components/optimized-components/teams';
 import { APP_NAME } from '@/core/constants/config/constants';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useSortedTasksByCreation } from '@/core/hooks/organizations/teams/use-sorted-tasks';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { isTeamManagerState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { isTeamManagerState, organizationProjectsState } from '@/core/stores';
 import { currentEmployeeFavoritesState } from '@/core/stores/common/favorites';
 import { EBaseEntityEnum } from '@/core/types/generics/enums/entity';
 import { TTask } from '@/core/types/schemas/task/task.schema';
@@ -58,7 +59,7 @@ export function AppSidebar({ publicTeam, ...props }: AppSidebarProps) {
 	const isTeamManager = useAtomValue(isTeamManagerState);
 	const { state } = useSidebar();
 	const currentEmployeeFavorites = useAtomValue(currentEmployeeFavoritesState);
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasksByCreation();
 	const { isOpen, closeModal } = useModal();
 	const t = useTranslations();
 	const organizationProjects = useAtomValue(organizationProjectsState);

--- a/apps/web/core/components/pages/kanban/menu-kanban-card.tsx
+++ b/apps/web/core/components/pages/kanban/menu-kanban-card.tsx
@@ -1,9 +1,11 @@
 import { SpinnerLoader } from '@/core/components';
 import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
 import { PlanTask } from '@/core/components/tasks/task-card';
-import { useAuthenticateUser, useModal, useTeamMemberCard, useTeamTasks } from '@/core/hooks';
+import { useAuthenticateUser, useModal, useTeamMemberCard } from '@/core/hooks';
+import { useCreateTaskMutation } from '@/core/hooks/organizations/teams/use-create-task.mutation';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
-import { activeTeamTaskId, taskStatusesState } from '@/core/stores';
+import { useSetActiveTask } from '@/core/hooks/organizations/teams/use-set-active-task';
+import { taskStatusesState } from '@/core/stores';
 import { EDailyPlanMode } from '@/core/types/generics/enums/daily-plan';
 import { EIssueType, ETaskPriority } from '@/core/types/generics/enums/task';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
@@ -11,7 +13,7 @@ import { TTask } from '@/core/types/schemas/task/task.schema';
 import { Combobox, Transition } from '@headlessui/react';
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
 import { ThreeCircleOutlineVerticalIcon } from 'assets/svg';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
 import React, { JSX, useCallback } from 'react';
 import { HorizontalSeparator } from '../../duplicated-components/separator';
@@ -19,8 +21,9 @@ import { CreateDailyPlanFormModal } from '../../features/daily-plan/create-daily
 
 export default function MenuKanbanCard({ item: task, member }: { item: TTask; member: any }) {
 	const t = useTranslations();
-	const setActiveTask = useSetAtom(activeTeamTaskId);
-	const { createTask, createLoading } = useTeamTasks();
+	const { setActiveTask } = useSetActiveTask();
+
+	const { mutateAsync: createTask, isPending: createLoading } = useCreateTaskMutation();
 	const { assignTask, unassignTask, assignTaskLoading, unAssignTaskLoading } = useTeamMemberCard(member);
 	const taskStatuses = useAtomValue(taskStatusesState);
 	const { closeModal, isOpen, openModal } = useModal();
@@ -37,11 +40,7 @@ export default function MenuKanbanCard({ item: task, member }: { item: TTask; me
 			closable: true,
 			action: 'edit',
 			active: true,
-			onClick: () => {
-				setActiveTask({
-					id: task.id
-				});
-			}
+			onClick: () => setActiveTask(task)
 		},
 		{
 			name: t('common.ESTIMATE'),

--- a/apps/web/core/components/pages/kanban/menu-kanban-card.tsx
+++ b/apps/web/core/components/pages/kanban/menu-kanban-card.tsx
@@ -1,19 +1,20 @@
-import { useAuthenticateUser, useModal, useTeamMemberCard, useTeamTasks } from '@/core/hooks';
-import { activeTeamState, activeTeamTaskId, taskStatusesState } from '@/core/stores';
-import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
-import { ThreeCircleOutlineVerticalIcon } from 'assets/svg';
 import { SpinnerLoader } from '@/core/components';
+import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
 import { PlanTask } from '@/core/components/tasks/task-card';
-import { useTranslations } from 'next-intl';
-import { useAtomValue, useSetAtom } from 'jotai';
-import { Combobox, Transition } from '@headlessui/react';
-import React, { JSX, useCallback } from 'react';
-import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
-import { HorizontalSeparator } from '../../duplicated-components/separator';
+import { useAuthenticateUser, useModal, useTeamMemberCard, useTeamTasks } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { activeTeamTaskId, taskStatusesState } from '@/core/stores';
 import { EDailyPlanMode } from '@/core/types/generics/enums/daily-plan';
+import { EIssueType, ETaskPriority } from '@/core/types/generics/enums/task';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { EIssueType, ETaskPriority } from '@/core/types/generics/enums/task';
+import { Combobox, Transition } from '@headlessui/react';
+import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
+import { ThreeCircleOutlineVerticalIcon } from 'assets/svg';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
+import React, { JSX, useCallback } from 'react';
+import { HorizontalSeparator } from '../../duplicated-components/separator';
 import { CreateDailyPlanFormModal } from '../../features/daily-plan/create-daily-plan-form-modal';
 
 export default function MenuKanbanCard({ item: task, member }: { item: TTask; member: any }) {
@@ -25,7 +26,7 @@ export default function MenuKanbanCard({ item: task, member }: { item: TTask; me
 	const { closeModal, isOpen, openModal } = useModal();
 	const authUser = useAuthenticateUser();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	// Use the authenticated user's employee ID (prefer employeeId FK over employee.id relation)
 	const employeeId = authUser?.user?.employeeId ?? authUser?.user?.employee?.id ?? '';

--- a/apps/web/core/components/pages/kanban/team-members-kanban-view.tsx
+++ b/apps/web/core/components/pages/kanban/team-members-kanban-view.tsx
@@ -89,7 +89,7 @@ export const KanbanView = ({ kanbanBoardTasks, isLoading }: { kanbanBoardTasks: 
 		};
 
 		// update task status on the server
-		updateTaskStatus(updateTaskStatusData);
+		updateTaskStatus({ taskData: updateTaskStatusData, taskId: updateTaskStatusData?.id });
 
 		// insert into next
 		nextTaskStatus.splice(destinationIndex, 0, updateTaskStatusData);

--- a/apps/web/core/components/pages/permissions/page-component.tsx
+++ b/apps/web/core/components/pages/permissions/page-component.tsx
@@ -1,20 +1,21 @@
 'use client';
 
-import { activeTeamManagersState, rolesState } from '@/core/stores';
-import NotFound from '@/core/components/pages/404';
-import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { CommonToggle, Container, Divider, Text } from '@/core/components';
+import { withAuthentication } from '@/core/components/layouts/app/authenticator';
 import { MainHeader, MainLayout } from '@/core/components/layouts/default-layout';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { useAtomValue } from 'jotai';
-import { fullWidthState } from '@/core/stores/common/full-width';
+import NotFound from '@/core/components/pages/404';
 import { useIsMemberManager } from '@/core/hooks/organizations';
-import { useRolePermissions } from '@/core/hooks/roles';
-import { Breadcrumb } from '../../duplicated-components/breadcrumb';
-import { EverCard } from '../../common/ever-card';
-import { TRole } from '@/core/types/schemas';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useRolePermissions } from '@/core/hooks/roles';
+import { rolesState } from '@/core/stores';
+import { fullWidthState } from '@/core/stores/common/full-width';
+import { TRole } from '@/core/types/schemas';
+import { useAtomValue } from 'jotai';
+import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { EverCard } from '../../common/ever-card';
+import { Breadcrumb } from '../../duplicated-components/breadcrumb';
 
 const Permissions = () => {
 	// Translations
@@ -28,7 +29,7 @@ const Permissions = () => {
 	const [selectedRole, setSelectedRole] = useState<TRole | null>(null);
 
 	// Hooks with data fetching
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 	const { rolePermissionsFormated, getRolePermissions, updateRolePermission } = useRolePermissions();
 	const { isTeamManager } = useIsMemberManager(user);
 	const roles = useAtomValue(rolesState);

--- a/apps/web/core/components/pages/profile/screenshots/screenshot-details.tsx
+++ b/apps/web/core/components/pages/profile/screenshots/screenshot-details.tsx
@@ -1,16 +1,17 @@
 'use client';
 import { Modal } from '@/core/components';
-import ScreenshotItem from './screenshot-item';
-import { useTranslations } from 'next-intl';
-import React, { useCallback, useEffect, useState } from 'react';
-import { useTeamTasks } from '@/core/hooks';
-import Image from 'next/image';
-import { cn } from '@/core/lib/helpers';
 import { ProgressBar } from '@/core/components/duplicated-components/_progress-bar';
+import { useGetTaskByIdQueryLazy } from '@/core/hooks/organizations/teams/use-get-team-task.query';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
+import { cn } from '@/core/lib/helpers';
+import { organizationProjectsState } from '@/core/stores';
 import { TOrganizationProject, TTimeSlot } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
-import { organizationProjectsState } from '@/core/stores';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+import React, { useCallback, useEffect, useState } from 'react';
+import ScreenshotItem from './screenshot-item';
 
 const ScreenshotDetailsModal = ({
 	open,
@@ -44,7 +45,8 @@ const ScreenshotDetailsModal = ({
 	const [task, setTask] = useState<TTask | null>(null);
 	const organizationProjects = useAtomValue(organizationProjectsState);
 
-	const { getTaskById } = useTeamTasks();
+	const { setDetailedTaskId } = useDetailedTask();
+	const { getTaskById } = useGetTaskByIdQueryLazy();
 
 	const getProject = useCallback(
 		async (projectId: string) => {
@@ -61,6 +63,8 @@ const ScreenshotDetailsModal = ({
 		async (taskId: string) => {
 			const task = await getTaskById(taskId);
 			task && setTask(task as TTask);
+			// switch current focused task
+			setDetailedTaskId(taskId);
 		},
 		[getTaskById]
 	);

--- a/apps/web/core/components/pages/profile/task-filters.tsx
+++ b/apps/web/core/components/pages/profile/task-filters.tsx
@@ -21,7 +21,6 @@ import { TaskDatePickerWithRange } from '../../tasks/task-date-range';
 import { DateRange } from 'react-day-picker';
 import '@/styles/style.css';
 import { useTaskFilter } from '@/core/hooks/tasks/use-task-filter';
-import { useDailyPlan } from '@/core/hooks';
 import { VerticalSeparator } from '../../duplicated-components/separator';
 import { Tooltip } from '../../duplicated-components/tooltip';
 import { InputField } from '../../duplicated-components/_input';
@@ -29,6 +28,7 @@ import { IClassName } from '@/core/types/interfaces/common/class-name';
 import { TaskSizesDropdown } from '../../tasks/task-sizes-dropdown';
 import { LazyAddManualTimeModal } from '@/core/components/optimized-components';
 import { Suspense } from 'react';
+import { useFuturePlans, usePastPlans, useSortedPlan } from '@/core/hooks/daily-plans/derived';
 export type ITab = 'worked' | 'assigned' | 'unassigned' | 'dailyplan' | 'stats';
 
 export type I_TaskFilter = ReturnType<typeof useTaskFilter>;
@@ -228,8 +228,9 @@ export function TaskStatusFilter({ hook, employeeId }: { hook: I_TaskFilter; emp
 	// Use useLocalStorageState for consistent state management
 	const [dailyPlanTab] = useLocalStorageState<string>('daily-plan-tab', 'Future Tasks');
 
-	// Get plans data from useDailyPlan instead of useDateRange to avoid global atom conflicts
-	const { sortedPlans, futurePlans, pastPlans } = useDailyPlan(employeeId);
+	const sortedPlans = useSortedPlan(employeeId ?? undefined);
+	const futurePlans = useFuturePlans(employeeId ?? undefined);
+	const pastPlans = usePastPlans(employeeId ?? undefined);
 	const { date, setDate } = useDateRange(dailyPlanTab);
 
 	// Map tab names to their corresponding plan data

--- a/apps/web/core/components/pages/projects/project-detail/page-component.tsx
+++ b/apps/web/core/components/pages/projects/project-detail/page-component.tsx
@@ -1,46 +1,47 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
-import { useTranslations, useLocale } from 'next-intl';
-import { useAtomValue } from 'jotai';
-import Image from 'next/image';
-import moment from 'moment';
-import {
-	ArrowLeftIcon,
-	Calendar,
-	ExternalLink,
-	Users,
-	Banknote,
-	Tag,
-	Building2,
-	CircleDot,
-	Pencil,
-	Archive,
-	Trash,
-	RotateCcw,
-	MoreVertical,
-	ShieldAlert
-} from 'lucide-react';
 import { Menu, Transition } from '@headlessui/react';
+import { useQuery } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
+import {
+	Archive,
+	ArrowLeftIcon,
+	Banknote,
+	Building2,
+	Calendar,
+	CircleDot,
+	ExternalLink,
+	MoreVertical,
+	Pencil,
+	RotateCcw,
+	ShieldAlert,
+	Tag,
+	Trash,
+	Users
+} from 'lucide-react';
+import moment from 'moment';
+import { useLocale, useTranslations } from 'next-intl';
+import Image from 'next/image';
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useMemo } from 'react';
 
-import { MainLayout } from '@/core/components/layouts/default-layout';
 import { Container } from '@/core/components';
+import { ProjectDetailSkeleton } from '@/core/components/common/skeleton/projects';
+import { Button } from '@/core/components/duplicated-components/_button';
 import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
 import { HorizontalSeparator, VerticalSeparator } from '@/core/components/duplicated-components/separator';
-import { cn } from '@/core/lib/helpers';
-import { activeTeamState, isTrackingEnabledState } from '@/core/stores';
-import { fullWidthState } from '@/core/stores/common/full-width';
-import { organizationProjectService } from '@/core/services/client/api/organizations';
-import { queryKeys } from '@/core/query/keys';
-import { EProjectBilling, EProjectBudgetType } from '@/core/types/generics/enums/project';
-import { Button } from '@/core/components/duplicated-components/_button';
-import { ProjectDetailSkeleton } from '@/core/components/common/skeleton/projects';
-import { InfoItem, MemberCard, Section, StatusBadge } from './components';
+import { MainLayout } from '@/core/components/layouts/default-layout';
 import { useProjectPermissions } from '@/core/hooks/projects/use-project-permissions';
 import { useProjectActionModal } from '@/core/hooks/use-project-action-modal';
+import { cn } from '@/core/lib/helpers';
 import { projectBelongsToTeam, projectHasNoTeams } from '@/core/lib/helpers/type-guards';
+import { queryKeys } from '@/core/query/keys';
+import { organizationProjectService } from '@/core/services/client/api/organizations';
+import { isTrackingEnabledState } from '@/core/stores';
+import { fullWidthState } from '@/core/stores/common/full-width';
+import { EProjectBilling, EProjectBudgetType } from '@/core/types/generics/enums/project';
+import { InfoItem, MemberCard, Section, StatusBadge } from './components';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 export default function ProjectDetailPageComponent() {
 	const t = useTranslations();
@@ -51,7 +52,7 @@ export default function ProjectDetailPageComponent() {
 	const currentLocale = params?.locale;
 
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const fullWidth = useAtomValue(fullWidthState);
 
 	// Fetch project by ID

--- a/apps/web/core/components/pages/reports/weekly-limit/members-select.tsx
+++ b/apps/web/core/components/pages/reports/weekly-limit/members-select.tsx
@@ -6,10 +6,9 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@/core/components/common/select';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useTranslations } from 'next-intl';
 import { useCallback, useState } from 'react';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
 
 interface IProps {
 	onChange: (value: string) => void;
@@ -29,7 +28,7 @@ interface IProps {
 export function MembersSelect(props: IProps) {
 	const { onChange } = props;
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const [selected, setSelected] = useState<string>('all');
 	const t = useTranslations();
 	const handleChange = useCallback(

--- a/apps/web/core/components/pages/settings/personal/danger-zone-personal.tsx
+++ b/apps/web/core/components/pages/settings/personal/danger-zone-personal.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { useModal, useOrganizationTeams, useUser } from '@/core/hooks';
+import { useModal, useUser } from '@/core/hooks';
 import { Button, Text } from '@/core/components';
 import Image from 'next/image';
 import { useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { RemoveModal } from '../../../settings/remove-modal';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useRemoveUserFromAllTeamMutation } from '@/core/hooks/organizations/teams/use-remove-user-from-all-team-mutation';
 type RemoveModalType = 'REMOVE' | 'DELETE' | 'DELETE_ALL' | string;
 type ActionFunction = () => void;
 
@@ -17,7 +18,9 @@ export const DangerZone = () => {
 	const { deleteUser, deleteUserLoading } = useUser();
 	const { data: user } = useUserQuery();
 
-	const { removeUserFromAllTeam, removeUserFromAllTeamLoading } = useOrganizationTeams();
+	const { mutateAsync: removeUserFromAllTeam, isPending: removeUserFromAllTeamLoading } =
+		useRemoveUserFromAllTeamMutation();
+
 	const handleRemoveUser = useCallback(() => {
 		if (user) {
 			return removeUserFromAllTeam(user.id);

--- a/apps/web/core/components/pages/settings/team/danger-zone-team.tsx
+++ b/apps/web/core/components/pages/settings/team/danger-zone-team.tsx
@@ -1,14 +1,15 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { useIsMemberManager, useModal, useOrganizationEmployeeTeams, useOrganizationTeams } from '@/core/hooks';
-import { activeTeamManagersState, activeTeamState } from '@/core/stores';
 import { Button, Text } from '@/core/components';
-import { useCallback, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { useAtomValue } from 'jotai';
-import { LAST_WORKSPACE_AND_TEAM } from '@/core/constants/config/constants';
-import { RemoveModal } from '@/core/components/settings/remove-modal';
 import { TransferTeamModal } from '@/core/components/features/teams/transfer-team-modal';
+import { RemoveModal } from '@/core/components/settings/remove-modal';
+import { LAST_WORKSPACE_AND_TEAM } from '@/core/constants/config/constants';
+import { useIsMemberManager, useModal, useOrganizationEmployeeTeams } from '@/core/hooks';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useDeleteOrganizationTeamMutation } from '@/core/hooks/organizations/teams/use-delete-organization-team-mutation';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTranslations } from 'next-intl';
+import { useCallback, useState } from 'react';
 
 export const DangerZoneTeam = () => {
 	const t = useTranslations();
@@ -16,13 +17,14 @@ export const DangerZoneTeam = () => {
 	const { isOpen: dangerIsOpen, closeModal: dangerCloseModal, openModal: dangerOpenaModal } = useModal();
 	const [removeModalType, setRemoveModalType] = useState<'DISPOSE' | 'QUIT' | null>(null);
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const { deleteOrganizationTeam, deleteOrganizationTeamLoading } = useOrganizationTeams();
+	const activeTeam = useCurrentTeam();
+	const { mutateAsync: deleteOrganizationTeam, isPending: deleteOrganizationTeamLoading } =
+		useDeleteOrganizationTeamMutation();
 	const { deleteOrganizationTeamEmployee, deleteOrganizationEmployeeTeamLoading } = useOrganizationEmployeeTeams();
 	const { data: user } = useUserQuery();
 
 	const { isTeamManager } = useIsMemberManager(user);
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
 	const handleDisposeTeam = useCallback(() => {
 		if (activeTeam) {

--- a/apps/web/core/components/pages/settings/team/integration-setting.tsx
+++ b/apps/web/core/components/pages/settings/team/integration-setting.tsx
@@ -1,22 +1,20 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { GitHubLogoIcon } from '@radix-ui/react-icons';
-import { useTranslations } from 'next-intl';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/core/components/common/select';
-import { useGitHubIntegration, useIntegrationTenant, useIntegrationTypes } from '@/core/hooks';
-import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
-import { GITHUB_APP_NAME } from '@/core/constants/config/constants';
-import { useOrganizationProjects } from '@/core/hooks';
-import { TrashIcon } from 'assets/svg';
 import { Button } from '@/core/components';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/core/components/common/select';
+import { InputField } from '@/core/components/duplicated-components/_input';
+import { GITHUB_APP_NAME } from '@/core/constants/config/constants';
+import { useGitHubIntegration, useIntegrationTenant, useIntegrationTypes, useOrganizationProjects } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { getActiveProjectIdCookie } from '@/core/lib/helpers/index';
 import { Switch } from '@headlessui/react';
+import { GitHubLogoIcon } from '@radix-ui/react-icons';
+import { TrashIcon } from 'assets/svg';
 import debounce from 'lodash/debounce';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import qs from 'qs';
-import { InputField } from '@/core/components/duplicated-components/_input';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
 export const IntegrationSetting = () => {
 	const t = useTranslations();
@@ -39,7 +37,7 @@ export const IntegrationSetting = () => {
 
 	const url = `https://github.com/apps/${GITHUB_APP_NAME.value}/installations/new?${queries.toString()}`;
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const [selectedRepo, setSelectedRepo] = useState<string | undefined>(undefined);
 

--- a/apps/web/core/components/pages/settings/team/invitation-setting.tsx
+++ b/apps/web/core/components/pages/settings/team/invitation-setting.tsx
@@ -1,19 +1,18 @@
-import { useModal, useRequestToJoinTeam } from '@/core/hooks';
 import { Button, NoData } from '@/core/components';
-import { SearchNormalIcon } from 'assets/svg';
-import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
-import { ChangeEvent, useEffect, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { InvitationTable } from '../../../teams/invite/invitation-table';
 import { InputField } from '@/core/components/duplicated-components/_input';
-import { getTeamInvitationsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
+import { useModal, useRequestToJoinTeam } from '@/core/hooks';
+import { useTeamMemberInvitation } from '@/core/hooks/organizations/teams/use-team-member-invitations';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { SearchNormalIcon } from 'assets/svg';
+import { useTranslations } from 'next-intl';
+import { ChangeEvent, useEffect, useState } from 'react';
+import { InvitationTable } from '../../../teams/invite/invitation-table';
 
 export const InvitationSetting = () => {
 	const t = useTranslations();
 
-	const teamInvitations = useAtomValue(getTeamInvitationsState);
+	const teamInvitations = useTeamMemberInvitation();
 	const { getRequestToJoin, requestToJoin } = useRequestToJoinTeam();
 
 	const { data: user } = useUserQuery();

--- a/apps/web/core/components/pages/settings/team/member-setting.tsx
+++ b/apps/web/core/components/pages/settings/team/member-setting.tsx
@@ -1,19 +1,18 @@
-import { useModal } from '@/core/hooks';
 import { Button, NoData, Text } from '@/core/components';
-import { SearchNormalIcon } from 'assets/svg';
-import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
-import { ChangeEvent, useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { MemberTable } from '../../../teams/member-table';
 import { InputField } from '@/core/components/duplicated-components/_input';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
+import { useModal } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { SearchNormalIcon } from 'assets/svg';
+import { useTranslations } from 'next-intl';
+import { ChangeEvent, useMemo, useState } from 'react';
+import { MemberTable } from '../../../teams/member-table';
 
 export const MemberSetting = () => {
 	const t = useTranslations();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const [filterString, setFilterString] = useState<string>('');
 
 	const { data: user } = useUserQuery();

--- a/apps/web/core/components/pages/settings/team/team-setting-form.tsx
+++ b/apps/web/core/components/pages/settings/team/team-setting-form.tsx
@@ -1,38 +1,42 @@
-import { useIsMemberManager, useOrganizationTeams } from '@/core/hooks';
-import { ERoleName } from '@/core/types/generics/enums/role';
-import { activeTeamState } from '@/core/stores';
 import { Button, ColorPicker, Text } from '@/core/components';
 import { EmojiPicker } from '@/core/components/common/emoji-picker';
 import TimeTrackingToggle, { RequireDailyPlanToTrack, ShareProfileViewsToggle } from '@/core/components/common/switch';
-import debounce from 'lodash/debounce';
-import isEqual from 'lodash/isEqual';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useTranslations } from 'next-intl';
-import { useAtom } from 'jotai';
-import { useParams } from 'next/navigation';
-import { CheckSquareOutlineIcon, EditPenUnderlineIcon } from 'assets/svg';
-import TeamSize from '@/core/components/teams/team-size-popover';
 import { InputField } from '@/core/components/duplicated-components/_input';
 import { Tooltip } from '@/core/components/duplicated-components/tooltip';
-import { toast } from 'sonner';
-import { TOrganizationTeam, TOrganizationTeamUpdate } from '@/core/types/schemas';
+import TeamSize from '@/core/components/teams/team-size-popover';
+import { useIsMemberManager } from '@/core/hooks';
+import { useEditOrganizationTeamMutation } from '@/core/hooks/organizations/teams/use-edit-organization-team-mutation';
+import {
+	useGetOrganizationTeamQuery,
+	useGetOrganizationTeamsQuery
+} from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { activeTeamState, organizationTeamsState } from '@/core/stores';
+import { ERoleName } from '@/core/types/generics/enums/role';
+import { TOrganizationTeam, TOrganizationTeamUpdate } from '@/core/types/schemas';
+import { CheckSquareOutlineIcon, EditPenUnderlineIcon } from 'assets/svg';
+import { useAtom, useSetAtom } from 'jotai';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 import { LoaderCircle } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 
 export const TeamSettingForm = () => {
 	const { data: user } = useUserQuery();
 	const { register, setValue, handleSubmit, getValues, trigger } = useForm();
 	const t = useTranslations();
 
+	const { isLoading: loading } = useGetOrganizationTeamsQuery();
+	const { isLoading: loadingTeam } = useGetOrganizationTeamQuery();
+	const { mutateAsync: editOrganizationTeam, isPending: editOrganizationTeamLoading } =
+		useEditOrganizationTeamMutation();
+
 	const [activeTeam, setActiveTeam] = useAtom(activeTeamState);
-	const {
-		editOrganizationTeam,
-		getOrganizationTeamsLoading: loading,
-		loadingTeam,
-		setTeams,
-		editOrganizationTeamLoading
-	} = useOrganizationTeams();
+	const setTeams = useSetAtom(organizationTeamsState);
 	const { isTeamManager, activeManager } = useIsMemberManager(user);
 	const [copied, setCopied] = useState<boolean>(false);
 	const [disabled, setDisabled] = useState<boolean>(true);

--- a/apps/web/core/components/pages/task/description-block/task-description-editor.tsx
+++ b/apps/web/core/components/pages/task/description-block/task-description-editor.tsx
@@ -1,25 +1,24 @@
-import Toolbar from './editor-toolbar';
-import {
-	TextEditorService,
-	withHtml,
-	withChecklists,
-	isValidSlateObject,
-	isMarkdown,
-	markdownToHtml
-} from '../../../../lib/helpers/text-editor-service';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import isHotkey from 'is-hotkey';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { Editor, createEditor, Element as SlateElement, Descendant, Transforms, Range } from 'slate';
+import { createEditor, Descendant, Editor, Range, Element as SlateElement, Transforms } from 'slate';
 import { withHistory } from 'slate-history';
-import { Editable, withReact, Slate } from 'slate-react';
-import EditorFooter from './editor-footer';
-import { useAtom } from 'jotai';
-import { detailedTaskState } from '@/core/stores';
+import { Editable, Slate, withReact } from 'slate-react';
 import { htmlToSlate } from 'slate-serializers';
-import { isHtml } from '../../../../lib/helpers/text-editor-service';
-import LinkElement from './editor-components/link-element';
 import { configHtmlToSlate } from '../../../../lib/helpers/text-editor-serializer-configurations';
+import {
+	isHtml,
+	isMarkdown,
+	isValidSlateObject,
+	markdownToHtml,
+	TextEditorService,
+	withChecklists,
+	withHtml
+} from '../../../../lib/helpers/text-editor-service';
 import CheckListElement from './editor-components/check-list-element';
+import LinkElement from './editor-components/link-element';
+import EditorFooter from './editor-footer';
+import Toolbar from './editor-toolbar';
 
 const HOTKEYS: { [key: string]: string } = {
 	'mod+b': 'bold',
@@ -38,7 +37,9 @@ const RichTextEditor = ({ readonly }: IRichTextProps) => {
 	const renderElement = useCallback((props: any) => <Element {...props} />, []);
 	const renderLeaf = useCallback((props: any) => <Leaf {...props} />, []);
 	const editor = useMemo(() => withChecklists(withHtml(withHistory(withReact(createEditor())))), []);
-	const [task] = useAtom(detailedTaskState);
+	const {
+		detailedTaskQuery: { data: task }
+	} = useDetailedTask();
 	const [isUpdated, setIsUpdated] = useState<boolean>(false);
 	const [editorValue, setEditorValue] = useState<any>();
 	const editorRef = useRef<HTMLDivElement>(null);

--- a/apps/web/core/components/pages/task/details-section/blocks/task-estimations-info.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-estimations-info.tsx
@@ -5,8 +5,9 @@ import {
 } from '@/core/components/features/projects/add-or-edit-project/steps/basic-information-form';
 import { TaskEstimate } from '@/core/components/tasks/task-estimate';
 import { TaskMemberEstimate } from '@/core/components/tasks/task-member-estimate';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import { cn } from '@/core/lib/helpers';
-import { detailedTaskState } from '@/core/stores';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TCreateTaskEstimation } from '@/core/types/schemas/task/task-estimation.schema';
 import { TTask } from '@/core/types/schemas/task/task.schema';
@@ -20,16 +21,16 @@ import {
 	Transition
 } from '@headlessui/react';
 import { ChevronDownIcon, ChevronUpIcon } from 'assets/svg';
-import { useAtom } from 'jotai';
 import { CheckIcon, Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import React, { useCallback, useMemo, useState } from 'react';
 import ProfileInfoWithTime from '../components/profile-info-with-time';
 import TaskRow from '../components/task-row';
-import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const TaskEstimationsInfo = () => {
-	const [task] = useAtom(detailedTaskState);
+	const {
+		detailedTaskQuery: { data: task }
+	} = useDetailedTask();
 	const t = useTranslations();
 	const activeTeam = useCurrentTeam();
 

--- a/apps/web/core/components/pages/task/details-section/blocks/task-estimations-info.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-estimations-info.tsx
@@ -1,4 +1,15 @@
-import { activeTeamState, detailedTaskState } from '@/core/stores';
+import { Card } from '@/core/components/duplicated-components/card';
+import {
+	Select,
+	Thumbnail
+} from '@/core/components/features/projects/add-or-edit-project/steps/basic-information-form';
+import { TaskEstimate } from '@/core/components/tasks/task-estimate';
+import { TaskMemberEstimate } from '@/core/components/tasks/task-member-estimate';
+import { cn } from '@/core/lib/helpers';
+import { detailedTaskState } from '@/core/stores';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TCreateTaskEstimation } from '@/core/types/schemas/task/task-estimation.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import {
 	Disclosure,
 	DisclosureButton,
@@ -9,28 +20,18 @@ import {
 	Transition
 } from '@headlessui/react';
 import { ChevronDownIcon, ChevronUpIcon } from 'assets/svg';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
+import { CheckIcon, Plus } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import React, { useCallback, useMemo, useState } from 'react';
 import ProfileInfoWithTime from '../components/profile-info-with-time';
 import TaskRow from '../components/task-row';
-import React, { useCallback, useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { TaskEstimate } from '@/core/components/tasks/task-estimate';
-import { CheckIcon, Plus } from 'lucide-react';
-import {
-	Select,
-	Thumbnail
-} from '@/core/components/features/projects/add-or-edit-project/steps/basic-information-form';
-import { cn } from '@/core/lib/helpers';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { Card } from '@/core/components/duplicated-components/card';
-import { TaskMemberEstimate } from '@/core/components/tasks/task-member-estimate';
-import { TCreateTaskEstimation } from '@/core/types/schemas/task/task-estimation.schema';
-import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const TaskEstimationsInfo = () => {
 	const [task] = useAtom(detailedTaskState);
 	const t = useTranslations();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const teamMembers = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 
@@ -124,7 +125,7 @@ export default TaskEstimationsInfo;
 
 function AddNewMemberEstimation({ task, onSuccess }: { task: TTask; onSuccess?: () => void }) {
 	const [selectedMember, setSelectedMember] = useState<TOrganizationTeamEmployee | null>(null);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const teamMembers = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 	const taskEstimation = useMemo<TCreateTaskEstimation>(
 		() => ({

--- a/apps/web/core/components/pages/task/details-section/blocks/task-main-info.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-main-info.tsx
@@ -1,29 +1,30 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { calculateRemainingDays, formatDateString } from '@/core/lib/helpers/index';
 import { useSyncRef, useTeamTasks } from '@/core/hooks';
-import { activeTeamState, detailedTaskState } from '@/core/stores';
+import { calculateRemainingDays, formatDateString } from '@/core/lib/helpers/index';
 import { clsxm } from '@/core/lib/utils';
+import { detailedTaskState } from '@/core/stores';
 import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
 import { TrashIcon } from 'assets/svg';
-import { forwardRef, useCallback, useState } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
+import { forwardRef, useCallback, useState } from 'react';
 import ProfileInfo from '../components/profile-info';
 import TaskRow from '../components/task-row';
 
 import { DatePicker } from '@/core/components/common/date-picker';
-import Link from 'next/link';
-import { useTranslations } from 'next-intl';
-import { PencilSquareIcon } from '@heroicons/react/20/solid';
 import { ActiveTaskIssuesDropdown } from '@/core/components/tasks/task-issue';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { PencilSquareIcon } from '@heroicons/react/20/solid';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useTaskMemberManagement } from '@/core/hooks/tasks/use-task-member-management';
 import { MemberSection } from './member-section';
 
 const TaskMainInfo = () => {
 	const [task] = useAtom(detailedTaskState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const t = useTranslations();
 
 	return (

--- a/apps/web/core/components/pages/task/details-section/blocks/task-plans.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-plans.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useState } from 'react';
 import { useDailyPlan } from '@/core/hooks';
-import { detailedTaskState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
-import TaskRow from '../components/task-row';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import { formatDayPlanDate } from '@/core/lib/helpers/index';
 import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
+import { useEffect, useState } from 'react';
+import TaskRow from '../components/task-row';
 
 export function TaskPlans() {
-	const task = useAtomValue(detailedTaskState);
+	const {
+		detailedTaskQuery: { data: task }
+	} = useDetailedTask();
 
 	// Use local state instead of global atom to prevent data conflicts
 	const [taskPlanList, setTaskPlanList] = useState<TDailyPlan[]>([]);

--- a/apps/web/core/components/pages/task/details-section/blocks/task-plans.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-plans.tsx
@@ -1,9 +1,9 @@
-import { useDailyPlan } from '@/core/hooks';
 import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import { formatDayPlanDate } from '@/core/lib/helpers/index';
 import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
 import { useEffect, useState } from 'react';
 import TaskRow from '../components/task-row';
+import { usePlansByTaskLazyQuery } from '@/core/hooks/daily-plans/queries';
 
 export function TaskPlans() {
 	const {
@@ -12,7 +12,7 @@ export function TaskPlans() {
 
 	// Use local state instead of global atom to prevent data conflicts
 	const [taskPlanList, setTaskPlanList] = useState<TDailyPlan[]>([]);
-	const { getPlansByTask } = useDailyPlan();
+	const { getPlansByTaskId: getPlansByTask } = usePlansByTaskLazyQuery();
 
 	useEffect(() => {
 		if (task?.id) {

--- a/apps/web/core/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-progress.tsx
@@ -1,21 +1,22 @@
 import { TaskProgressBar } from '@/core/components/tasks/task-progress-bar';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import { secondsToTime } from '@/core/lib/helpers/index';
-import { detailedTaskState } from '@/core/stores';
 import { ITime } from '@/core/types/interfaces/common/time';
 import { TTaskStatistics } from '@/core/types/interfaces/task/task';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
 import { ChevronDownIcon, ChevronUpIcon } from 'assets/svg';
-import { useAtom } from 'jotai';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useState } from 'react';
 import ProfileInfoWithTime from '../components/profile-info-with-time';
 import TaskRow from '../components/task-row';
-import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const TaskProgress = () => {
-	const [task] = useAtom(detailedTaskState);
+	const {
+		detailedTaskQuery: { data: task }
+	} = useDetailedTask();
 	const { data: user } = useUserQuery();
 
 	const activeTeam = useCurrentTeam();
@@ -183,7 +184,9 @@ const TaskProgress = () => {
 export default TaskProgress;
 
 const IndividualMembersTotalTime = ({ numMembersToShow }: { numMembersToShow: number }) => {
-	const [task] = useAtom(detailedTaskState);
+	const {
+		detailedTaskQuery: { data: task }
+	} = useDetailedTask();
 
 	const activeTeam = useCurrentTeam();
 

--- a/apps/web/core/components/pages/task/details-section/blocks/task-progress.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-progress.tsx
@@ -1,23 +1,24 @@
-import { activeTeamState, detailedTaskState } from '@/core/stores';
-import { useAtom, useAtomValue } from 'jotai';
-import TaskRow from '../components/task-row';
+import { TaskProgressBar } from '@/core/components/tasks/task-progress-bar';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { secondsToTime } from '@/core/lib/helpers/index';
+import { detailedTaskState } from '@/core/stores';
+import { ITime } from '@/core/types/interfaces/common/time';
+import { TTaskStatistics } from '@/core/types/interfaces/task/task';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
+import { ChevronDownIcon, ChevronUpIcon } from 'assets/svg';
+import { useAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useState } from 'react';
 import ProfileInfoWithTime from '../components/profile-info-with-time';
-import { secondsToTime } from '@/core/lib/helpers/index';
-import { ChevronDownIcon, ChevronUpIcon } from 'assets/svg';
-import { useTranslations } from 'next-intl';
-import { TaskProgressBar } from '@/core/components/tasks/task-progress-bar';
-import { TTaskStatistics } from '@/core/types/interfaces/task/task';
-import { ITime } from '@/core/types/interfaces/common/time';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import TaskRow from '../components/task-row';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 const TaskProgress = () => {
 	const [task] = useAtom(detailedTaskState);
 	const { data: user } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const t = useTranslations();
 
 	const [userTotalTime, setUserTotalTime] = useState<ITime>({
@@ -184,7 +185,7 @@ export default TaskProgress;
 const IndividualMembersTotalTime = ({ numMembersToShow }: { numMembersToShow: number }) => {
 	const [task] = useAtom(detailedTaskState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const matchingMembers = activeTeam?.members?.filter((member) =>
 		task?.members?.some((taskMember) => taskMember.id === member.employeeId)

--- a/apps/web/core/components/pages/task/details-section/blocks/task-publicity.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-publicity.tsx
@@ -25,7 +25,8 @@ const TaskPublicity = () => {
 				if (!task?.id || !detailedTaskId) return setIsTaskPublic(task?.public);
 				updatePublicity({ taskId: task?.id, taskData: { ...task, public: value } })
 					.then((task) => setActiveTask(task))
-					.then(() => setIsTaskPublic(value));
+					.then(() => setIsTaskPublic(value))
+					.catch(() => setIsTaskPublic(task?.public));
 			}, 500);
 			debounceUpdatePublicity(value);
 		},

--- a/apps/web/core/components/pages/task/details-section/blocks/task-secondary-info.tsx
+++ b/apps/web/core/components/pages/task/details-section/blocks/task-secondary-info.tsx
@@ -1,29 +1,17 @@
-import { useModal, useTeamTasks } from '@/core/hooks';
-import { activeTeamState, detailedTaskState, isTeamManagerState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { ERoleName } from '@/core/types/generics/enums/role';
-import { PlusIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Button, Modal, SpinnerLoader } from '@/core/components';
-import { TaskVersionForm } from '@/core/components/tasks/version-form';
-import { cloneDeep } from 'lodash';
-import Link from 'next/link';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useAtomValue } from 'jotai';
-import TaskRow from '../components/task-row';
-import { useTranslations } from 'next-intl';
-import { toast } from 'sonner';
-import { AddIcon, CircleIcon, Square4OutlineIcon, TrashIcon } from 'assets/svg';
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger
 } from '@/core/components/common/dropdown-menu';
-import { clsxm } from '@/core/lib/utils';
-import { organizationProjectsState } from '@/core/stores/projects/organization-projects';
-import { isValidProjectForDisplay, projectBelongsToTeam, projectHasNoTeams } from '@/core/lib/helpers/type-guards';
+import { EverCard } from '@/core/components/common/ever-card';
 import { ScrollArea, ScrollBar } from '@/core/components/common/scroll-bar';
-import Image from 'next/image';
+import { Tooltip } from '@/core/components/duplicated-components/tooltip';
+import { QuickCreateProjectModal } from '@/core/components/features/projects/quick-create-project-modal';
+import { TaskLabels } from '@/core/components/tasks/task-labels';
+import { TaskPrioritiesForm } from '@/core/components/tasks/task-priorities-form';
+import { TaskSizesForm } from '@/core/components/tasks/task-sizes-form';
 import {
 	ActiveTaskPropertiesDropdown,
 	ActiveTaskSizesDropdown,
@@ -32,18 +20,31 @@ import {
 	EpicPropertiesDropdown as TaskEpicDropdown,
 	TaskStatus
 } from '@/core/components/tasks/task-status';
-import { TaskLabels } from '@/core/components/tasks/task-labels';
 import { TaskStatusesForm } from '@/core/components/tasks/task-statuses-form';
-import { TaskPrioritiesForm } from '@/core/components/tasks/task-priorities-form';
-import { TaskSizesForm } from '@/core/components/tasks/task-sizes-form';
-import { Tooltip } from '@/core/components/duplicated-components/tooltip';
-import { EverCard } from '@/core/components/common/ever-card';
-import { QuickCreateProjectModal } from '@/core/components/features/projects/quick-create-project-modal';
+import { TaskVersionForm } from '@/core/components/tasks/version-form';
+import { useModal, useTeamTasks } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTaskLabelsValue } from '@/core/hooks/tasks/use-task-labels-value';
+import { cn } from '@/core/lib/helpers';
+import { isValidProjectForDisplay, projectBelongsToTeam, projectHasNoTeams } from '@/core/lib/helpers/type-guards';
+import { clsxm } from '@/core/lib/utils';
+import { detailedTaskState, isTeamManagerState } from '@/core/stores';
+import { organizationProjectsState } from '@/core/stores/projects/organization-projects';
+import { ERoleName } from '@/core/types/generics/enums/role';
 import { EIssueType } from '@/core/types/generics/enums/task';
 import { TOrganizationProject, TTaskVersion } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useTaskLabelsValue } from '@/core/hooks/tasks/use-task-labels-value';
-import { cn } from '@/core/lib/helpers';
+import { ChevronDownIcon, PlusIcon } from '@heroicons/react/20/solid';
+import { AddIcon, CircleIcon, Square4OutlineIcon, TrashIcon } from 'assets/svg';
+import { useAtomValue } from 'jotai';
+import { cloneDeep } from 'lodash';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import TaskRow from '../components/task-row';
 
 type StatusType = 'version' | 'epic' | 'status' | 'label' | 'size' | 'priority';
 
@@ -311,7 +312,7 @@ export function ProjectDropDown(props: ITaskProjectDropdownProps) {
 	const { task, controlled = false, onChange, styles } = props;
 	const { openModal, isOpen, closeModal } = useModal();
 	const organizationProjects = useAtomValue(organizationProjectsState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { updateTask, updateLoading } = useTeamTasks();
 	const t = useTranslations();
 

--- a/apps/web/core/components/pages/task/parent-task.tsx
+++ b/apps/web/core/components/pages/task/parent-task.tsx
@@ -71,7 +71,7 @@ function CreateParentTask({ modal, task }: { modal: IHookModal; task: TTask }) {
 				setLoading(false);
 			}
 		},
-		[task, loadTeamTasksData, modal, updateTask, t]
+		[task, loadTeamTasksData, modal, updateTask, t, setActiveTask]
 	);
 
 	const filteredTasks = tasks.filter((t) => t.id !== task.id);

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task-times.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task-times.tsx
@@ -1,8 +1,10 @@
-import { useTeamMemberCard, useTeamTasks } from '@/core/hooks';
 import { TaskTimes } from '@/core/components/tasks/task-times';
-import { useEffect, useState } from 'react';
+import { useTeamMemberCard } from '@/core/hooks';
+import { useGetTaskByIdQueryLazy } from '@/core/hooks/organizations/teams/use-get-team-task.query';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useEffect, useState } from 'react';
 
 export default function UserTeamActiveTaskTimesBlock({
 	member,
@@ -13,7 +15,8 @@ export default function UserTeamActiveTaskTimesBlock({
 }) {
 	const memberInfo = useTeamMemberCard(member);
 
-	const { getTaskById } = useTeamTasks();
+	const { setDetailedTaskId } = useDetailedTask();
+	const { getTaskById } = useGetTaskByIdQueryLazy();
 
 	const [activeTask, setActiveTask] = useState<TTask | null | undefined>(null);
 
@@ -22,7 +25,10 @@ export default function UserTeamActiveTaskTimesBlock({
 			return;
 		}
 		getTaskById(activeTaskId)
-			.then((response) => setActiveTask(response as TTask))
+			.then((response) => {
+				setDetailedTaskId(activeTaskId);
+				setActiveTask(response as TTask);
+			})
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-active-task.tsx
@@ -1,8 +1,10 @@
-import { useTeamMemberCard, useTeamTasks, useTMCardTaskEdit } from '@/core/hooks';
-import { useEffect, useState } from 'react';
-import { TaskBlockInfo } from '../../../team/team-members-views/user-team-block/task-info';
+import { useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks';
+import { useGetTaskByIdQueryLazy } from '@/core/hooks/organizations/teams/use-get-team-task.query';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useEffect, useState } from 'react';
+import { TaskBlockInfo } from '../../../team/team-members-views/user-team-block/task-info';
 
 export default function UserTeamActiveBlockTaskInfo({
 	member,
@@ -15,14 +17,18 @@ export default function UserTeamActiveBlockTaskInfo({
 	const [activeTask, setActiveTask] = useState<TTask | null | undefined>(null);
 	const taskEdition = useTMCardTaskEdit(activeTask);
 
-	const { getTaskById } = useTeamTasks();
+	const { setDetailedTaskId } = useDetailedTask();
+	const { getTaskById } = useGetTaskByIdQueryLazy();
 
 	useEffect(() => {
 		if (!activeTaskId) {
 			return;
 		}
 		getTaskById(activeTaskId)
-			.then((task) => setActiveTask(task as TTask))
+			.then((task) => {
+				setDetailedTaskId(activeTaskId);
+				setActiveTask(task as TTask);
+			})
 			.catch(console.error);
 	}, [activeTaskId, getTaskById]);
 

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-task-estimate.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-block/user-team-task-estimate.tsx
@@ -1,8 +1,10 @@
-import { useTeamMemberCard, useTeamTasks, useTMCardTaskEdit } from '@/core/hooks';
-import { useEffect, useState } from 'react';
-import { TaskEstimateInfo } from '../../../team/team-members-views/user-team-card/task-estimate';
+import { useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks';
+import { useGetTaskByIdQueryLazy } from '@/core/hooks/organizations/teams/use-get-team-task.query';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useEffect, useState } from 'react';
+import { TaskEstimateInfo } from '../../../team/team-members-views/user-team-card/task-estimate';
 
 export default function UserTeamActiveTaskEstimateBlock({
 	member,
@@ -15,14 +17,18 @@ export default function UserTeamActiveTaskEstimateBlock({
 	const [activeTask, setActiveTask] = useState<TTask | null | undefined>(null);
 	const taskEdition = useTMCardTaskEdit(activeTask);
 
-	const { getTaskById } = useTeamTasks();
+	const { setDetailedTaskId } = useDetailedTask();
+	const { getTaskById } = useGetTaskByIdQueryLazy();
 
 	useEffect(() => {
 		if (!activeTaskId) {
 			return;
 		}
 		getTaskById(activeTaskId)
-			.then((response) => setActiveTask(response as TTask))
+			.then((response) => {
+				setDetailedTaskId(activeTaskId);
+				setActiveTask(response as TTask);
+			})
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-card.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-card.tsx
@@ -1,18 +1,20 @@
+import { EverCard } from '@/core/components/common/ever-card';
+import { VerticalSeparator } from '@/core/components/duplicated-components/separator';
+import { useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks';
+import { useGetTaskByIdQueryLazy } from '@/core/hooks/organizations/teams/use-get-team-task.query';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import { clsxm } from '@/core/lib/utils';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { Transition } from '@headlessui/react';
 import { SixSquareGridIcon } from 'assets/svg';
+import { useEffect, useState } from 'react';
+import { UserTeamCardMenu } from '../../../team/team-members-views/user-team-card/user-team-card-menu';
 import MemberInfo from './member-infos';
 import UserTeamActiveTaskInfo from './user-team-active-task';
 import UserTeamActiveTaskTimes from './user-team-active-task-times';
 import UserTeamActiveTaskEstimate from './user-team-task-estimate';
 import UserTeamActiveTaskTodayWorked from './user-team-today-worked';
-import { useTeamMemberCard, useTeamTasks, useTMCardTaskEdit } from '@/core/hooks';
-import { useEffect, useState } from 'react';
-import { UserTeamCardMenu } from '../../../team/team-members-views/user-team-card/user-team-card-menu';
-import { EverCard } from '@/core/components/common/ever-card';
-import { VerticalSeparator } from '@/core/components/duplicated-components/separator';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { TTask } from '@/core/types/schemas/task/task.schema';
 
 export default function UserTeamCard({
 	member,
@@ -85,14 +87,18 @@ function UserActiveTaskMenu({ member }: { member: TOrganizationTeamEmployee }) {
 	const [activeTask, setActiveTask] = useState<TTask | null | undefined>(null);
 	const taskEdition = useTMCardTaskEdit(activeTask);
 
-	const { getTaskById } = useTeamTasks();
+	const { setDetailedTaskId } = useDetailedTask();
+	const { getTaskById } = useGetTaskByIdQueryLazy();
 
 	useEffect(() => {
 		if (!member.activeTaskId) {
 			return;
 		}
 		getTaskById(member.activeTaskId)
-			.then((response) => setActiveTask(response as TTask))
+			.then((response) => {
+				setDetailedTaskId(member.activeTaskId ?? null);
+				setActiveTask(response as TTask);
+			})
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task-times.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task-times.tsx
@@ -1,9 +1,11 @@
-import { cn } from '@/core/lib/helpers';
-import { useTeamMemberCard, useTeamTasks } from '@/core/hooks';
 import { TaskTimes } from '@/core/components/tasks/task-times';
-import { useEffect, useState } from 'react';
+import { useTeamMemberCard } from '@/core/hooks';
+import { useGetTaskByIdQueryLazy } from '@/core/hooks/organizations/teams/use-get-team-task.query';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
+import { cn } from '@/core/lib/helpers';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useEffect, useState } from 'react';
 
 export default function UserTeamActiveTaskTimes({
 	member,
@@ -14,7 +16,8 @@ export default function UserTeamActiveTaskTimes({
 }) {
 	const memberInfo = useTeamMemberCard(member);
 
-	const { getTaskById } = useTeamTasks();
+	const { setDetailedTaskId } = useDetailedTask();
+	const { getTaskById } = useGetTaskByIdQueryLazy();
 
 	const [activeTask, setActiveTask] = useState<TTask | null | undefined>(null);
 
@@ -23,7 +26,10 @@ export default function UserTeamActiveTaskTimes({
 			return;
 		}
 		getTaskById(member.activeTaskId)
-			.then((response) => setActiveTask(response as TTask))
+			.then((response) => {
+				setDetailedTaskId(member.activeTaskId ?? null);
+				setActiveTask(response as TTask);
+			})
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-active-task.tsx
@@ -1,9 +1,11 @@
+import { useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks';
+import { useGetTaskByIdQueryLazy } from '@/core/hooks/organizations/teams/use-get-team-task.query';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import { cn } from '@/core/lib/helpers';
-import { useTeamMemberCard, useTeamTasks, useTMCardTaskEdit } from '@/core/hooks';
-import { useEffect, useState } from 'react';
-import { TaskInfo } from '../../../team/team-members-views/user-team-card/task-info';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useEffect, useState } from 'react';
+import { TaskInfo } from '../../../team/team-members-views/user-team-card/task-info';
 
 export default function UserTeamActiveTaskInfo({
 	member,
@@ -13,12 +15,16 @@ export default function UserTeamActiveTaskInfo({
 	const [activeTask, setActiveTask] = useState<TTask | null | undefined>(null);
 	const taskEdition = useTMCardTaskEdit(activeTask);
 
-	const { getTaskById } = useTeamTasks();
+	const { setDetailedTaskId } = useDetailedTask();
+	const { getTaskById } = useGetTaskByIdQueryLazy();
 
 	useEffect(() => {
 		if (member.activeTaskId) {
 			getTaskById(member.activeTaskId)
-				.then((response) => setActiveTask(response as TTask))
+				.then((response) => {
+					setDetailedTaskId(member.activeTaskId ?? null);
+					setActiveTask(response as TTask);
+				})
 				.catch((_) => console.log(_));
 		}
 

--- a/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-task-estimate.tsx
+++ b/apps/web/core/components/pages/teams/all-teams/all-teams-members-views/users-teams-card/user-team-task-estimate.tsx
@@ -1,9 +1,11 @@
+import { useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks';
+import { useGetTaskByIdQueryLazy } from '@/core/hooks/organizations/teams/use-get-team-task.query';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
 import { cn } from '@/core/lib/helpers';
-import { useTeamMemberCard, useTeamTasks, useTMCardTaskEdit } from '@/core/hooks';
-import { useEffect, useState } from 'react';
-import { TaskEstimateInfo } from '../../../team/team-members-views/user-team-card/task-estimate';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useEffect, useState } from 'react';
+import { TaskEstimateInfo } from '../../../team/team-members-views/user-team-card/task-estimate';
 
 export default function UserTeamActiveTaskEstimate({
 	member,
@@ -13,14 +15,18 @@ export default function UserTeamActiveTaskEstimate({
 	const [activeTask, setActiveTask] = useState<TTask | null | undefined>(null);
 	const taskEdition = useTMCardTaskEdit(activeTask);
 
-	const { getTaskById } = useTeamTasks();
+	const { setDetailedTaskId } = useDetailedTask();
+	const { getTaskById } = useGetTaskByIdQueryLazy();
 
 	useEffect(() => {
 		if (!member.activeTaskId) {
 			return;
 		}
 		getTaskById(member.activeTaskId)
-			.then((response) => setActiveTask(response as TTask))
+			.then((response) => {
+				setDetailedTaskId(member.activeTaskId ?? null);
+				setActiveTask(response as TTask);
+			})
 			.catch((_) => console.log(_));
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/core/components/pages/teams/team/tasks/dropdown-menu-task.tsx
+++ b/apps/web/core/components/pages/teams/team/tasks/dropdown-menu-task.tsx
@@ -1,25 +1,24 @@
-import { Button } from '@/core/components/duplicated-components/_button';
 import {
 	DropdownMenu,
-	DropdownMenuTrigger,
 	DropdownMenuContent,
 	DropdownMenuItem,
-	DropdownMenuSeparator
+	DropdownMenuSeparator,
+	DropdownMenuTrigger
 } from '@/core/components/common/dropdown-menu';
+import { Button } from '@/core/components/duplicated-components/_button';
 import { useAuthenticateUser, useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks';
 import { useTranslations } from 'next-intl';
-import { FC, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { FC, useCallback } from 'react';
 
-import { toast } from 'sonner';
-import { TTask } from '@/core/types/schemas/task/task.schema';
 import { Spinner } from '@/core/components/common/spinner';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useFavoriteTasks } from '@/core/hooks/tasks/use-favorites-task';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { toast } from 'sonner';
 
 const DropdownMenuTask: FC<{ task: TTask }> = ({ task }) => {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const router = useRouter();
 	const { user } = useAuthenticateUser();
 	const isAssigned = task?.members?.some((m) => m?.user?.id === user?.id);

--- a/apps/web/core/components/pages/teams/team/team-members-views/team-members-card-view.tsx
+++ b/apps/web/core/components/pages/teams/team/team-members-views/team-members-card-view.tsx
@@ -1,15 +1,14 @@
+import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
+import { InvitedCard, InviteUserTeamCard } from '@/core/components/teams/invite/user-invite-card';
 import { useIsMemberManager, useModal, useOrganizationEmployeeTeams } from '@/core/hooks';
+import { useTeamMemberInvitation } from '@/core/hooks/organizations/teams/use-team-member-invitations';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { EInviteStatus } from '@/core/types/generics/enums/invite';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { Transition } from '@headlessui/react';
 import React, { memo, useCallback } from 'react';
 import { InviteUserTeamSkeleton, UserTeamCardSkeleton } from './team-members-header';
 import { UserTeamCard } from './user-team-card';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { InvitedCard, InviteUserTeamCard } from '@/core/components/teams/invite/user-invite-card';
-import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
-import { EInviteStatus } from '@/core/types/generics/enums/invite';
-import { useAtomValue } from 'jotai';
-import { getTeamInvitationsState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
 interface Props {
 	teamMembers: TOrganizationTeamEmployee[];
@@ -24,7 +23,7 @@ const TeamMembersCardView: React.FC<Props> = memo(
 
 		const { isTeamManager } = useIsMemberManager(user);
 
-		const teamInvitations = useAtomValue(getTeamInvitationsState);
+		const teamInvitations = useTeamMemberInvitation();
 
 		const { updateOrganizationTeamEmployeeOrderOnList } = useOrganizationEmployeeTeams();
 

--- a/apps/web/core/components/pages/teams/team/team-members-views/user-team-block/user-team-block-header.tsx
+++ b/apps/web/core/components/pages/teams/team/team-members-views/user-team-block/user-team-block-header.tsx
@@ -1,27 +1,27 @@
 import { Button } from '@/core/components';
-import { useModal, useUserProfilePage } from '@/core/hooks';
-import { taskBlockFilterState, blockViewSearchQueryState } from '@/core/stores/tasks/task-filter';
-import { useAtom, useAtomValue } from 'jotai';
-import { useTranslations } from 'next-intl';
-import { useMemo, useEffect } from 'react';
-import { activeTeamState } from '@/core/stores';
-import { clsxm } from '@/core/lib/utils';
-import {
-	SearchNormalIcon,
-	TimerPlayIcon,
-	CheckCircleTickIcon,
-	CrossCircleIcon,
-	StopCircleIcon,
-	PauseIcon
-} from 'assets/svg';
-import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
-import { useTaskFilter } from '@/core/hooks/tasks/use-task-filter';
-import { TaskNameFilter } from '@/core/components/pages/profile/task-filters';
 import { VerticalSeparator } from '@/core/components/duplicated-components/separator';
+import { InviteFormModal } from '@/core/components/features/teams/invite-form-modal';
+import { TaskNameFilter } from '@/core/components/pages/profile/task-filters';
+import { useModal, useUserProfilePage } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTaskFilter } from '@/core/hooks/tasks/use-task-filter';
 import { useProcessedTeamMembers } from '@/core/hooks/teams/use-processed-team-members';
 import { useTeamMemberFilterStatsForUI } from '@/core/hooks/teams/use-team-member-filter-stats';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { clsxm } from '@/core/lib/utils';
 import { TeamMemberFilterType } from '@/core/lib/utils/team-members.utils';
+import { blockViewSearchQueryState, taskBlockFilterState } from '@/core/stores/tasks/task-filter';
+import {
+	CheckCircleTickIcon,
+	CrossCircleIcon,
+	PauseIcon,
+	SearchNormalIcon,
+	StopCircleIcon,
+	TimerPlayIcon
+} from 'assets/svg';
+import { useAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
+import { useEffect, useMemo } from 'react';
 
 // Interface for filter stats (kept for UI compatibility)
 interface IFilter {
@@ -73,7 +73,7 @@ const statusButtons = (
 export function UserTeamBlockHeader() {
 	const t = useTranslations();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 	const { openModal, isOpen, closeModal } = useModal();
 	const [activeFilter, setActiveFilter] = useAtom<TeamMemberFilterType>(taskBlockFilterState);

--- a/apps/web/core/components/pages/teams/team/team-members-views/user-team-card/index.tsx
+++ b/apps/web/core/components/pages/teams/team/team-members-views/user-team-card/index.tsx
@@ -17,7 +17,6 @@ import { TaskTimes, TodayWorkedTime } from '@/core/components/tasks/task-times';
 import { ITEMS_LENGTH_TO_VIRTUALIZED } from '@/core/constants/config/constants';
 import {
 	useCollaborative,
-	useDailyPlan,
 	useTMCardTaskEdit,
 	useTaskStatistics,
 	useTeamMemberCard,
@@ -47,6 +46,7 @@ import { TaskEstimateInfo } from './task-estimate';
 import { TaskInfo } from './task-info';
 import { UserInfo } from './user-info';
 import { UserTeamCardMenu } from './user-team-card-menu';
+import { useEmployeeDailyPlansQuery, useMyDailyPlansQuery } from '@/core/hooks/daily-plans/queries';
 
 type IUserTeamCard = {
 	active?: boolean;
@@ -126,16 +126,18 @@ export function UserTeamCard({
 
 	const isManagerConnectedUser = activeTeamManagers.findIndex((member) => member.employee?.user?.id === user?.id);
 
-	// Memoize accordion state early to use in useDailyPlan options
+	// Memoize accordion state early to use in useMyDailyPlansQuery & useEmployeeDailyPlansQuery options
 	const isAccordionExpanded = useMemo(() => {
 		return userDetailAccordion === memberInfo.memberUser?.id;
 	}, [userDetailAccordion, memberInfo.memberUser?.id]);
 
 	// PERFORMANCE FIX: Only fetch daily plans when accordion is expanded
 	// This prevents unnecessary API calls for every team member card on initial render
-	const { getDayPlansByEmployeeLoading, getMyDailyPlansLoading } = useDailyPlan(
-		memberInfo.isAuthUser ? undefined : memberInfo.member?.employeeId,
-		{ enabled: isAccordionExpanded } // Only enable queries when accordion is open
+	// Only enable queries when accordion is open
+	const { isPending: getMyDailyPlansLoading } = useMyDailyPlansQuery({ enabled: isAccordionExpanded });
+	const { isPending: getDayPlansByEmployeeLoading } = useEmployeeDailyPlansQuery(
+		memberInfo.isAuthUser ? undefined : (memberInfo.member?.employeeId ?? undefined),
+		{ enabled: isAccordionExpanded }
 	);
 
 	// Memoize callback to prevent unnecessary re-renders

--- a/apps/web/core/components/pages/teams/team/team-members.tsx
+++ b/apps/web/core/components/pages/teams/team/team-members.tsx
@@ -1,24 +1,26 @@
-import { useOrganizationTeams } from '@/core/hooks';
-import { Transition } from '@headlessui/react';
-import UserTeamCardSkeletonCard from '@/core/components/teams/user-team-card-skeleton';
+import { Container } from '@/core/components';
 import InviteUserTeamCardSkeleton from '@/core/components/teams/invite-team-card-skeleton';
 import { UserCard } from '@/core/components/teams/team-page-skeleton';
+import UserTeamCardSkeletonCard from '@/core/components/teams/user-team-card-skeleton';
 import { IssuesView } from '@/core/constants/config/constants';
-import { useAtomValue } from 'jotai';
-import { taskBlockFilterState, blockViewSearchQueryState } from '@/core/stores/tasks/task-filter';
-import { Container } from '@/core/components';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useFuseMemberSearch } from '@/core/hooks/teams/use-fuse-member-search';
+import { useFilteredTeamMembers, useProcessedTeamMembers } from '@/core/hooks/teams/use-processed-team-members';
+import { TeamMemberFilterType } from '@/core/lib/utils/team-members.utils';
 import { fullWidthState } from '@/core/stores/common/full-width';
-import { useMemo, memo } from 'react';
+import { blockViewSearchQueryState, taskBlockFilterState } from '@/core/stores/tasks/task-filter';
+import { TaskCardProps } from '@/core/types/interfaces/task/task-card';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { Transition } from '@headlessui/react';
+import { useAtomValue } from 'jotai';
+import { memo, useMemo } from 'react';
+import TeamMembersBlockView from './team-members-views/team-members-block-view';
 import TeamMembersCardView from './team-members-views/team-members-card-view';
 import TeamMembersTableView from './team-members-views/user-team-table/team-members-table-view';
-import TeamMembersBlockView from './team-members-views/team-members-block-view';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { TaskCardProps } from '@/core/types/interfaces/task/task-card';
-import { useProcessedTeamMembers, useFilteredTeamMembers } from '@/core/hooks/teams/use-processed-team-members';
-import { activeTeamState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { TeamMemberFilterType } from '@/core/lib/utils/team-members.utils';
-import { useFuseMemberSearch } from '@/core/hooks/teams/use-fuse-member-search';
+import {
+	useGetOrganizationTeamQuery,
+	useGetOrganizationTeamsQuery
+} from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
 
 // Types for better performance and security
 
@@ -66,8 +68,10 @@ export const TeamMembers = memo<TeamMembersProps>(({ publicTeam = false, kanbanV
 	const searchQuery = useAtomValue(blockViewSearchQueryState);
 	const fullWidth = useAtomValue(fullWidthState);
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const { getOrganizationTeamsLoading: teamsFetching } = useOrganizationTeams();
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
+
+	const { isPending: teamsFetching } = useGetOrganizationTeamsQuery();
 
 	// Use refactored hooks for member processing
 	const processedMembers = useProcessedTeamMembers(activeTeam, user!);

--- a/apps/web/core/components/pages/time-and-activity/page-component.tsx
+++ b/apps/web/core/components/pages/time-and-activity/page-component.tsx
@@ -13,10 +13,11 @@ import {
 } from '@/core/components/optimized-components/reports';
 import { GroupByType, useReportActivity } from '@/core/hooks/activities/use-report-activity';
 import { useTimeActivityStats } from '@/core/hooks/activities/use-time-activity-stats';
-import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
+import { useSortedTasksByCreation } from '@/core/hooks/organizations/teams/use-sorted-tasks';
 import { cn } from '@/core/lib/helpers';
-import { isTrackingEnabledState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { isTrackingEnabledState, organizationProjectsState } from '@/core/stores';
 import { fullWidthState } from '@/core/stores/common/full-width';
 import { FilterState } from '@/core/types/interfaces/timesheet/time-limit-report';
 import { ArrowLeftIcon } from '@radix-ui/react-icons';
@@ -134,7 +135,7 @@ const TimeActivityComponents = () => {
 	const { userManagedTeams } = useOrganizationAndTeamManagers();
 	const organizationProjects = useAtomValue(organizationProjectsState);
 
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasksByCreation();
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 	const activeTeam = useCurrentTeam();
 

--- a/apps/web/core/components/pages/time-and-activity/page-component.tsx
+++ b/apps/web/core/components/pages/time-and-activity/page-component.tsx
@@ -1,28 +1,29 @@
 'use client';
-import { MainLayout } from '@/core/components/layouts/default-layout';
-import { useTranslations } from 'next-intl';
-import { useRouter, useParams } from 'next/navigation';
-import { useAtomValue } from 'jotai';
-import { fullWidthState } from '@/core/stores/common/full-width';
 import { Container } from '@/core/components';
-import { cn } from '@/core/lib/helpers';
-import { ArrowLeftIcon } from '@radix-ui/react-icons';
-import { useMemo, useState, useCallback } from 'react';
 import { Card } from '@/core/components/common/card';
-import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
-import { GroupByType, useReportActivity } from '@/core/hooks/activities/use-report-activity';
-import { useTimeActivityStats } from '@/core/hooks/activities/use-time-activity-stats';
+import { TimeActivityPageSkeleton } from '@/core/components/common/skeleton/time-activity-page-skeleton';
 import { ViewOption } from '@/core/components/common/view-select';
 import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
-import { TimeActivityPageSkeleton } from '@/core/components/common/skeleton/time-activity-page-skeleton';
-import { FilterState } from '@/core/types/interfaces/timesheet/time-limit-report';
+import { MainLayout } from '@/core/components/layouts/default-layout';
 import {
-	LazyTimeActivityHeader,
-	LazyCardTimeAndActivity,
 	LazyActivityTable,
+	LazyCardTimeAndActivity,
+	LazyTimeActivityHeader,
 	LazyTimeActivityTable
 } from '@/core/components/optimized-components/reports';
-import { activeTeamState, isTrackingEnabledState, tasksByTeamState, organizationProjectsState } from '@/core/stores';
+import { GroupByType, useReportActivity } from '@/core/hooks/activities/use-report-activity';
+import { useTimeActivityStats } from '@/core/hooks/activities/use-time-activity-stats';
+import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { cn } from '@/core/lib/helpers';
+import { isTrackingEnabledState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { fullWidthState } from '@/core/stores/common/full-width';
+import { FilterState } from '@/core/types/interfaces/timesheet/time-limit-report';
+import { ArrowLeftIcon } from '@radix-ui/react-icons';
+import { useAtomValue } from 'jotai';
+import { useTranslations } from 'next-intl';
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useMemo, useState } from 'react';
 
 const STORAGE_KEY = 'ever-teams-activity-view-options';
 
@@ -135,7 +136,7 @@ const TimeActivityComponents = () => {
 
 	const tasks = useAtomValue(tasksByTeamState);
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const breadcrumbPath = useMemo(
 		() => [

--- a/apps/web/core/components/pages/timesheet/timesheet-filter-popover.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-filter-popover.tsx
@@ -4,8 +4,9 @@ import { Button } from '@/core/components/duplicated-components/_button';
 import { useTimelogFilterOptions } from '@/core/hooks';
 import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useSortedTasksByCreation } from '@/core/hooks/organizations/teams/use-sorted-tasks';
 import { cn } from '@/core/lib/helpers';
-import { organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { organizationProjectsState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
 import React from 'react';
@@ -18,7 +19,7 @@ export const TimeSheetFilterPopover = React.memo(function TimeSheetFilterPopover
 	const activeTeam = useCurrentTeam();
 
 	const organizationProjects = useAtomValue(organizationProjectsState);
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasksByCreation();
 
 	const t = useTranslations();
 	const { setEmployeeState, setProjectState, setStatusState, setTaskState, employee, project, statusState, task } =

--- a/apps/web/core/components/pages/timesheet/timesheet-filter-popover.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-filter-popover.tsx
@@ -1,20 +1,21 @@
-import React from 'react';
-import { Button } from '@/core/components/duplicated-components/_button';
-import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
 import { SettingFilterIcon } from '@/assets/svg';
-import { useTranslations } from 'next-intl';
+import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
+import { Button } from '@/core/components/duplicated-components/_button';
 import { useTimelogFilterOptions } from '@/core/hooks';
 import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { cn } from '@/core/lib/helpers';
-import { statusTable } from '../../timesheet/timesheet-action';
-import { MultiSelect } from '../../common/multi-select';
+import { organizationProjectsState, tasksByTeamState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { useTranslations } from 'next-intl';
+import React from 'react';
+import { MultiSelect } from '../../common/multi-select';
+import { statusTable } from '../../timesheet/timesheet-action';
 
 export const TimeSheetFilterPopover = React.memo(function TimeSheetFilterPopover() {
 	const [shouldRemoveItems, setShouldRemoveItems] = React.useState(false);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const organizationProjects = useAtomValue(organizationProjectsState);
 	const tasks = useAtomValue(tasksByTeamState);

--- a/apps/web/core/components/pages/timesheet/timesheet-page-content.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-page-content.tsx
@@ -11,6 +11,17 @@ import { useLocalStorageState, useModal } from '@/core/hooks';
 import { fullWidthState } from '@/core/stores/common/full-width';
 import { useAtomValue } from 'jotai';
 
+import { TimesheetDetailModalSkeleton } from '@/core/components/common/skeleton/timesheet-skeletons';
+import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
+import { IconsSearch } from '@/core/components/icons';
+import {
+	LazyCalendarView,
+	LazyTimesheetCard,
+	LazyTimesheetDetailModal,
+	LazyTimesheetFilter,
+	LazyTimesheetPagination,
+	LazyTimesheetView
+} from '@/core/components/optimized-components/calendar';
 import {
 	CalendarViewIcon,
 	ListViewIcon,
@@ -19,27 +30,16 @@ import {
 	PendingTaskIcon,
 	SelectedTimesheet
 } from '@/core/components/timesheet';
-import { ArrowLeftIcon } from 'assets/svg';
-import type { IconBaseProps } from 'react-icons';
-import { TimesheetDetailModalSkeleton } from '@/core/components/common/skeleton/timesheet-skeletons';
-import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
-import { IconsSearch } from '@/core/components/icons';
 import { ViewToggleButton } from '@/core/components/timesheet/timesheet-toggle-view';
 import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
 import { useTimesheetFilters } from '@/core/hooks/activities/use-timesheet-filters';
 import { useTimesheetPagination } from '@/core/hooks/activities/use-timesheet-pagination';
 import { useTimesheetViewData } from '@/core/hooks/activities/use-timesheet-view-data';
-import { differenceBetweenHours, getGreeting, secondsToTime } from '@/core/lib/helpers/index';
-import { activeTeamState } from '@/core/stores';
-import {
-	LazyCalendarView,
-	LazyTimesheetView,
-	LazyTimesheetDetailModal,
-	LazyTimesheetFilter,
-	LazyTimesheetCard,
-	LazyTimesheetPagination
-} from '@/core/components/optimized-components/calendar';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { differenceBetweenHours, getGreeting, secondsToTime } from '@/core/lib/helpers/index';
+import { ArrowLeftIcon } from 'assets/svg';
+import type { IconBaseProps } from 'react-icons';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 type TimesheetViewMode = 'ListView' | 'CalendarView';
 export type TimesheetDetailMode = 'Pending' | 'MenHours' | 'MemberWork';
@@ -56,7 +56,7 @@ export function TimeSheetPageContent({ params }: { params: { memberId: string } 
 		return [10, 20, 30, 50];
 	};
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const isTrackingEnabled = !!activeTeam?.members?.find(
 		(member) => member.employee?.userId === user?.id && member.isTrackingEnabled

--- a/apps/web/core/components/projects/filters-card-modal.tsx
+++ b/apps/web/core/components/projects/filters-card-modal.tsx
@@ -1,14 +1,15 @@
 import { Button, Modal } from '@/core/components';
-import { ListFilterPlus, X } from 'lucide-react';
-import { useTranslations } from 'next-intl';
-import { MultiSelectWithSearch } from '../common/multi-select-with-search';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import Image from 'next/image';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { EverCard } from '../common/ever-card';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
+import { organizationProjectsState, taskStatusesState } from '@/core/stores';
 import { EProjectBudgetType } from '@/core/types/generics/enums/project';
 import { useAtomValue } from 'jotai';
-import { organizationProjectsState, organizationTeamsState, taskStatusesState } from '@/core/stores';
+import { ListFilterPlus, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { EverCard } from '../common/ever-card';
+import { MultiSelectWithSearch } from '../common/multi-select-with-search';
 
 interface IFiltersCardModalProps {
 	open: boolean;
@@ -23,7 +24,7 @@ export default function FiltersCardModal({ open, closeModal }: IFiltersCardModal
 	const [selectedStatus, setSelectedStatus] = useState<string[]>([]);
 	const [selectedBudgetType, setSelectedBudgetType] = useState<string[]>([]);
 	const params = useSearchParams();
-	const teams = useAtomValue(organizationTeamsState);
+	const { teams } = useOrganisationTeams();
 
 	const organizationProjects = useAtomValue(organizationProjectsState);
 	const teamMembers = useMemo(

--- a/apps/web/core/components/settings/table-action-popover.tsx
+++ b/apps/web/core/components/settings/table-action-popover.tsx
@@ -1,16 +1,16 @@
-import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
-import { useTranslations } from 'next-intl';
-import { ConfirmationModal } from './confirmation-modal';
-import { ThreeCircleOutlineHorizontalIcon } from 'assets/svg';
-import { useEmployeeUpdate, useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks/organizations';
 import { useModal } from '@/core/hooks/common';
+import { useEmployeeUpdate, useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks/organizations';
+import { useActiveTeamManagers } from '@/core/hooks/organizations/teams/use-active-team-managers';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { rolesState } from '@/core/stores';
-import { useDropdownAction } from '../pages/teams/team/team-members-views/user-team-card/user-team-card-menu';
 import { ERoleName } from '@/core/types/generics/enums/role';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
+import { ThreeCircleOutlineHorizontalIcon } from 'assets/svg';
 import { useAtomValue } from 'jotai';
-import { activeTeamManagersState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useTranslations } from 'next-intl';
+import { useDropdownAction } from '../pages/teams/team/team-members-views/user-team-card/user-team-card-menu';
+import { ConfirmationModal } from './confirmation-modal';
 
 type Props = {
 	member: TOrganizationTeamEmployee;
@@ -25,7 +25,7 @@ export const TableActionPopover = ({ member, handleEdit, status }: Props) => {
 	// const [isOpen, setIsOpen] = useState(false);
 	const t = useTranslations();
 	const { data: user } = useUserQuery();
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
 
 	const memberInfo = useTeamMemberCard(member);
 	const taskEdition = useTMCardTaskEdit(memberInfo.memberTask);

--- a/apps/web/core/components/tasks/assigned-tasks.tsx
+++ b/apps/web/core/components/tasks/assigned-tasks.tsx
@@ -1,14 +1,15 @@
-import { secondsToTime } from '@/core/lib/helpers/date-and-time';
 import { RawStatusDropdown } from '@/core/components/tasks/status-dropdown';
+import { secondsToTime } from '@/core/lib/helpers/date-and-time';
 
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
 import { useTaskStatistics } from '@/core/hooks/tasks/use-task-statistics';
-import { activeTaskStatisticsState, activeTeamTaskState, timerSecondsState } from '@/core/stores';
+import { activeTaskStatisticsState, timerSecondsState } from '@/core/stores';
+import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { PlayIcon } from '@heroicons/react/20/solid';
-import { useRef } from 'react';
 import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { useRef } from 'react';
 
 interface ITaskDetailCard {
 	now?: boolean;
@@ -24,7 +25,7 @@ const AssignedTask = ({ now = false, task }: ITaskDetailCard) => {
 	const statActiveTask = useAtomValue(activeTaskStatisticsState);
 	const activeTaskTotalStat = statActiveTask.total;
 
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 	const { getTaskStat, activeTaskEstimation } = useTaskStatistics(timerReconds);
 
 	if (activeTeamTask?.id === task?.id) {

--- a/apps/web/core/components/tasks/daily-plan/daily-plan-filter.tsx
+++ b/apps/web/core/components/tasks/daily-plan/daily-plan-filter.tsx
@@ -1,5 +1,4 @@
 import { formatDayPlanDate } from '@/core/lib/helpers/index';
-import { useDailyPlan } from '@/core/hooks';
 import { cn } from '@/core/lib/helpers';
 import { CircleIcon } from 'assets/svg';
 import { PropsWithChildren, useEffect, useMemo, useState } from 'react';
@@ -8,6 +7,7 @@ import { Tooltip } from '../../duplicated-components/tooltip';
 import { Popover, PopoverContent, PopoverTrigger } from '../../common/popover';
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '../../common/command';
 import { Button } from '../../common/button';
+import { useEmployeeDailyPlansQuery, useEmployeeDailyPlansQueryLazy } from '@/core/hooks/daily-plans/queries';
 
 export function DailyPlanDropDownItem({
 	children,
@@ -49,16 +49,18 @@ export function DailyPlanDropDownItem({
 export function DailyPlanFilter({ employeeId }: { employeeId: string }) {
 	const [selectedPlans, setSelectedPlans] = useState<string[]>([]);
 
-	// Get employee plans from React Query (not global atom)
-	const { employeePlans, getEmployeeDayPlans } = useDailyPlan(employeeId);
+	const { data: employeePlansResult } = useEmployeeDailyPlansQuery(employeeId);
+	const { getPlanByEmployeeId } = useEmployeeDailyPlansQueryLazy();
 	const [open, setOpen] = useState(false);
+
+	const employeePlans = useMemo(() => employeePlansResult?.items ?? [], []);
 
 	// Load employee plans on mount
 	useEffect(() => {
 		if (selectedPlans.length === 0) {
-			getEmployeeDayPlans(employeeId);
+			getPlanByEmployeeId(employeeId);
 		}
-	}, [selectedPlans, getEmployeeDayPlans, employeeId]);
+	}, [selectedPlans, getPlanByEmployeeId, employeeId]);
 
 	// Filter plans locally without modifying global atoms.
 	// NOTE: This prevents data conflicts when multiple components view different employees.

--- a/apps/web/core/components/tasks/daily-plan/future-tasks.tsx
+++ b/apps/web/core/components/tasks/daily-plan/future-tasks.tsx
@@ -14,7 +14,7 @@ import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
 import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
 import DailyPlanTasksTableView from './table-view';
 import { HorizontalSeparator } from '../../duplicated-components/separator';
-import { useDailyPlan } from '@/core/hooks';
+import { useFuturePlans } from '@/core/hooks/daily-plans/derived';
 
 export function FutureTasks({
 	profile,
@@ -29,7 +29,7 @@ export function FutureTasks({
 }) {
 	// Use employeeId from props if provided, otherwise calculate from user
 	const targetEmployeeId = employeeId ?? user?.employee?.id ?? user?.employeeId ?? '';
-	const { futurePlans } = useDailyPlan(targetEmployeeId);
+	const futurePlans = useFuturePlans(targetEmployeeId ?? undefined);
 	// Use a safe default instead of direct localStorage access
 	const { date } = useDateRange('Future Tasks');
 	const view = useAtomValue(dailyPlanViewHeaderTabs);
@@ -49,7 +49,7 @@ export function FutureTasks({
 		return filteredData;
 	}, [date, futurePlans, user, filterByEmployee]);
 
-	if(!futureDailyPlanTasks) return null;
+	if (!futureDailyPlanTasks) return null;
 	return (
 		<div className="flex flex-col gap-6">
 			{futureDailyPlanTasks?.length > 0 ? (

--- a/apps/web/core/components/tasks/daily-plan/past-tasks.tsx
+++ b/apps/web/core/components/tasks/daily-plan/past-tasks.tsx
@@ -15,7 +15,7 @@ import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
 import DailyPlanTasksTableView from './table-view';
 import { HorizontalSeparator } from '../../duplicated-components/separator';
 import { EmptyPlans, PlanHeader } from '@/core/components/daily-plan';
-import { useDailyPlan } from '@/core/hooks';
+import { usePastPlans } from '@/core/hooks/daily-plans/derived';
 
 export function PastTasks({
 	user,
@@ -33,7 +33,7 @@ export function PastTasks({
 	// Use employeeId from props if provided, otherwise calculate from user
 	const employeeId = propsEmployeeId ?? user?.employee?.id ?? user?.employeeId ?? '';
 
-	const { pastPlans } = useDailyPlan(employeeId);
+	const pastPlans = usePastPlans(employeeId ?? undefined);
 
 	const view = useAtomValue(dailyPlanViewHeaderTabs);
 	// Use a safe default instead of direct localStorage access

--- a/apps/web/core/components/tasks/daily-plan/table-view/cells/task-action-menu-cell.tsx
+++ b/apps/web/core/components/tasks/daily-plan/table-view/cells/task-action-menu-cell.tsx
@@ -1,17 +1,16 @@
-import { CellContext } from '@tanstack/react-table';
-import { ActiveTaskStatusDropdown } from '../../../task-status';
-import { useMemo, useState } from 'react';
 import { I_UserProfilePage, useTeamMemberCard } from '@/core/hooks';
-import { get } from 'lodash';
-import { TaskCardMenu } from '../../../task-card';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { CellContext } from '@tanstack/react-table';
+import { get } from 'lodash';
+import { useMemo, useState } from 'react';
+import { TaskCardMenu } from '../../../task-card';
+import { ActiveTaskStatusDropdown } from '../../../task-status';
 
 export default function TaskActionMenuCell(props: CellContext<TTask, unknown>) {
 	const [loading, setLoading] = useState(false);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const members = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 	const profile = get(props.column, 'columnDef.meta.profile') as unknown as I_UserProfilePage;
 	const plan = get(props.column, 'columnDef.meta.plan');

--- a/apps/web/core/components/tasks/daily-plan/table-view/cells/task-estimation-cell.tsx
+++ b/apps/web/core/components/tasks/daily-plan/table-view/cells/task-estimation-cell.tsx
@@ -1,9 +1,8 @@
 import { TaskEstimateInfo } from '@/core/components/pages/teams/team/team-members-views/user-team-card/task-estimate';
 import { I_UserProfilePage, useTeamMemberCard, useTMCardTaskEdit } from '@/core/hooks';
-import { activeTeamState } from '@/core/stores';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { CellContext } from '@tanstack/react-table';
-import { useAtomValue } from 'jotai';
 import { get } from 'lodash';
 import { useMemo } from 'react';
 
@@ -11,7 +10,7 @@ export default function DailyPlanTaskEstimationCell(props: CellContext<TTask, un
 	const plan = get(props.column, 'columnDef.meta.plan');
 	const profile = get(props.column, 'columnDef.meta.profile') as unknown as I_UserProfilePage;
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const members = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 	const currentMember = useMemo(
 		() =>

--- a/apps/web/core/components/tasks/daily-plan/table-view/cells/task-times-cell.tsx
+++ b/apps/web/core/components/tasks/daily-plan/table-view/cells/task-times-cell.tsx
@@ -1,16 +1,15 @@
-import { CellContext } from '@tanstack/react-table';
-import { TaskTimes } from '../../../task-times';
 import { I_UserProfilePage, useTeamMemberCard } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { CellContext } from '@tanstack/react-table';
 import get from 'lodash/get';
 import { useMemo } from 'react';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { TaskTimes } from '../../../task-times';
 
 export default function DailyPlanTaskTimesCell(props: CellContext<TTask, unknown>) {
 	const profile = get(props.column, 'columnDef.meta.profile') as unknown as I_UserProfilePage;
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const members = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 	const currentMember = useMemo(
 		() =>

--- a/apps/web/core/components/tasks/kanban-card.tsx
+++ b/apps/web/core/components/tasks/kanban-card.tsx
@@ -1,17 +1,17 @@
-import { DraggableProvided } from '@hello-pangea/dnd';
+import CircularProgress from '@/core/components/svgs/circular-progress';
 import PriorityIcon from '@/core/components/svgs/priority-icon';
 import { useTaskStatistics, useTeamMemberCard, useTimerView } from '@/core/hooks';
-import { ImageOverlapperProps } from '../common/image-overlapper';
-import Link from 'next/link';
-import CircularProgress from '@/core/components/svgs/circular-progress';
 import { secondsToTime } from '@/core/lib/helpers/index';
-import { activeTeamState, activeTeamTaskId, activeTeamTaskState } from '@/core/stores';
-import { useAtom, useAtomValue } from 'jotai';
-import { HorizontalSeparator } from '../duplicated-components/separator';
-import { ITag } from '@/core/types/interfaces/tag/tag';
+import { activeTeamTaskId, activeTeamTaskState } from '@/core/stores';
 import { ETaskPriority } from '@/core/types/generics/enums/task';
-import { TTask } from '@/core/types/schemas/task/task.schema';
+import { ITag } from '@/core/types/interfaces/tag/tag';
 import { TTaskStatistics } from '@/core/types/interfaces/task/task';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { DraggableProvided } from '@hello-pangea/dnd';
+import { useAtom, useAtomValue } from 'jotai';
+import Link from 'next/link';
+import { ImageOverlapperProps } from '../common/image-overlapper';
+import { HorizontalSeparator } from '../duplicated-components/separator';
 
 import { LazyImageComponent, LazyMenuKanbanCard } from '@/core/components/optimized-components/kanban';
 import {
@@ -20,6 +20,7 @@ import {
 	LazyTaskIssueStatus
 } from '@/core/components/optimized-components/tasks';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 function getStyle(provided: DraggableProvided, style: any) {
 	if (!style) {
@@ -133,7 +134,7 @@ type ItemProps = {
  */
 export default function Item(props: ItemProps) {
 	const { item, isDragging, provided, style } = props;
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 	const { getEstimation } = useTaskStatistics(0);
 	const [activeTask, setActiveTask] = useAtom(activeTeamTaskId);

--- a/apps/web/core/components/tasks/kanban-card.tsx
+++ b/apps/web/core/components/tasks/kanban-card.tsx
@@ -2,13 +2,13 @@ import CircularProgress from '@/core/components/svgs/circular-progress';
 import PriorityIcon from '@/core/components/svgs/priority-icon';
 import { useTaskStatistics, useTeamMemberCard, useTimerView } from '@/core/hooks';
 import { secondsToTime } from '@/core/lib/helpers/index';
-import { activeTeamTaskId, activeTeamTaskState } from '@/core/stores';
+import { activeTeamTaskId } from '@/core/stores';
 import { ETaskPriority } from '@/core/types/generics/enums/task';
 import { ITag } from '@/core/types/interfaces/tag/tag';
 import { TTaskStatistics } from '@/core/types/interfaces/task/task';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { DraggableProvided } from '@hello-pangea/dnd';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue } from 'jotai';
 import Link from 'next/link';
 import { ImageOverlapperProps } from '../common/image-overlapper';
 import { HorizontalSeparator } from '../duplicated-components/separator';
@@ -19,8 +19,10 @@ import {
 	LazyTaskInput,
 	LazyTaskIssueStatus
 } from '@/core/components/optimized-components/tasks';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useSetActiveTask } from '@/core/hooks/organizations/teams/use-set-active-task';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
 function getStyle(provided: DraggableProvided, style: any) {
 	if (!style) {
@@ -137,8 +139,9 @@ export default function Item(props: ItemProps) {
 	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 	const { getEstimation } = useTaskStatistics(0);
-	const [activeTask, setActiveTask] = useAtom(activeTeamTaskId);
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { setActiveTask } = useSetActiveTask();
+	const activeTask = useAtomValue(activeTeamTaskId);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 	const { timerStatus } = useTimerView();
 
 	const members = activeTeam?.members || [];
@@ -223,7 +226,7 @@ export default function Item(props: ItemProps) {
 											console.log(e);
 										}}
 										onEnterKey={() => {
-											setActiveTask({ id: '' });
+											setActiveTask(activeTeamTask ?? null);
 										}}
 									/>
 								</div>

--- a/apps/web/core/components/tasks/task-block-card.tsx
+++ b/apps/web/core/components/tasks/task-block-card.tsx
@@ -1,19 +1,20 @@
-import { TTaskStatistics } from '@/core/types/interfaces/task/task';
-import { TaskInput } from './task-input';
-import { useAtom, useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskId, activeTeamTaskState, timerStatusState } from '@/core/stores';
-import Link from 'next/link';
-import { useTaskStatistics, useTeamMemberCard } from '@/core/hooks';
 import ImageComponent, { ImageOverlapperProps } from '@/core/components/common/image-overlapper';
-import { TaskIssueStatus } from './task-issue';
-import { Priority, setCommentIconColor } from '@/core/components/tasks/kanban-card';
 import CircularProgress from '@/core/components/svgs/circular-progress';
+import { Priority, setCommentIconColor } from '@/core/components/tasks/kanban-card';
+import { useTaskStatistics, useTeamMemberCard } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { secondsToTime } from '@/core/lib/helpers/index';
+import { activeTeamTaskId, activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { TTaskStatistics } from '@/core/types/interfaces/task/task';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useAtom, useAtomValue } from 'jotai';
+import Link from 'next/link';
 import React from 'react';
 import { HorizontalSeparator } from '../duplicated-components/separator';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { LazyMenuKanbanCard, LazyTaskAllStatusTypes } from '../optimized-components';
+import { TaskInput } from './task-input';
+import { TaskIssueStatus } from './task-issue';
 
 interface TaskItemProps {
 	task: TTask;
@@ -22,7 +23,7 @@ interface TaskItemProps {
 export default function TaskBlockCard(props: TaskItemProps) {
 	const { task } = props;
 	const [activeTask, setActiveTask] = useAtom(activeTeamTaskId);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const timerStatus = useAtomValue(timerStatusState);
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);

--- a/apps/web/core/components/tasks/task-block-card.tsx
+++ b/apps/web/core/components/tasks/task-block-card.tsx
@@ -2,13 +2,15 @@ import ImageComponent, { ImageOverlapperProps } from '@/core/components/common/i
 import CircularProgress from '@/core/components/svgs/circular-progress';
 import { Priority, setCommentIconColor } from '@/core/components/tasks/kanban-card';
 import { useTaskStatistics, useTeamMemberCard } from '@/core/hooks';
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useSetActiveTask } from '@/core/hooks/organizations/teams/use-set-active-task';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { secondsToTime } from '@/core/lib/helpers/index';
-import { activeTeamTaskId, activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { activeTeamTaskId, timerStatusState } from '@/core/stores';
 import { TTaskStatistics } from '@/core/types/interfaces/task/task';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue } from 'jotai';
 import Link from 'next/link';
 import React from 'react';
 import { HorizontalSeparator } from '../duplicated-components/separator';
@@ -22,11 +24,12 @@ interface TaskItemProps {
 
 export default function TaskBlockCard(props: TaskItemProps) {
 	const { task } = props;
-	const [activeTask, setActiveTask] = useAtom(activeTeamTaskId);
+	const { setActiveTask } = useSetActiveTask();
+	const activeTask = useAtomValue(activeTeamTaskId);
 	const activeTeam = useCurrentTeam();
 	const timerStatus = useAtomValue(timerStatusState);
 
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 
 	const { data: user } = useUserQuery();
 	const { getEstimation } = useTaskStatistics(0);
@@ -112,7 +115,7 @@ export default function TaskBlockCard(props: TaskItemProps) {
 											console.log(e);
 										}}
 										onEnterKey={() => {
-											setActiveTask({ id: '' });
+											setActiveTask(task ?? null);
 										}}
 									/>
 								</div>

--- a/apps/web/core/components/tasks/task-card.tsx
+++ b/apps/web/core/components/tasks/task-card.tsx
@@ -19,13 +19,14 @@ import {
 	useTaskStatistics,
 	useTeamMemberCard
 } from '@/core/hooks';
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { useFavoriteTasks } from '@/core/hooks/tasks/use-favorites-task';
 import { useTimerButtonLogic } from '@/core/hooks/tasks/use-timer-button';
 import { secondsToTime, tomorrowDate } from '@/core/lib/helpers/index';
 import { clsxm } from '@/core/lib/utils';
-import { activeTeamTaskState, timerSecondsState } from '@/core/stores';
+import { timerSecondsState } from '@/core/stores';
 import { Nullable, SetAtom } from '@/core/types/generics';
 import { EDailyPlanMode, EDailyPlanStatus } from '@/core/types/generics/enums/daily-plan';
 import { IClassName } from '@/core/types/interfaces/common/class-name';
@@ -388,7 +389,7 @@ const TimerButtonCall = React.memo(
 		activeTeam: TOrganizationTeam | null;
 		className?: string;
 	}) => {
-		const activeTeamTask = useAtomValue(activeTeamTaskState);
+		const { task: activeTeamTask } = useCurrentActiveTask();
 
 		const {
 			loading,

--- a/apps/web/core/components/tasks/task-card.tsx
+++ b/apps/web/core/components/tasks/task-card.tsx
@@ -1,5 +1,14 @@
 'use client';
-import { secondsToTime, tomorrowDate } from '@/core/lib/helpers/index';
+import { SpinnerLoader, Text } from '@/core/components';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuPortal,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger
+} from '@/core/components/common/dropdown-menu';
+import ImageComponent, { ImageOverlapperProps } from '@/core/components/common/image-overlapper';
 import {
 	I_TeamMemberCardHook,
 	I_UserProfilePage,
@@ -10,52 +19,44 @@ import {
 	useTaskStatistics,
 	useTeamMemberCard
 } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import ImageComponent, { ImageOverlapperProps } from '@/core/components/common/image-overlapper';
-import { EDailyPlanStatus, EDailyPlanMode } from '@/core/types/generics/enums/daily-plan';
+import { useFavoriteTasks } from '@/core/hooks/tasks/use-favorites-task';
+import { useTimerButtonLogic } from '@/core/hooks/tasks/use-timer-button';
+import { secondsToTime, tomorrowDate } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { activeTeamTaskState, timerSecondsState } from '@/core/stores';
+import { Nullable, SetAtom } from '@/core/types/generics';
+import { EDailyPlanMode, EDailyPlanStatus } from '@/core/types/generics/enums/daily-plan';
+import { IClassName } from '@/core/types/interfaces/common/class-name';
+import { IEmployee } from '@/core/types/interfaces/organization/employee';
 import {
 	IDailyPlanTasksUpdate,
 	IRemoveTaskFromManyPlansRequest
 } from '@/core/types/interfaces/task/daily-plan/daily-plan';
-import { activeTeamState, activeTeamTaskState, timerSecondsState } from '@/core/stores';
-import { clsxm } from '@/core/lib/utils';
-import {
-	DropdownMenu,
-	DropdownMenuTrigger,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownMenuPortal
-} from '@/core/components/common/dropdown-menu';
-import { SpinnerLoader, Text } from '@/core/components';
+import { TDailyPlan, TOrganizationTeam, TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { ReloadIcon } from '@radix-ui/react-icons';
+import { SixSquareGridIcon, ThreeCircleOutlineVerticalIcon } from 'assets/svg';
+import { SetStateAction, useAtomValue } from 'jotai';
+import { LoaderCircle } from 'lucide-react';
+import moment from 'moment';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import React, { useCallback, useMemo, useState, useTransition } from 'react';
-import { SetStateAction, useAtomValue } from 'jotai';
+import { toast } from 'sonner';
+import { EverCard } from '../common/ever-card';
+import { AddTasksEstimationHoursModal, EnforcePlanedTaskModal, SuggestDailyPlanModal } from '../daily-plan';
+import { VerticalSeparator } from '../duplicated-components/separator';
+import { AddTaskToPlan } from '../features/daily-plan/add-task-to-plan';
+import { CreateDailyPlanFormModal } from '../features/daily-plan/create-daily-plan-form-modal';
+import { TaskEstimateInfo } from '../pages/teams/team/team-members-views/user-team-card/task-estimate';
 import { TimerButton } from '../timer/timer-button';
 import { TaskAllStatusTypes } from './task-all-status-type';
 import { TaskNameInfoDisplay } from './task-displays';
 import { TaskAvatars } from './task-items';
 import { ActiveTaskStatusDropdown } from './task-status';
 import { TaskTimes } from './task-times';
-import { useTranslations } from 'next-intl';
-import { SixSquareGridIcon, ThreeCircleOutlineVerticalIcon } from 'assets/svg';
-import { CreateDailyPlanFormModal } from '../features/daily-plan/create-daily-plan-form-modal';
-import { ReloadIcon } from '@radix-ui/react-icons';
-import moment from 'moment';
-import { AddTasksEstimationHoursModal, EnforcePlanedTaskModal, SuggestDailyPlanModal } from '../daily-plan';
-import { Nullable, SetAtom } from '@/core/types/generics';
-import { TaskEstimateInfo } from '../pages/teams/team/team-members-views/user-team-card/task-estimate';
-import { EverCard } from '../common/ever-card';
-import { VerticalSeparator } from '../duplicated-components/separator';
-import { AddTaskToPlan } from '../features/daily-plan/add-task-to-plan';
-import { IEmployee } from '@/core/types/interfaces/organization/employee';
-import { IClassName } from '@/core/types/interfaces/common/class-name';
-import { toast } from 'sonner';
-import { TDailyPlan, TOrganizationTeam, TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { useTimerButtonLogic } from '@/core/hooks/tasks/use-timer-button';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { LoaderCircle } from 'lucide-react';
-import { useFavoriteTasks } from '@/core/hooks/tasks/use-favorites-task';
 
 type Props = {
 	active?: boolean;
@@ -100,7 +101,7 @@ export const TaskCard = React.memo(function TaskCard(props: Props) {
 	);
 
 	const { data: user } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const canSeeActivity = useCanSeeActivityScreen();
 
 	const isTrackingEnabled = useMemo(

--- a/apps/web/core/components/tasks/task-card.tsx
+++ b/apps/web/core/components/tasks/task-card.tsx
@@ -13,7 +13,6 @@ import {
 	I_TeamMemberCardHook,
 	I_UserProfilePage,
 	useCanSeeActivityScreen,
-	useDailyPlan,
 	useModal,
 	useTMCardTaskEdit,
 	useTaskStatistics,
@@ -58,6 +57,12 @@ import { TaskNameInfoDisplay } from './task-displays';
 import { TaskAvatars } from './task-items';
 import { ActiveTaskStatusDropdown } from './task-status';
 import { TaskTimes } from './task-times';
+import { useFuturePlans, useTodayPlan } from '@/core/hooks/daily-plans/derived';
+import {
+	useCreateDailyPlanMutation,
+	useRemoveTaskFromManyPlansMutation,
+	useRemoveTaskFromPlanMutation
+} from '@/core/hooks/daily-plans/mutations';
 
 type Props = {
 	active?: boolean;
@@ -592,7 +597,8 @@ export function TaskCardMenu({
 
 	const canSeeActivity = useCanSeeActivityScreen();
 
-	const { todayPlan, futurePlans } = useDailyPlan();
+	const todayPlan = useTodayPlan();
+	const futurePlans = useFuturePlans();
 
 	const taskPlannedToday = useMemo(
 		() => todayPlan[todayPlan.length - 1]?.tasks?.find((planTask) => planTask.id === task.id),
@@ -795,7 +801,7 @@ export function PlanTask({
 	const t = useTranslations();
 	const [isPending, startTransition] = useTransition();
 
-	const { createDailyPlan, createDailyPlanLoading } = useDailyPlan();
+	const { mutateAsync: createDailyPlan, isPending: createDailyPlanLoading } = useCreateDailyPlanMutation();
 	const { data: user } = useUserQuery();
 
 	const handleOpenModal = async () => {
@@ -806,6 +812,7 @@ export function PlanTask({
 			} else if (planMode === 'today') {
 				startTransition(async () => {
 					try {
+						if (!user?.tenantId) throw new Error('Workspace should be defined');
 						await createDailyPlan({
 							workTimePlanned: 0,
 							taskId,
@@ -912,13 +919,13 @@ export function RemoveTaskFromPlan({
 	plan?: TDailyPlan;
 }) {
 	const t = useTranslations();
-	const { removeTaskFromPlan } = useDailyPlan(member?.employeeId);
+	const { mutateAsync: removeTaskFromPlan } = useRemoveTaskFromPlanMutation();
 	const data: IDailyPlanTasksUpdate = {
 		taskId: task.id,
 		employeeId: member?.employeeId ?? undefined
 	};
 	const onClick = () => {
-		removeTaskFromPlan(data, plan?.id ?? '');
+		removeTaskFromPlan({ dailyPlanId: plan?.id ?? '', data });
 	};
 	return (
 		<span
@@ -935,13 +942,13 @@ export function RemoveTaskFromPlan({
 
 export function RemoveManyTaskFromPlan({ task, member }: { task: TTask; member?: TOrganizationTeamEmployee }) {
 	// const t = useTranslations();
-	const { removeManyTaskPlans } = useDailyPlan();
+	const { mutateAsync: removeManyTaskPlans } = useRemoveTaskFromManyPlansMutation();
 	const data: IRemoveTaskFromManyPlansRequest = {
 		plansIds: [],
 		employeeId: member?.employeeId ?? ''
 	};
 	const onClick = () => {
-		removeManyTaskPlans(data, task.id ?? '');
+		removeManyTaskPlans({ data, taskId: task.id ?? '' });
 	};
 	return (
 		<span

--- a/apps/web/core/components/tasks/task-detail-card.tsx
+++ b/apps/web/core/components/tasks/task-detail-card.tsx
@@ -1,14 +1,15 @@
-import { secondsToTime } from '@/core/lib/helpers/date-and-time';
-import { useTaskStatistics } from '@/core/hooks/tasks/use-task-statistics';
-import { activeTaskStatisticsState, activeTeamTaskState, timerSecondsState } from '@/core/stores';
-import { RawStatusDropdown } from '@/core/components/tasks/status-dropdown';
 import { ProgressBar } from '@/core/components/common/progress-bar';
 import Separator from '@/core/components/common/separator';
+import { RawStatusDropdown } from '@/core/components/tasks/status-dropdown';
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
+import { useTaskStatistics } from '@/core/hooks/tasks/use-task-statistics';
+import { secondsToTime } from '@/core/lib/helpers/date-and-time';
+import { activeTaskStatisticsState, timerSecondsState } from '@/core/stores';
+import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
 import { useRef } from 'react';
-import { useAtomValue } from 'jotai';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
 
 interface ITaskDetailCard {
 	now?: boolean;
@@ -22,7 +23,7 @@ const TaskDetailCard = ({ now = false, task }: ITaskDetailCard) => {
 
 	let taskStat: TTaskStatistic | null | undefined = null;
 
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 
 	const statActiveTask = useAtomValue(activeTaskStatisticsState);
 

--- a/apps/web/core/components/tasks/task-input.tsx
+++ b/apps/web/core/components/tasks/task-input.tsx
@@ -12,9 +12,11 @@ import {
 	useTaskInput
 } from '@/core/hooks';
 import { useInfinityScrolling } from '@/core/hooks/common/use-infinity-fetch';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useSetActiveTask } from '@/core/hooks/organizations/teams/use-set-active-task';
 import { cn } from '@/core/lib/helpers';
 import { clsxm } from '@/core/lib/utils';
-import { activeTeamTaskId, issueTypesListState, taskLabelsListState, timerStatusState } from '@/core/stores';
+import { issueTypesListState, taskLabelsListState, timerStatusState } from '@/core/stores';
 import { EIssueType, ETaskPriority, ETaskSize, ETaskStatusName } from '@/core/types/generics/enums/task';
 import { Nullable } from '@/core/types/generics/utils';
 import { IIssueType } from '@/core/types/interfaces/task/issue-type';
@@ -23,7 +25,7 @@ import { TTask } from '@/core/types/schemas/task/task.schema';
 import { Combobox, Popover, PopoverPanel, Transition } from '@headlessui/react';
 import { CheckIcon, ChevronDownIcon, PlusIcon, UserGroupIcon } from '@heroicons/react/20/solid';
 import { CircleIcon, CheckCircleTickIcon as TickCircleIcon } from 'assets/svg';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
 import { JSX, PropsWithChildren, RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -36,7 +38,6 @@ import { ActiveTaskIssuesDropdown, TaskIssuesDropdown } from './task-issue';
 import { TaskItem } from './task-items';
 import { TaskLabels } from './task-labels';
 import { ActiveTaskPropertiesDropdown, ActiveTaskSizesDropdown, ActiveTaskStatusDropdown } from './task-status';
-import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 type Props = {
 	task?: Nullable<TTask>;
@@ -118,8 +119,7 @@ export function TaskInput(props: Props) {
 		updateTaskTitleHandler,
 		setFilter
 	} = datas;
-	const setActiveTask = useSetAtom(activeTeamTaskId);
-
+	const { setActiveTask } = useSetActiveTask();
 	const inputTaskTitle = useMemo(() => inputTask?.title || '', [inputTask?.title]);
 
 	const [taskName, setTaskName] = useState('');
@@ -148,12 +148,7 @@ export function TaskInput(props: Props) {
 	 */
 	const setAuthActiveTask = useCallback(
 		(task: TTask) => {
-			if (datas.setActiveTask) {
-				// NOTE_FIX: datas.setActiveTask already calls updateOrganizationTeamEmployeeActiveTask
-				// which has optimistic updates for React Query. No need to call updateOrganizationTeamEmployee
-				// here as it would be redundant and would overwrite the optimistic update.
-				datas.setActiveTask(task);
-			}
+			setActiveTask(task);
 			setEditMode(false);
 		},
 		[datas, setEditMode]

--- a/apps/web/core/components/tasks/task-input.tsx
+++ b/apps/web/core/components/tasks/task-input.tsx
@@ -1,4 +1,7 @@
 'use client';
+import { Button, Divider, SpinnerLoader } from '@/core/components';
+import { LazyRender } from '@/core/components/common/lazy-render';
+import { ProjectDropDown } from '@/core/components/pages/task/details-section/blocks/task-secondary-info';
 import {
 	HostKeys,
 	RTuseTaskInput,
@@ -8,40 +11,32 @@ import {
 	useOutsideClick,
 	useTaskInput
 } from '@/core/hooks';
-import {
-	activeTeamState,
-	activeTeamTaskId,
-	issueTypesListState,
-	timerStatusState,
-	taskLabelsListState
-} from '@/core/stores';
+import { useInfinityScrolling } from '@/core/hooks/common/use-infinity-fetch';
+import { cn } from '@/core/lib/helpers';
 import { clsxm } from '@/core/lib/utils';
+import { activeTeamTaskId, issueTypesListState, taskLabelsListState, timerStatusState } from '@/core/stores';
+import { EIssueType, ETaskPriority, ETaskSize, ETaskStatusName } from '@/core/types/generics/enums/task';
+import { Nullable } from '@/core/types/generics/utils';
+import { IIssueType } from '@/core/types/interfaces/task/issue-type';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { Combobox, Popover, PopoverPanel, Transition } from '@headlessui/react';
 import { CheckIcon, ChevronDownIcon, PlusIcon, UserGroupIcon } from '@heroicons/react/20/solid';
-import { Button, Divider, SpinnerLoader } from '@/core/components';
 import { CircleIcon, CheckCircleTickIcon as TickCircleIcon } from 'assets/svg';
-import { JSX, RefObject, PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
+import { useTranslations } from 'next-intl';
+import { JSX, PropsWithChildren, RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { EverCard } from '../common/ever-card';
+import { InputField } from '../duplicated-components/_input';
+import { OutlineBadge } from '../duplicated-components/badge';
+import { Tooltip } from '../duplicated-components/tooltip';
+import { ObserverComponent } from './observer';
 import { ActiveTaskIssuesDropdown, TaskIssuesDropdown } from './task-issue';
 import { TaskItem } from './task-items';
 import { TaskLabels } from './task-labels';
 import { ActiveTaskPropertiesDropdown, ActiveTaskSizesDropdown, ActiveTaskStatusDropdown } from './task-status';
-import { useTranslations } from 'next-intl';
-import { useInfinityScrolling } from '@/core/hooks/common/use-infinity-fetch';
-import { LazyRender } from '@/core/components/common/lazy-render';
-import { ProjectDropDown } from '@/core/components/pages/task/details-section/blocks/task-secondary-info';
-import { toast } from 'sonner';
-import { cn } from '@/core/lib/helpers';
-import { InputField } from '../duplicated-components/_input';
-import { Tooltip } from '../duplicated-components/tooltip';
-import { EverCard } from '../common/ever-card';
-import { OutlineBadge } from '../duplicated-components/badge';
-import { ObserverComponent } from './observer';
-import { Nullable } from '@/core/types/generics/utils';
-import { IIssueType } from '@/core/types/interfaces/task/issue-type';
-import { EIssueType, ETaskStatusName, ETaskPriority, ETaskSize } from '@/core/types/generics/enums/task';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 type Props = {
 	task?: Nullable<TTask>;
@@ -495,7 +490,7 @@ function TaskCard({
 	const activeTaskEl = useRef<HTMLLIElement | null>(null);
 	const taskLabelsData = useAtomValue(taskLabelsListState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	// Refs for dropdown elements to exclude from outside click detection
 	const statusDropdownRef = useRef<HTMLDivElement>(null);

--- a/apps/web/core/components/tasks/task-items.tsx
+++ b/apps/web/core/components/tasks/task-items.tsx
@@ -1,22 +1,22 @@
-import { imgTitle } from '@/core/lib/helpers/index';
-import { useTeamTasks } from '@/core/hooks';
-import { clsxm, isValidUrl } from '@/core/lib/utils';
-import clsx from 'clsx';
 import { ConfirmDropdown, SpinnerLoader } from '@/core/components';
 import ImageComponent, { ImageOverlapperProps } from '@/core/components/common/image-overlapper';
+import { useHandleStatusUpdate } from '@/core/hooks/organizations/teams/use-handle-status-update';
+import { imgTitle } from '@/core/lib/helpers/index';
+import { clsxm, isValidUrl } from '@/core/lib/utils';
+import { ETaskStatusName } from '@/core/types/generics/enums/task';
+import { IClassName } from '@/core/types/interfaces/common/class-name';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { CrossIcon, RefreshIcon } from 'assets/svg';
+import clsx from 'clsx';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useCallback } from 'react';
 import stc from 'string-to-color';
+import { Avatar } from '../duplicated-components/avatar';
+import { Tooltip } from '../duplicated-components/tooltip';
 import { TaskIssueStatus } from './task-issue';
 import { TaskPriorityStatus } from './task-status';
 import { TaskStatusModal } from './task-status-modal';
-import { useTranslations } from 'next-intl';
-import { Tooltip } from '../duplicated-components/tooltip';
-import { Avatar } from '../duplicated-components/avatar';
-import { IClassName } from '@/core/types/interfaces/common/class-name';
-import { ETaskStatusName } from '@/core/types/generics/enums/task';
-import { TTask } from '@/core/types/schemas/task/task.schema';
 
 type Props = {
 	task?: TTask;
@@ -25,7 +25,8 @@ type Props = {
 } & IClassName;
 
 export function TaskItem({ task, selected, onClick, className }: Props) {
-	const { handleStatusUpdate, updateLoading } = useTeamTasks();
+	const { handleStatusUpdate, isPending: updateLoading } = useHandleStatusUpdate();
+
 	const t = useTranslations();
 
 	const handleChange = useCallback(
@@ -142,7 +143,7 @@ export function TaskAvatars({ task, limit = 2 }: { task: PartialITeamTask; limit
 	if (!members?.length) {
 		return (
 			<div className="flex justify-center items-center -space-x-2 avatars min-w-10">
-				<ImageComponent radius={30} diameter={30} images={taskAssignee} item={task} />
+				<ImageComponent radius={30} diameter={30} images={taskAssignee} item={task as TTask} />
 			</div>
 		);
 	}

--- a/apps/web/core/components/tasks/task-list.tsx
+++ b/apps/web/core/components/tasks/task-list.tsx
@@ -10,6 +10,7 @@ import TaskFilter from './task-filter';
 import { TaskItem } from './task-item';
 import { useTranslations } from 'next-intl';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useSetActiveTask } from '@/core/hooks/organizations/teams/use-set-active-task';
 
 export function CreateTaskOption({ onClick, loading }: { onClick: () => void; loading?: boolean }) {
 	const t = useTranslations();
@@ -31,7 +32,6 @@ export function CreateTaskOption({ onClick, loading }: { onClick: () => void; lo
 export function TasksList({ onClickTask }: { onClickTask?: (task: TTask) => void }) {
 	const {
 		inputTask,
-		setActiveTask,
 		editMode,
 		setEditMode,
 		setQuery,
@@ -51,6 +51,7 @@ export function TasksList({ onClickTask }: { onClickTask?: (task: TTask) => void
 		closeModal,
 		closeableTask
 	} = useTaskInput();
+	const { setActiveTask } = useSetActiveTask();
 	const t = useTranslations();
 	const [combxShow, setCombxShow] = useState<true | undefined>(undefined);
 

--- a/apps/web/core/components/tasks/task-progress-bar.tsx
+++ b/apps/web/core/components/tasks/task-progress-bar.tsx
@@ -1,10 +1,11 @@
-import { I_TeamMemberCardHook, useTaskStatistics } from '@/core/hooks';
-import { Nullable } from '@/core/types/generics/utils';
-import { activeTeamState, timerSecondsState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
 import RadialProgress from '@/core/components/common/radial-progress';
-import { ProgressBar } from '../duplicated-components/_progress-bar';
+import { I_TeamMemberCardHook, useTaskStatistics } from '@/core/hooks';
+import { timerSecondsState } from '@/core/stores';
+import { Nullable } from '@/core/types/generics/utils';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useAtomValue } from 'jotai';
+import { ProgressBar } from '../duplicated-components/_progress-bar';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 export function TaskProgressBar({
 	isAuthUser,
@@ -24,7 +25,7 @@ export function TaskProgressBar({
 	const seconds = useAtomValue(timerSecondsState);
 	const { getEstimation } = useTaskStatistics(isAuthUser && activeAuthTask ? seconds : 0);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	//removed as when certain task's timer was active it was affecting the timers with no estimations. Was taking user's previous task's estimation
 	// const currentMember = activeTeam?.members.find(
 	// 	(member) => member.id === memberInfo?.member?.id

--- a/apps/web/core/components/tasks/task-status.tsx
+++ b/apps/web/core/components/tasks/task-status.tsx
@@ -1,34 +1,35 @@
 'use client';
 /* eslint-disable no-mixed-spaces-and-tabs */
+import { Nullable } from '@/core/types/generics/utils';
 import { IClassName } from '@/core/types/interfaces/common/class-name';
 import { ITaskStatusField } from '@/core/types/interfaces/task/task-status/task-status-field';
-import { Nullable } from '@/core/types/generics/utils';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 // import { LoginIcon, RecordIcon } from 'lib/components/svgs';
-import { PropsWithChildren, useMemo } from 'react';
+import { SpinnerLoader } from '@/core/components/common/loader';
 import { useStatusValue, useTaskStatusValue } from '@/core/hooks';
-import { XMarkIcon } from '@heroicons/react/24/outline';
-import { readableColor } from 'polished';
-import { useTheme } from 'next-themes';
-import { Square4OutlineIcon, CircleIcon } from 'assets/svg';
-import { getTextColor } from '@/core/lib/helpers/index';
-import { Tooltip } from '../duplicated-components/tooltip';
-import { CustomListboxDropdown } from './custom-dropdown';
-import { capitalize } from 'lodash';
+import { useSortedTasksByCreation } from '@/core/hooks/organizations/teams/use-sorted-tasks';
+import { useActiveTaskStatus } from '@/core/hooks/tasks/use-active-task-status';
+import { useMapToTaskStatusValues } from '@/core/hooks/tasks/use-map-to-task-status-values';
+import { useTaskLabelsValue } from '@/core/hooks/tasks/use-task-labels-value';
+import { useTaskPrioritiesValue } from '@/core/hooks/tasks/use-task-priorities-value';
+import { useTaskVersionsValue } from '@/core/hooks/tasks/use-task-versions-value';
 import { cn } from '@/core/lib/helpers';
+import { getTextColor } from '@/core/lib/helpers/index';
+import { taskSizesListState } from '@/core/stores';
 import { ETaskStatusName } from '@/core/types/generics/enums/task';
+import { IActiveTaskStatuses, TStatusItem, TTaskStatusesDropdown } from '@/core/types/interfaces/task/task-card';
 import { TTaskStatus } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { TStatusItem, TTaskStatusesDropdown, IActiveTaskStatuses } from '@/core/types/interfaces/task/task-card';
-import { MultipleStatusDropdown } from './multiple-status-dropdown';
-import { useTaskVersionsValue } from '@/core/hooks/tasks/use-task-versions-value';
-import { SpinnerLoader } from '@/core/components/common/loader';
-import { useTaskPrioritiesValue } from '@/core/hooks/tasks/use-task-priorities-value';
-import { useMapToTaskStatusValues } from '@/core/hooks/tasks/use-map-to-task-status-values';
-import { useActiveTaskStatus } from '@/core/hooks/tasks/use-active-task-status';
-import { useTaskLabelsValue } from '@/core/hooks/tasks/use-task-labels-value';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { CircleIcon, Square4OutlineIcon } from 'assets/svg';
 import { useAtomValue } from 'jotai';
-import { tasksByTeamState, taskSizesListState } from '@/core/stores';
+import { capitalize } from 'lodash';
+import { useTheme } from 'next-themes';
+import { readableColor } from 'polished';
+import { PropsWithChildren, useMemo } from 'react';
+import { Tooltip } from '../duplicated-components/tooltip';
+import { CustomListboxDropdown } from './custom-dropdown';
+import { MultipleStatusDropdown } from './multiple-status-dropdown';
 
 /**
  * Task status dropwdown
@@ -237,7 +238,7 @@ export function EpicPropertiesDropdown({
 	children,
 	taskStatusClassName
 }: TTaskStatusesDropdown<'epic'>) {
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasksByCreation();
 	const status = useMemo(() => {
 		const temp: any = {};
 		tasks.forEach((task) => {

--- a/apps/web/core/components/tasks/task-statuses-form.tsx
+++ b/apps/web/core/components/tasks/task-statuses-form.tsx
@@ -1,23 +1,22 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { useModal, useRefetchData, useTaskStatus } from '@/core/hooks';
-import { tasksByTeamState } from '@/core/stores';
-import { clsxm } from '@/core/lib/utils';
-import { Spinner } from '@/core/components/common/spinner';
-import { PlusIcon } from '@heroicons/react/20/solid';
 import { Button, ColorPicker, Modal, Text } from '@/core/components';
+import { Spinner } from '@/core/components/common/spinner';
+import { DeleteTaskStatusConfirmationModal } from '@/core/components/features/tasks/delete-status-confirmation-modal';
+import SortTasksStatusSettings from '@/core/components/pages/kanban/sort-tasks-status-settings';
+import { useModal, useRefetchData, useTaskStatus } from '@/core/hooks';
+import { useSortedTasksByCreation } from '@/core/hooks/organizations/teams/use-sorted-tasks';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { clsxm } from '@/core/lib/utils';
+import { TTaskStatus } from '@/core/types/schemas';
+import { PlusIcon } from '@heroicons/react/20/solid';
+import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useTranslations } from 'next-intl';
-import { useAtomValue } from 'jotai';
+import { InputField } from '../duplicated-components/_input';
 import { generateIconList, IIcon } from '../settings/icon-items';
 import IconPopover from '../settings/icon-popover';
 import { StatusesListCard } from '../settings/list-card';
-import SortTasksStatusSettings from '@/core/components/pages/kanban/sort-tasks-status-settings';
-import { DeleteTaskStatusConfirmationModal } from '@/core/components/features/tasks/delete-status-confirmation-modal';
 import { StandardTaskStatusDropDown } from './task-status';
-import { InputField } from '../duplicated-components/_input';
-import { TTaskStatus } from '@/core/types/schemas';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
 type StatusForm = {
 	formOnly?: boolean;
@@ -140,7 +139,7 @@ export const TaskStatusesForm = ({ formOnly = false, onCreated }: StatusForm) =>
 		openModal: openDeleteConfirmationModal
 	} = useModal();
 	const [statusToDelete, setStatusToDelete] = useState<TTaskStatus | null>(null);
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasksByCreation();
 
 	/**
 	 * Get Icon by status name

--- a/apps/web/core/components/tasks/task-times.tsx
+++ b/apps/web/core/components/tasks/task-times.tsx
@@ -1,18 +1,17 @@
-import { secondsToTime } from '@/core/lib/helpers/index';
-import { I_TeamMemberCardHook } from '@/core/hooks';
-import { IClassName } from '@/core/types/interfaces/common/class-name';
-import { Nullable } from '@/core/types/generics/utils';
-import { IEmployee } from '@/core/types/interfaces/organization/employee';
-import { clsxm } from '@/core/lib/utils';
 import { Text } from '@/core/components';
+import { I_TeamMemberCardHook } from '@/core/hooks';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { secondsToTime } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { Nullable } from '@/core/types/generics/utils';
+import { IClassName } from '@/core/types/interfaces/common/class-name';
+import { IEmployee } from '@/core/types/interfaces/organization/employee';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 import { Tooltip } from '../duplicated-components/tooltip';
-import { TOrganizationTeamEmployee } from '@/core/types/schemas';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
-import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
 
 type Props = {
 	task: Nullable<TTask>;
@@ -27,7 +26,7 @@ type Props = {
 export function TaskTimes({ className, task, memberInfo, showDaily = true, showTotal = true, isBlock = false }: Props) {
 	// For public page
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const currentMember = useMemo(
 		() => activeTeam?.members?.find((member) => member.id === memberInfo?.member?.id || memberInfo?.id),
 		[activeTeam?.members, memberInfo?.id, memberInfo?.member?.id]
@@ -216,7 +215,7 @@ function TimeBlockInfo({
 export function TodayWorkedTime({ className, memberInfo }: Omit<Props, 'task' | 'activeAuthTask'>) {
 	// Get current timer seconds
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const t = useTranslations();
 

--- a/apps/web/core/components/tasks/unassigned-task.tsx
+++ b/apps/web/core/components/tasks/unassigned-task.tsx
@@ -1,14 +1,15 @@
-import { secondsToTime } from '@/core/lib/helpers/date-and-time';
 import { RawStatusDropdown } from '@/core/components/tasks/status-dropdown';
+import { secondsToTime } from '@/core/lib/helpers/date-and-time';
 
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
 import { useTaskStatistics } from '@/core/hooks/tasks/use-task-statistics';
-import { activeTaskStatisticsState, activeTeamTaskState, timerSecondsState } from '@/core/stores';
+import { activeTaskStatisticsState, timerSecondsState } from '@/core/stores';
+import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { PlayIcon } from '@heroicons/react/20/solid';
-import { useRef } from 'react';
 import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { useRef } from 'react';
 
 interface ITaskDetailCard {
 	now?: boolean;
@@ -22,7 +23,7 @@ const UnAssignedTask = ({ now = false, task }: ITaskDetailCard) => {
 
 	let taskStat: TTaskStatistic | null | undefined = null;
 
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 
 	const statActiveTask = useAtomValue(activeTaskStatisticsState);
 	const activeTaskTotalStat = statActiveTask.total;

--- a/apps/web/core/components/teams/member-table.tsx
+++ b/apps/web/core/components/teams/member-table.tsx
@@ -1,40 +1,43 @@
+import { Text } from '@/core/components';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/core/components/common/table';
 import { CHARACTER_LIMIT_TO_SHOW } from '@/core/constants/config/constants';
-import { imgTitle } from '@/core/lib/helpers/index';
 import { useSettings, useSyncRef } from '@/core/hooks';
 import { usePagination } from '@/core/hooks/common/use-pagination';
-import { activeTeamIdState, activeTeamState, organizationTeamsState } from '@/core/stores';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUpdateOrganizationTeam } from '@/core/hooks/organizations/teams/use-update-organization-team';
+import { imgTitle } from '@/core/lib/helpers/index';
 import { clsxm } from '@/core/lib/utils';
-import { Text } from '@/core/components';
+import { activeTeamIdState, organizationTeamsState } from '@/core/stores';
+import { ERoleName } from '@/core/types/generics/enums/role';
+import { TOrganizationTeamEmployee, TRole } from '@/core/types/schemas';
+import { useAtom, useAtomValue } from 'jotai';
 import cloneDeep from 'lodash/cloneDeep';
 import moment from 'moment';
-import { ChangeEvent, KeyboardEvent, useCallback, useRef } from 'react';
 import { useTranslations } from 'next-intl';
-import { useAtom, useAtomValue } from 'jotai';
+import { ChangeEvent, KeyboardEvent, useCallback, useRef } from 'react';
 import stc from 'string-to-color';
-import { MemberTableStatus } from './member-table-status';
-import { TableActionPopover } from '../settings/table-action-popover';
-import { EditUserRoleDropdown } from '../features/roles/edit-role-dropdown';
-import { Avatar } from '../duplicated-components/avatar';
 import { InputField } from '../duplicated-components/_input';
-import { Tooltip } from '../duplicated-components/tooltip';
 import { Paginate } from '../duplicated-components/_pagination';
-import { TOrganizationTeamEmployee, TRole } from '@/core/types/schemas';
-import { useUpdateOrganizationTeam } from '@/core/hooks/organizations/teams/use-update-organization-team';
-import { ERoleName } from '@/core/types/generics/enums/role';
-import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/core/components/common/table';
+import { Avatar } from '../duplicated-components/avatar';
+import { Tooltip } from '../duplicated-components/tooltip';
+import { EditUserRoleDropdown } from '../features/roles/edit-role-dropdown';
+import { TableActionPopover } from '../settings/table-action-popover';
+import { MemberTableStatus } from './member-table-status';
+import { useOrganisationTeams } from '@/core/hooks/organizations/teams/use-organisation-teams';
 
 export const MemberTable = ({ members }: { members: TOrganizationTeamEmployee[] }) => {
 	const t = useTranslations();
 	const { total, onPageChange, itemsPerPage, itemOffset, endOffset, setItemsPerPage, currentItems, pageCount } =
 		usePagination<TOrganizationTeamEmployee>({ items: members, defaultItemsPerPage: 5 });
 	const { updateAvatar } = useSettings();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { updateOrganizationTeam } = useUpdateOrganizationTeam();
 
 	const activeTeamRef = useSyncRef(activeTeam);
 
 	const activeTeamId = useAtomValue(activeTeamIdState);
-	const [organizationTeams, setOrganizationTeams] = useAtom(organizationTeamsState);
+	const [, setOrganizationTeams] = useAtom(organizationTeamsState);
+	const { teams: organizationTeams } = useOrganisationTeams();
 	const editMemberRef = useRef<TOrganizationTeamEmployee | null>(null);
 
 	const updateTeamMember = useCallback(

--- a/apps/web/core/components/teams/team-avatar.tsx
+++ b/apps/web/core/components/teams/team-avatar.tsx
@@ -1,26 +1,25 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { imgTitle } from '@/core/lib/helpers/index';
-import { useAuthenticateUser } from '@/core/hooks';
-import { clsxm } from '@/core/lib/utils';
 import { Button } from '@/core/components';
+import { useAuthenticateUser } from '@/core/hooks';
+import { useImageAssets } from '@/core/hooks/common/use-image-assets';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUpdateOrganizationTeam } from '@/core/hooks/organizations/teams/use-update-organization-team';
+import { imgTitle } from '@/core/lib/helpers/index';
+import { clsxm } from '@/core/lib/utils';
+import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
 import Image from 'next/image';
 import { readableColor } from 'polished';
 import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useTranslations } from 'next-intl';
 import stc from 'string-to-color';
-import { useImageAssets } from '@/core/hooks/common/use-image-assets';
 import { Avatar } from '../duplicated-components/avatar';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
-import { useUpdateOrganizationTeam } from '@/core/hooks/organizations/teams/use-update-organization-team';
 
 export const TeamAvatar = ({ disabled, bgColor }: { disabled: boolean; bgColor?: string | null }) => {
 	const t = useTranslations();
 	const { register } = useForm();
 	const [avatarBtn, setAvatarBtn] = useState(false);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { updateOrganizationTeam } = useUpdateOrganizationTeam();
 	const { createImageAssets } = useImageAssets();
 	const { user } = useAuthenticateUser();

--- a/apps/web/core/components/teams/teams-dropdown.tsx
+++ b/apps/web/core/components/teams/teams-dropdown.tsx
@@ -13,17 +13,18 @@ import { AllTeamItem, TeamItem, mapTeamItems } from './team-item';
 // Import optimized components from centralized location
 import { ModalSkeleton } from '@/core/components/common/skeleton/modal-skeleton';
 import { LazyCreateTeamModal } from '@/core/components/optimized-components/teams';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { cn } from '@/core/lib/helpers';
-import { detailedTaskState, timerStatusState } from '@/core/stores';
-import { useAtom, useAtomValue } from 'jotai';
-import { usePathname, useRouter } from 'next/navigation';
-import { Suspense } from 'react';
 import {
 	useGetOrganizationTeamQuery,
 	useGetOrganizationTeamsQuery
 } from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
 import { useSetActiveTeam } from '@/core/hooks/organizations/teams/use-set-active-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useDetailedTask } from '@/core/hooks/tasks/use-detailed-task';
+import { cn } from '@/core/lib/helpers';
+import { timerStatusState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
+import { usePathname, useRouter } from 'next/navigation';
+import { Suspense } from 'react';
 
 export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 	const { data: user } = useUserQuery();
@@ -43,7 +44,10 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 	const timerRunningStatus = useMemo(() => {
 		return Boolean(timerStatus?.running);
 	}, [timerStatus]);
-	const [detailedTask, setDetailedTask] = useAtom(detailedTaskState);
+	const {
+		detailedTaskQuery: { data: detailedTask },
+		setDetailedTaskId
+	} = useDetailedTask();
 	const path = usePathname();
 	const router = useRouter();
 
@@ -77,7 +81,7 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 					 */
 					const taskBelongsToNewTeam = item.data.tasks?.some((task) => task.id === detailedTask?.id);
 					if (!taskBelongsToNewTeam) {
-						setDetailedTask(null);
+						setDetailedTaskId(null);
 						router.push('/');
 					}
 				}
@@ -96,7 +100,7 @@ export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 				}
 			}
 		},
-		[setActiveTeam, t, setDetailedTask, path, router, timerRunningStatus] // Updated dependencies for timer protection
+		[setActiveTeam, t, setDetailedTaskId, path, router, timerRunningStatus] // Updated dependencies for timer protection
 	);
 
 	useEffect(() => {

--- a/apps/web/core/components/teams/teams-dropdown.tsx
+++ b/apps/web/core/components/teams/teams-dropdown.tsx
@@ -1,33 +1,40 @@
 'use client';
 
-import { useModal, useOrganizationTeams } from '@/core/hooks';
+import { Button, Dropdown } from '@/core/components';
+import { useModal } from '@/core/hooks';
+import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
 import { useProfileValidation } from '@/core/hooks/users/use-profile-validation';
 import { PlusIcon } from '@heroicons/react/24/solid';
-import { Button, Dropdown } from '@/core/components';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { AllTeamItem, TeamItem, mapTeamItems } from './team-item';
 import { useTranslations } from 'next-intl';
-import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
-import React from 'react';
-import { Tooltip } from '../duplicated-components/tooltip';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import { Tooltip } from '../duplicated-components/tooltip';
+import { AllTeamItem, TeamItem, mapTeamItems } from './team-item';
 // Import optimized components from centralized location
-import { LazyCreateTeamModal } from '@/core/components/optimized-components/teams';
-import { Suspense } from 'react';
 import { ModalSkeleton } from '@/core/components/common/skeleton/modal-skeleton';
+import { LazyCreateTeamModal } from '@/core/components/optimized-components/teams';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { activeTeamState, detailedTaskState, organizationTeamsState, timerStatusState } from '@/core/stores';
-import { useAtomValue, useAtom } from 'jotai';
-import { usePathname, useRouter } from 'next/navigation';
 import { cn } from '@/core/lib/helpers';
+import { detailedTaskState, timerStatusState } from '@/core/stores';
+import { useAtom, useAtomValue } from 'jotai';
+import { usePathname, useRouter } from 'next/navigation';
+import { Suspense } from 'react';
+import {
+	useGetOrganizationTeamQuery,
+	useGetOrganizationTeamsQuery
+} from '@/core/hooks/organizations/teams/use-get-organization-teams-query';
+import { useSetActiveTeam } from '@/core/hooks/organizations/teams/use-set-active-team';
 
 export const TeamsDropDown = ({ publicTeam }: { publicTeam?: boolean }) => {
 	const { data: user } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const teams = useAtomValue(organizationTeamsState);
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
 
-	const { setActiveTeam } = useOrganizationTeams();
+	const { data: teamsResult } = useGetOrganizationTeamsQuery();
+	const teams = useMemo(() => teamsResult?.data?.items ?? [], [teamsResult]);
+
+	const setActiveTeam = useSetActiveTeam();
 	const { userManagedTeams } = useOrganizationAndTeamManagers();
 	const timerStatus = useAtomValue(timerStatusState);
 	const t = useTranslations();

--- a/apps/web/core/components/timer/timer-card.tsx
+++ b/apps/web/core/components/timer/timer-card.tsx
@@ -8,11 +8,10 @@ import { PauseIcon } from '@/core/components/svgs/pause-icon';
 import { PlayIcon } from '@/core/components/svgs/play-icon';
 import { useStartStopTimerHandler } from '@/core/hooks/activities/use-start-stop-timer-handler';
 import { useTimer } from '@/core/hooks/activities/use-timer';
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { useTaskStatistics } from '@/core/hooks/tasks/use-task-statistics';
 import { pad } from '@/core/lib/helpers/number';
-import { activeTeamTaskState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 
@@ -33,7 +32,7 @@ const Timer = () => {
 	const { modals, startStopTimerHandler } = useStartStopTimerHandler();
 
 	const activeTeam = useCurrentTeam();
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 

--- a/apps/web/core/components/timer/timer-card.tsx
+++ b/apps/web/core/components/timer/timer-card.tsx
@@ -1,19 +1,20 @@
-import { pad } from '@/core/lib/helpers/number';
-import { useStartStopTimerHandler } from '@/core/hooks/activities/use-start-stop-timer-handler';
-import { useTaskStatistics } from '@/core/hooks/tasks/use-task-statistics';
-import { useTimer } from '@/core/hooks/activities/use-timer';
 import { ProgressBar } from '@/core/components/common/progress-bar';
-import { PauseIcon } from '@/core/components/svgs/pause-icon';
-import { PlayIcon } from '@/core/components/svgs/play-icon';
 import {
 	AddTasksEstimationHoursModal,
 	EnforcePlanedTaskModal,
 	SuggestDailyPlanModal
 } from '@/core/components/daily-plan';
+import { PauseIcon } from '@/core/components/svgs/pause-icon';
+import { PlayIcon } from '@/core/components/svgs/play-icon';
+import { useStartStopTimerHandler } from '@/core/hooks/activities/use-start-stop-timer-handler';
+import { useTimer } from '@/core/hooks/activities/use-timer';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useTaskStatistics } from '@/core/hooks/tasks/use-task-statistics';
+import { pad } from '@/core/lib/helpers/number';
+import { activeTeamTaskState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
-import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState } from '@/core/stores';
 
 const Timer = () => {
 	const t = useTranslations();
@@ -31,7 +32,7 @@ const Timer = () => {
 
 	const { modals, startStopTimerHandler } = useStartStopTimerHandler();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);

--- a/apps/web/core/components/timer/timer.tsx
+++ b/apps/web/core/components/timer/timer.tsx
@@ -9,8 +9,8 @@ import { useTranslations } from 'next-intl';
 import { TimerButton } from './timer-button';
 
 import { useStartStopTimerHandler } from '@/core/hooks/activities/use-start-stop-timer-handler';
+import { useCurrentActiveTask } from '@/core/hooks/organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
-import { activeTeamTaskState } from '@/core/stores';
 import { ETimeLogSource } from '@/core/types/generics/enums/timer';
 import { IClassName } from '@/core/types/interfaces/common/class-name';
 import {
@@ -21,7 +21,6 @@ import {
 	LifebuoyIcon
 } from '@heroicons/react/24/outline';
 import { HotkeysEvent } from 'hotkeys-js';
-import { useAtomValue } from 'jotai';
 import { useCallback, useMemo } from 'react';
 import { AddTasksEstimationHoursModal, EnforcePlanedTaskModal, SuggestDailyPlanModal } from '../daily-plan';
 import { ProgressBar } from '../duplicated-components/_progress-bar';
@@ -47,7 +46,7 @@ export function Timer({ className, showTimerButton = true }: IClassName) {
 	} = useTimerView();
 	const { modals, startStopTimerHandler } = useStartStopTimerHandler();
 	const activeTeam = useCurrentTeam();
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 
 	// FIX_NOTE: Use team-scoped time instead of global timerStatus.duration
@@ -231,7 +230,7 @@ export function MinTimerFrame({ className }: IClassName) {
 	const { hours, minutes, seconds, ms_p, timerStatus, disabled, hasPlan, startTimer, stopTimer } = useTimerView();
 	const { modals, startStopTimerHandler } = useStartStopTimerHandler();
 	const activeTeam = useCurrentTeam();
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 	const t = useTranslations();
 

--- a/apps/web/core/components/timer/timer.tsx
+++ b/apps/web/core/components/timer/timer.tsx
@@ -1,13 +1,18 @@
-import { pad } from '@/core/lib/helpers/index';
+import { Text } from '@/core/components';
 import { HostKeys, useDetectOS, useHotkeys, useTimerView } from '@/core/hooks';
 import { useTimerOptimisticUI } from '@/core/hooks/activities/use-timer-optimistic-ui';
 import { useTodayWorkedTime } from '@/core/hooks/activities/use-today-worked-time';
+import { pad } from '@/core/lib/helpers/index';
 import { clsxm } from '@/core/lib/utils';
-import { Text } from '@/core/components';
+import { Transition } from '@headlessui/react';
 import { useTranslations } from 'next-intl';
 import { TimerButton } from './timer-button';
-import { Transition } from '@headlessui/react';
 
+import { useStartStopTimerHandler } from '@/core/hooks/activities/use-start-stop-timer-handler';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { activeTeamTaskState } from '@/core/stores';
+import { ETimeLogSource } from '@/core/types/generics/enums/timer';
+import { IClassName } from '@/core/types/interfaces/common/class-name';
 import {
 	ArrowUturnUpIcon,
 	ComputerDesktopIcon,
@@ -16,16 +21,12 @@ import {
 	LifebuoyIcon
 } from '@heroicons/react/24/outline';
 import { HotkeysEvent } from 'hotkeys-js';
+import { useAtomValue } from 'jotai';
 import { useCallback, useMemo } from 'react';
 import { AddTasksEstimationHoursModal, EnforcePlanedTaskModal, SuggestDailyPlanModal } from '../daily-plan';
-import { useStartStopTimerHandler } from '@/core/hooks/activities/use-start-stop-timer-handler';
 import { ProgressBar } from '../duplicated-components/_progress-bar';
-import { Tooltip } from '../duplicated-components/tooltip';
 import { VerticalSeparator } from '../duplicated-components/separator';
-import { IClassName } from '@/core/types/interfaces/common/class-name';
-import { ETimeLogSource } from '@/core/types/generics/enums/timer';
-import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState } from '@/core/stores';
+import { Tooltip } from '../duplicated-components/tooltip';
 
 export function Timer({ className, showTimerButton = true }: IClassName) {
 	const t = useTranslations();
@@ -45,7 +46,7 @@ export function Timer({ className, showTimerButton = true }: IClassName) {
 		stopTimer
 	} = useTimerView();
 	const { modals, startStopTimerHandler } = useStartStopTimerHandler();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 
@@ -229,7 +230,7 @@ export function Timer({ className, showTimerButton = true }: IClassName) {
 export function MinTimerFrame({ className }: IClassName) {
 	const { hours, minutes, seconds, ms_p, timerStatus, disabled, hasPlan, startTimer, stopTimer } = useTimerView();
 	const { modals, startStopTimerHandler } = useStartStopTimerHandler();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 	const t = useTranslations();

--- a/apps/web/core/components/users/user-nav-menu.tsx
+++ b/apps/web/core/components/users/user-nav-menu.tsx
@@ -1,44 +1,45 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { CHARACTER_LIMIT_TO_SHOW } from '@/core/constants/config/constants';
-import { imgTitle } from '@/core/lib/helpers/index';
-import { useAuthenticateUser } from '@/core/hooks';
-import { activeTeamState, isTeamMemberState, publicState, timerStatusState } from '@/core/stores';
-import { clsxm, isValidUrl } from '@/core/lib/utils';
-import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
 import { Divider, FullWidthToggler, Text, ThemeToggler } from '@/core/components';
+import { CHARACTER_LIMIT_TO_SHOW } from '@/core/constants/config/constants';
+import { useAuthenticateUser } from '@/core/hooks';
+import { imgTitle } from '@/core/lib/helpers/index';
+import { clsxm, isValidUrl } from '@/core/lib/utils';
+import { isTeamMemberState, publicState, timerStatusState } from '@/core/stores';
+import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
 
+import Collaborate from '@/core/components/collaborate';
+import { KeyboardShortcuts } from '@/core/components/common/keyboard-shortcuts';
+import { LanguageDropDownWithFlags } from '@/core/components/common/language-dropdown-flags';
+import ThemesPopup from '@/core/components/common/themes-popup';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { signOutFunction } from '@/core/lib/helpers/social-logins';
+import { ETimerStatus } from '@/core/types/generics/enums/timer';
+import { ThemeInterface } from '@/core/types/interfaces/common/theme';
+import gauzyDark from '@/public/assets/themeImages/gauzyDark.png';
+import gauzyLight from '@/public/assets/themeImages/gauzyLight.png';
 import {
+	BriefCaseIcon,
 	DevicesIcon,
+	FullWidthIcon,
 	LogoutRoundIcon,
 	MoonLightOutlineIcon as MoonIcon,
 	PeoplesIcon,
-	BriefCaseIcon,
-	SettingOutlineIcon,
-	FullWidthIcon
+	SettingOutlineIcon
 } from 'assets/svg';
-import ThemesPopup from '@/core/components/common/themes-popup';
+import { useAtomValue } from 'jotai';
+import { ChevronDown, Globe2Icon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
 import Link from 'next/link';
-import { useMemo } from 'react';
-import { useAtomValue } from 'jotai';
-import stc from 'string-to-color';
-import gauzyDark from '@/public/assets/themeImages/gauzyDark.png';
-import gauzyLight from '@/public/assets/themeImages/gauzyLight.png';
-import { TimerStatus, getTimerStatusValue } from '../timer/timer-status';
-import Collaborate from '@/core/components/collaborate';
-import { TeamsDropDown } from '../teams/teams-dropdown';
-import { KeyboardShortcuts } from '@/core/components/common/keyboard-shortcuts';
 import { usePathname } from 'next/navigation';
-import { useTranslations } from 'next-intl';
-import { ChevronDown, Globe2Icon } from 'lucide-react';
-import { LanguageDropDownWithFlags } from '@/core/components/common/language-dropdown-flags';
-import { signOutFunction } from '@/core/lib/helpers/social-logins';
-import { Avatar } from '../duplicated-components/avatar';
+import { useMemo } from 'react';
+import stc from 'string-to-color';
 import { EverCard } from '../common/ever-card';
+import { Avatar } from '../duplicated-components/avatar';
 import { Tooltip } from '../duplicated-components/tooltip';
-import { ETimerStatus } from '@/core/types/generics/enums/timer';
-import { ThemeInterface } from '@/core/types/interfaces/common/theme';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { TeamsDropDown } from '../teams/teams-dropdown';
+import { TimerStatus, getTimerStatusValue } from '../timer/timer-status';
 
 export function UserNavAvatar() {
 	const { data: user } = useUserQuery();
@@ -46,7 +47,7 @@ export function UserNavAvatar() {
 	const name = user?.name || user?.firstName || user?.lastName || user?.username || '';
 	const timerStatus = useAtomValue(timerStatusState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const publicTeam = useAtomValue(publicState);
 	const members = activeTeam?.members || [];
 	const currentMember = members.find((m) => {
@@ -140,7 +141,7 @@ function UserNavMenu() {
 	const name = user?.name || user?.firstName || user?.lastName || user?.username;
 	const timerStatus = useAtomValue(timerStatusState);
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const isTeamMember = useAtomValue(isTeamMemberState);
 
 	const publicTeam = useAtomValue(publicState);

--- a/apps/web/core/components/users/user-profile-plans.tsx
+++ b/apps/web/core/components/users/user-profile-plans.tsx
@@ -1,26 +1,30 @@
 'use client';
-import { useAtomValue } from 'jotai';
 import { AlertPopup, Container } from '@/core/components';
-import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
-import { useEffect, useMemo, useState } from 'react';
-import { useCanSeeActivityScreen, useDailyPlan, useTimer, useUserProfilePage } from '@/core/hooks';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
-import { filterDailyPlan } from '@/core/hooks/daily-plans/use-filter-date-range';
-import { useLocalStorageState } from '@/core/hooks/common/use-local-storage-state';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/core/components/common/select';
+import { Button } from '@/core/components/duplicated-components/_button';
 import {
 	DAILY_PLAN_SUGGESTION_MODAL_DATE,
 	HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL,
 	HAS_VISITED_OUTSTANDING_TASKS
 } from '@/core/constants/config/constants';
-import { TUser } from '@/core/types/schemas';
-import { activeTeamState } from '@/core/stores';
-import { fullWidthState } from '@/core/stores/common/full-width';
+import { useCanSeeActivityScreen, useDailyPlan, useTimer, useUserProfilePage } from '@/core/hooks';
+import { useLocalStorageState } from '@/core/hooks/common/use-local-storage-state';
+import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
+import { filterDailyPlan } from '@/core/hooks/daily-plans/use-filter-date-range';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { clsxm } from '@/core/lib/utils';
-import { Button } from '@/core/components/duplicated-components/_button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/core/components/common/select';
+import { fullWidthState } from '@/core/stores/common/full-width';
+import { TUser } from '@/core/types/schemas';
 import { ReloadIcon, StarIcon } from '@radix-ui/react-icons';
+import { useAtomValue } from 'jotai';
+import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
+import { useEffect, useMemo, useState } from 'react';
 
+import { AllPlans, EmptyPlans } from '@/core/components/daily-plan';
+import { IconsCalendarMonthOutline } from '@/core/components/icons';
+import moment from 'moment';
+import { usePathname } from 'next/navigation';
+import { VerticalSeparator } from '../duplicated-components/separator';
 import {
 	estimatedTotalTime,
 	getTotalTasks,
@@ -31,11 +35,7 @@ import {
 } from '../tasks/daily-plan';
 import { FutureTasks } from '../tasks/daily-plan/future-tasks';
 import ViewsHeaderTabs from '../tasks/daily-plan/views-header-tabs';
-import moment from 'moment';
-import { usePathname } from 'next/navigation';
-import { IconsCalendarMonthOutline } from '@/core/components/icons';
-import { VerticalSeparator } from '../duplicated-components/separator';
-import { AllPlans, EmptyPlans } from '@/core/components/daily-plan';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 
 export type FilterTabs = 'Today Tasks' | 'Future Tasks' | 'Past Tasks' | 'All Tasks' | 'Outstanding';
 type FilterOutstanding = 'ALL' | 'DATE';
@@ -88,7 +88,9 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 
 	const screenOutstanding = {
 		ALL: <OutstandingAll profile={profile} user={user} outstandingPlans={outstandingPlans} />,
-		DATE: <OutstandingFilterDate profile={profile} user={user} outstandingPlans={outstandingPlans} filterByEmployee/>
+		DATE: (
+			<OutstandingFilterDate profile={profile} user={user} outstandingPlans={outstandingPlans} filterByEmployee />
+		)
 	};
 	const tabsScreens = {
 		'Today Tasks': <AllPlans profile={profile} currentTab={currentTab} user={user} employeeId={targetEmployeeId} />,
@@ -102,7 +104,7 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 	const haveSeenDailyPlanSuggestionModal = window?.localStorage.getItem(HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL);
 	const { hasPlan } = useTimer();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 	const [popupOpen, setPopupOpen] = useState(false);
 	const canSeeActivity = useCanSeeActivityScreen();
@@ -160,7 +162,9 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 				outstandingPlans.map((plan) => {
 					const tasks = plan.tasks ?? [];
 					// Filter by user if user exists (privacy/security - same as OutstandingAll)
-					return user ? tasks.filter((task) => task.members?.some((member) => member.userId === user.id)) : tasks;
+					return user
+						? tasks.filter((task) => task.members?.some((member) => member.userId === user.id))
+						: tasks;
 				})
 			).totalTasks
 		};

--- a/apps/web/core/components/users/user-profile-plans.tsx
+++ b/apps/web/core/components/users/user-profile-plans.tsx
@@ -7,7 +7,7 @@ import {
 	HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL,
 	HAS_VISITED_OUTSTANDING_TASKS
 } from '@/core/constants/config/constants';
-import { useCanSeeActivityScreen, useDailyPlan, useTimer, useUserProfilePage } from '@/core/hooks';
+import { useCanSeeActivityScreen, useTimer, useUserProfilePage } from '@/core/hooks';
 import { useLocalStorageState } from '@/core/hooks/common/use-local-storage-state';
 import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
 import { filterDailyPlan } from '@/core/hooks/daily-plans/use-filter-date-range';
@@ -36,6 +36,16 @@ import {
 import { FutureTasks } from '../tasks/daily-plan/future-tasks';
 import ViewsHeaderTabs from '../tasks/daily-plan/views-header-tabs';
 import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
+import {
+	useFuturePlans,
+	useOutstandingPlans,
+	usePastPlans,
+	useProfileDailyPlans,
+	useSortedPlan,
+	useTodayPlan
+} from '@/core/hooks/daily-plans/derived';
+import { useDeleteDailyPlanMutation } from '@/core/hooks/daily-plans/mutations';
+import { useMyDailyPlansQuery } from '@/core/hooks/daily-plans/queries';
 
 export type FilterTabs = 'Today Tasks' | 'Future Tasks' | 'Past Tasks' | 'All Tasks' | 'Outstanding';
 type FilterOutstanding = 'ALL' | 'DATE';
@@ -53,7 +63,7 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 	const profile = useUserProfilePage();
 	const { data: authUser } = useUserQuery();
 
-	const targetEmployeeId = useMemo(() => {
+	const targetEmployeeId: string = useMemo(() => {
 		// PRIORITY 1: Use employeeId from props if provided (from UserTeamCard)
 		if (propsEmployeeId) {
 			return propsEmployeeId;
@@ -70,17 +80,15 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 		return employeeId;
 	}, [profile.isAuthUser, authUser, user, propsEmployeeId]);
 
-	const {
-		futurePlans,
-		pastPlans,
-		todayPlan,
-		outstandingPlans,
-		sortedPlans,
-		profileDailyPlans,
-		deleteDailyPlan,
-		deleteDailyPlanLoading,
-		getMyDailyPlansLoading
-	} = useDailyPlan(targetEmployeeId);
+	const futurePlans = useFuturePlans(targetEmployeeId);
+	const pastPlans = usePastPlans(targetEmployeeId);
+	const todayPlan = useTodayPlan(targetEmployeeId);
+	const outstandingPlans = useOutstandingPlans(targetEmployeeId);
+	const sortedPlans = useSortedPlan(targetEmployeeId);
+	const profileDailyPlans = useProfileDailyPlans(targetEmployeeId);
+	const { mutateAsync: deleteDailyPlan, isPending: deleteDailyPlanLoading } = useDeleteDailyPlanMutation();
+	const { isPending: getMyDailyPlansLoading } = useMyDailyPlansQuery();
+
 	const fullWidth = useAtomValue(fullWidthState);
 	const [currentOutstanding, setCurrentOutstanding] = useLocalStorageState<FilterOutstanding>('outstanding', 'DATE');
 	const [currentTab, setCurrentTab] = useLocalStorageState<FilterTabs>('daily-plan-tab', 'Today Tasks');

--- a/apps/web/core/hooks/activities/use-start-stop-timer-handler.ts
+++ b/apps/web/core/hooks/activities/use-start-stop-timer-handler.ts
@@ -4,12 +4,13 @@ import {
 	DAILY_PLAN_SUGGESTION_MODAL_DATE,
 	TASKS_ESTIMATE_HOURS_MODAL_DATE
 } from '@/core/constants/config/constants';
-import { activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { timerStatusState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
 import { useCallback, useMemo } from 'react';
 import { useModal } from '../common/use-modal';
-import { useTimer } from './use-timer';
+import { useCurrentActiveTask } from '../organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useTimer } from './use-timer';
 
 export function useStartStopTimerHandler() {
 	const {
@@ -39,7 +40,7 @@ export function useStartStopTimerHandler() {
 
 	const { timerStatusFetching, startTimer, stopTimer, hasPlan, canRunTimer } = useTimer();
 
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 	const activeTeam = useCurrentTeam();
 
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);

--- a/apps/web/core/hooks/activities/use-start-stop-timer-handler.ts
+++ b/apps/web/core/hooks/activities/use-start-stop-timer-handler.ts
@@ -1,14 +1,15 @@
+import { estimatedTotalTime } from '@/core/components/tasks/daily-plan';
+import {
+	DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE,
+	DAILY_PLAN_SUGGESTION_MODAL_DATE,
+	TASKS_ESTIMATE_HOURS_MODAL_DATE
+} from '@/core/constants/config/constants';
+import { activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
 import { useCallback, useMemo } from 'react';
 import { useModal } from '../common/use-modal';
-import {
-	DAILY_PLAN_SUGGESTION_MODAL_DATE,
-	TASKS_ESTIMATE_HOURS_MODAL_DATE,
-	DAILY_PLAN_ESTIMATE_HOURS_MODAL_DATE
-} from '@/core/constants/config/constants';
-import { estimatedTotalTime } from '@/core/components/tasks/daily-plan';
 import { useTimer } from './use-timer';
-import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export function useStartStopTimerHandler() {
 	const {
@@ -39,7 +40,7 @@ export function useStartStopTimerHandler() {
 	const { timerStatusFetching, startTimer, stopTimer, hasPlan, canRunTimer } = useTimer();
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const requirePlan = useMemo(() => activeTeam?.requirePlanToTrack, [activeTeam?.requirePlanToTrack]);
 

--- a/apps/web/core/hooks/activities/use-timer.ts
+++ b/apps/web/core/hooks/activities/use-timer.ts
@@ -40,7 +40,6 @@ import { useRefreshIntervalV2 } from '../common';
 import { useFirstLoad } from '../common/use-first-load';
 import { useQueryCall } from '../common/use-query';
 import { useSyncRef } from '../common/use-sync-ref';
-import { useDailyPlan } from '../daily-plans/use-daily-plan';
 import { useOrganizationEmployeeTeams } from '../organizations';
 import { useCurrentActiveTask } from '../organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '../organizations/teams/use-current-team';
@@ -50,6 +49,7 @@ import { useUpdateTaskMutation } from '../organizations/teams/use-update-task.mu
 import { useDetailedTask } from '../tasks/use-detailed-task';
 import { useTaskStatistics } from '../tasks/use-task-statistics';
 import { useTimerPolling } from './use-timer-polling';
+import { useProfileDailyPlans } from '../daily-plans/derived';
 
 /**
  * ! Don't modify this function unless you know what you're doing
@@ -197,7 +197,7 @@ export function useTimer() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 
 	// Use useDailyPlan to get the logged-in user's plans (no employeeId = current user)
-	const { myDailyPlans } = useDailyPlan();
+	const myDailyPlans = useProfileDailyPlans();
 
 	const { data: teamTasksResult } = useCurrentTeamTasksQuery();
 	const teamTasks = useMemo(() => teamTasksResult?.items ?? [], []);

--- a/apps/web/core/hooks/activities/use-today-worked-time.ts
+++ b/apps/web/core/hooks/activities/use-today-worked-time.ts
@@ -1,8 +1,7 @@
-import { useMemo } from 'react';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
 import { secondsToTime } from '@/core/lib/helpers/date-and-time';
 import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { useMemo } from 'react';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
 
 /**
@@ -22,7 +21,7 @@ import { useUserQuery } from '../queries/user-user.query';
  * @returns Object with hours, minutes, seconds, and total seconds worked today
  */
 export function useTodayWorkedTime(memberInfo?: { member?: { id?: string }; id?: string }) {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { data: user } = useUserQuery();
 
 	// Find the current member in the active team

--- a/apps/web/core/hooks/common/use-collaborative.ts
+++ b/apps/web/core/hooks/common/use-collaborative.ts
@@ -1,17 +1,18 @@
-import { activeTeamState, collaborativeMembersState, collaborativeSelectState } from '@/core/stores';
-import { useCallback } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
 import { BOARD_APP_DOMAIN } from '@/core/constants/config/constants';
-import { useRouter } from 'next/navigation';
-import { nanoid } from 'nanoid';
-import capitalize from 'lodash/capitalize';
+import { collaborativeMembersState, collaborativeSelectState } from '@/core/stores';
 import { TUser } from '@/core/types/schemas';
+import { useAtom } from 'jotai';
+import capitalize from 'lodash/capitalize';
+import { nanoid } from 'nanoid';
+import { useRouter } from 'next/navigation';
+import { useCallback } from 'react';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
 
 export function useCollaborative(user?: TUser) {
 	const meetType = process.env.NEXT_PUBLIC_MEET_TYPE || 'Jitsi';
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { data: authUser } = useUserQuery();
 	const [collaborativeSelect, setCollaborativeSelect] = useAtom(collaborativeSelectState);
 	const [collaborativeMembers, setCollaborativeMembers] = useAtom(collaborativeMembersState);

--- a/apps/web/core/hooks/daily-plans/derived/index.ts
+++ b/apps/web/core/hooks/daily-plans/derived/index.ts
@@ -1,0 +1,5 @@
+export * from './use-filtered-plans';
+export * from './use-outstanding-plans';
+export * from './use-plan-tasks';
+export * from './use-profile-daily-plans';
+export * from './use-sorted-plans';

--- a/apps/web/core/hooks/daily-plans/derived/use-filtered-plans.ts
+++ b/apps/web/core/hooks/daily-plans/derived/use-filtered-plans.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { useProfileDailyPlans } from './use-profile-daily-plans';
+import { IUseDailyPlanOptions } from '../queries';
+import { useAscSortedPlans, useDescSortedPlans } from './use-sorted-plans';
+
+export const useFuturePlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const ascSortedPlans = useAscSortedPlans(employeeId, { enabled });
+
+	const futurePlans = useMemo(() => {
+		const today = new Date();
+		return ascSortedPlans?.filter((plan) => {
+			const planDate = new Date(plan.date);
+			today.setHours(23, 59, 59, 0); // Set today time to exclude timestamps in comparization
+			// NOTE_FIX: Use > instead of >= to exclude today's plans from future plans
+			// Future plans should only include dates AFTER today, not today itself
+			return planDate.getTime() > today.getTime();
+		});
+	}, [ascSortedPlans]);
+
+	return futurePlans;
+};
+
+export const usePastPlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const descSortedPlans = useDescSortedPlans(employeeId, { enabled });
+
+	const pastPlans = useMemo(() => {
+		const today = new Date();
+		return descSortedPlans?.filter((plan) => {
+			const planDate = new Date(plan.date);
+			today.setHours(0, 0, 0, 0); // Set today time to exclude timestamps in comparization
+			// NOTE_FIX: Use > instead of >= to exclude today's plans from future plans
+			// Future plans should only include dates AFTER today, not today itself
+			return planDate.getTime() < today.getTime();
+		});
+	}, [descSortedPlans]);
+
+	return pastPlans;
+};
+
+export const useTodayPlan = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const profileDailyPlans = useProfileDailyPlans(employeeId, { enabled });
+
+	const todayPlan = useMemo(() => {
+		// NOTE: Replacement for todayPlanState atom.
+		// We keep the same ISO-date prefix logic so counters/charts using
+		// "today" are not affected by this refactor.
+		return [...(profileDailyPlans.items ? profileDailyPlans.items : [])].filter((plan) =>
+			plan.date?.toString()?.startsWith(new Date()?.toISOString().split('T')[0])
+		);
+	}, [profileDailyPlans]);
+
+	return todayPlan;
+};

--- a/apps/web/core/hooks/daily-plans/derived/use-filtered-plans.ts
+++ b/apps/web/core/hooks/daily-plans/derived/use-filtered-plans.ts
@@ -3,15 +3,22 @@ import { useProfileDailyPlans } from './use-profile-daily-plans';
 import { IUseDailyPlanOptions } from '../queries';
 import { useAscSortedPlans, useDescSortedPlans } from './use-sorted-plans';
 
+/**
+ * Returns daily plans scheduled for future dates (after today).
+ * Plans are sorted ascending (nearest date first).
+ *
+ * @param employeeId - Employee ID to filter plans (optional, defaults to current user)
+ * @param options - Query options ({ enabled })
+ */
 export const useFuturePlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
 	const ascSortedPlans = useAscSortedPlans(employeeId, { enabled });
 
 	const futurePlans = useMemo(() => {
 		const today = new Date();
+		today.setHours(23, 59, 59, 0); // Set today time to exclude timestamps in comparization
 		return ascSortedPlans?.filter((plan) => {
 			const planDate = new Date(plan.date);
-			today.setHours(23, 59, 59, 0); // Set today time to exclude timestamps in comparization
 			// NOTE_FIX: Use > instead of >= to exclude today's plans from future plans
 			// Future plans should only include dates AFTER today, not today itself
 			return planDate.getTime() > today.getTime();
@@ -21,15 +28,22 @@ export const useFuturePlans = (employeeId?: string, options: IUseDailyPlanOption
 	return futurePlans;
 };
 
+/**
+ * Returns daily plans from past dates (before today).
+ * Plans are sorted descending (most recent first).
+ *
+ * @param employeeId - Employee ID to filter plans (optional, defaults to current user)
+ * @param options - Query options ({ enabled })
+ */
 export const usePastPlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
 	const descSortedPlans = useDescSortedPlans(employeeId, { enabled });
 
 	const pastPlans = useMemo(() => {
 		const today = new Date();
+		today.setHours(0, 0, 0, 0); // Set today time to exclude timestamps in comparization
 		return descSortedPlans?.filter((plan) => {
 			const planDate = new Date(plan.date);
-			today.setHours(0, 0, 0, 0); // Set today time to exclude timestamps in comparization
 			// NOTE_FIX: Use > instead of >= to exclude today's plans from future plans
 			// Future plans should only include dates AFTER today, not today itself
 			return planDate.getTime() < today.getTime();
@@ -39,6 +53,13 @@ export const usePastPlans = (employeeId?: string, options: IUseDailyPlanOptions 
 	return pastPlans;
 };
 
+/**
+ * Returns daily plans for today's date.
+ * Replaces legacy `todayPlanState` atom.
+ *
+ * @param employeeId - Employee ID to filter plans (optional, defaults to current user)
+ * @param options - Query options ({ enabled })
+ */
 export const useTodayPlan = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
 	const profileDailyPlans = useProfileDailyPlans(employeeId, { enabled });

--- a/apps/web/core/hooks/daily-plans/derived/use-outstanding-plans.ts
+++ b/apps/web/core/hooks/daily-plans/derived/use-outstanding-plans.ts
@@ -1,18 +1,31 @@
 import { useMemo } from 'react';
 import { IUseDailyPlanOptions } from '../queries';
 import { useProfileDailyPlans } from './use-profile-daily-plans';
-import { useTodayTasks } from './use-plan-tasks';
+import { useFutureTasks, useTodayTasks } from './use-plan-tasks';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useSortedTasksByCreation } from '../../organizations/teams/use-sorted-tasks';
 import { useCurrentTeam } from '../../organizations/teams/use-current-team';
 import { TDailyPlan } from '@/core/types/schemas';
 
+/** ID for the virtual plan containing unplanned tasks (client-side only) */
+const VIRTUAL_UNPLANNED_TASKS_ID = 'outstanding-no-plan';
+
+/**
+ * Returns "outstanding" plans requiring attention:
+ * 1. Past plans with incomplete tasks not yet rescheduled
+ * 2. Unplanned tasks with time tracked or estimates (as a virtual plan)
+ *
+ * Replaces legacy `outstandingPlansState` atom.
+ *
+ * @param employeeId - Employee ID to filter plans (required for accurate unplanned tasks detection)
+ * @param options - Query options ({ enabled })
+ */
 export const useOutstandingPlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
 	const activeTeam = useCurrentTeam();
 	const profileDailyPlans = useProfileDailyPlans(employeeId, { enabled });
 	const todayTasks = useTodayTasks();
-	const futureTasks = useTodayTasks();
+	const futureTasks = useFutureTasks();
 	const allTeamTasks = useSortedTasksByCreation();
 
 	// NOTE: Replacement for futureTasksState atom; keeps future task list
@@ -71,7 +84,7 @@ export const useOutstandingPlans = (employeeId?: string, options: IUseDailyPlanO
 			tasksNotInAnyPlan.length > 0
 				? [
 						{
-							id: 'outstanding-no-plan',
+							id: VIRTUAL_UNPLANNED_TASKS_ID,
 							date: new Date().toISOString(),
 							tasks: tasksNotInAnyPlan,
 							workTimePlanned: 0,

--- a/apps/web/core/hooks/daily-plans/derived/use-outstanding-plans.ts
+++ b/apps/web/core/hooks/daily-plans/derived/use-outstanding-plans.ts
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+import { IUseDailyPlanOptions } from '../queries';
+import { useProfileDailyPlans } from './use-profile-daily-plans';
+import { useTodayTasks } from './use-plan-tasks';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useSortedTasksByCreation } from '../../organizations/teams/use-sorted-tasks';
+import { useCurrentTeam } from '../../organizations/teams/use-current-team';
+import { TDailyPlan } from '@/core/types/schemas';
+
+export const useOutstandingPlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const activeTeam = useCurrentTeam();
+	const profileDailyPlans = useProfileDailyPlans(employeeId, { enabled });
+	const todayTasks = useTodayTasks();
+	const futureTasks = useTodayTasks();
+	const allTeamTasks = useSortedTasksByCreation();
+
+	// NOTE: Replacement for futureTasksState atom; keeps future task list
+	// local to this hook instead of global Jotai.
+	// NOTE: Replacement for outstandingPlansState atom; keeps "outstanding"
+	// logic close to daily-plan queries instead of global Jotai stores.
+	const outstandingPlans = useMemo(() => {
+		// Build a Set of task IDs from today/future to avoid repeated linear searches (O(1) lookup instead of O(n²))
+		const usedIds = new Set<string>([...todayTasks, ...futureTasks].map((t: TTask) => t.id));
+
+		// PART 1: Past plans with incomplete tasks not in today/future
+		const pastPlansWithIncompleteTasks = [...(profileDailyPlans.items ? profileDailyPlans.items : [])]
+			// Exclude today plans
+			.filter((plan) => !plan.date?.toString()?.startsWith(new Date()?.toISOString().split('T')[0]))
+			// Exclude future plans (keep only past plans)
+			.filter((plan) => {
+				const planDate = new Date(plan.date);
+				const today = new Date();
+				today.setHours(23, 59, 59, 0);
+				return planDate.getTime() <= today.getTime();
+			})
+			.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+			.map((plan) => ({
+				...plan,
+				// Include only non-completed tasks
+				tasks: plan.tasks?.filter((task) => task.status !== 'completed')
+			}))
+			.map((plan) => ({
+				...plan,
+				// Include only tasks not added yet to today/future plans
+				tasks: plan.tasks?.filter((_task) => !usedIds.has(_task.id))
+			}))
+			.filter((plan) => plan.tasks?.length && plan.tasks.length > 0);
+
+		// PART 2: Tasks assigned to member that are NOT in ANY plan
+		// Build a Set of ALL task IDs that are in ANY plan (today, future, past)
+		const allPlannedTaskIds = new Set<string>(
+			profileDailyPlans.items?.flatMap((plan) => plan.tasks?.map((t) => t.id) ?? []) ?? []
+		);
+
+		// Filter tasks assigned to the target employee that are NOT in any plan
+		const tasksNotInAnyPlan = allTeamTasks.filter((task) => {
+			// Must be assigned to the target employee (match by employeeId, not current user)
+			const isAssignedToTargetEmployee = !!employeeId && task.members?.some((member) => member.id === employeeId);
+			// Must NOT be in any plan
+			const isNotInAnyPlan = !allPlannedTaskIds.has(task.id);
+			// Must have time tracked OR estimation set
+			const hasTimeOrEstimate =
+				(task.totalWorkedTime && task.totalWorkedTime > 0) || (task.estimate && task.estimate > 0);
+
+			return isAssignedToTargetEmployee && isNotInAnyPlan && hasTimeOrEstimate;
+		});
+
+		// Create a virtual plan for tasks not in any plan (if any exist)
+		const virtualPlanForUnplannedTasks: TDailyPlan[] =
+			tasksNotInAnyPlan.length > 0
+				? [
+						{
+							id: 'outstanding-no-plan',
+							date: new Date().toISOString(),
+							tasks: tasksNotInAnyPlan,
+							workTimePlanned: 0,
+							status: 'open',
+							tenantId: activeTeam?.tenantId ?? null,
+							organizationId: activeTeam?.organizationId ?? null,
+							employeeId: employeeId ?? null,
+							employee: null,
+							organizationTeamId: activeTeam?.id ?? null,
+							organizationTeam: null
+						}
+					]
+				: [];
+
+		// Combine past plans with incomplete tasks + virtual plan for unplanned tasks
+		return [...pastPlansWithIncompleteTasks, ...virtualPlanForUnplannedTasks];
+	}, [profileDailyPlans, todayTasks, futureTasks, allTeamTasks, activeTeam, employeeId]);
+
+	return outstandingPlans;
+};

--- a/apps/web/core/hooks/daily-plans/derived/use-plan-tasks.ts
+++ b/apps/web/core/hooks/daily-plans/derived/use-plan-tasks.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import { IUseDailyPlanOptions } from '../queries';
+import { useFuturePlans, useTodayPlan } from './use-filtered-plans';
+
+export const useTodayTasks = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const todayPlan = useTodayPlan(employeeId, { enabled });
+
+	// NOTE: Replacement for todayTasksState atom; derived locally from todayPlan.
+	const todayTasks = useMemo(() => {
+		return todayPlan.flatMap((plan) => plan.tasks ?? []);
+	}, [todayPlan]);
+
+	return todayTasks;
+};
+
+export const useFutureTasks = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const futurePlans = useFuturePlans(employeeId, { enabled });
+
+	// NOTE: Replacement for futureTasksState atom; keeps future task list
+	// local to this hook instead of global Jotai.
+	const futureTasks = useMemo(() => {
+		return futurePlans.flatMap((plan) => plan.tasks ?? []);
+	}, [futurePlans]);
+
+	return futureTasks;
+};

--- a/apps/web/core/hooks/daily-plans/derived/use-plan-tasks.ts
+++ b/apps/web/core/hooks/daily-plans/derived/use-plan-tasks.ts
@@ -2,18 +2,32 @@ import { useMemo } from 'react';
 import { IUseDailyPlanOptions } from '../queries';
 import { useFuturePlans, useTodayPlan } from './use-filtered-plans';
 
+/**
+ * Returns all tasks from today's daily plans.
+ * Replaces legacy `todayTasksState` atom.
+ *
+ * @param employeeId - Employee ID (optional, defaults to current user)
+ * @param options - Query options ({ enabled })
+ */
 export const useTodayTasks = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
 	const todayPlan = useTodayPlan(employeeId, { enabled });
 
 	// NOTE: Replacement for todayTasksState atom; derived locally from todayPlan.
 	const todayTasks = useMemo(() => {
-		return todayPlan.flatMap((plan) => plan.tasks ?? []);
+		return todayPlan?.flatMap((plan) => plan.tasks ?? []) ?? [];
 	}, [todayPlan]);
 
 	return todayTasks;
 };
 
+/**
+ * Returns all tasks from future daily plans.
+ * Replaces legacy `futureTasksState` atom.
+ *
+ * @param employeeId - Employee ID (optional, defaults to current user)
+ * @param options - Query options ({ enabled })
+ */
 export const useFutureTasks = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
 	const futurePlans = useFuturePlans(employeeId, { enabled });
@@ -21,7 +35,7 @@ export const useFutureTasks = (employeeId?: string, options: IUseDailyPlanOption
 	// NOTE: Replacement for futureTasksState atom; keeps future task list
 	// local to this hook instead of global Jotai.
 	const futureTasks = useMemo(() => {
-		return futurePlans.flatMap((plan) => plan.tasks ?? []);
+		return futurePlans?.flatMap((plan) => plan.tasks ?? []) ?? [];
 	}, [futurePlans]);
 
 	return futureTasks;

--- a/apps/web/core/hooks/daily-plans/derived/use-profile-daily-plans.ts
+++ b/apps/web/core/hooks/daily-plans/derived/use-profile-daily-plans.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { useAuthenticateUser } from '../../auth';
+import { IUseDailyPlanOptions, useEmployeeDailyPlansQuery, useMyDailyPlansQuery } from '../queries';
+
+export const useProfileDailyPlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const { user } = useAuthenticateUser();
+	const isViewingOtherEmployee = useMemo(
+		() => !!employeeId && employeeId !== user?.employeeId && employeeId !== user?.employee?.id,
+		[employeeId, user?.employeeId, user?.employee?.id]
+	);
+
+	const getDayPlansByEmployeeQuery = useEmployeeDailyPlansQuery(employeeId, {
+		enabled: isViewingOtherEmployee && enabled
+	});
+	const getMyDailyPlansQuery = useMyDailyPlansQuery({ enabled: !isViewingOtherEmployee && enabled });
+
+	return isViewingOtherEmployee
+		? getDayPlansByEmployeeQuery.data || { items: [], total: 0 }
+		: getMyDailyPlansQuery.data || { items: [], total: 0 };
+};

--- a/apps/web/core/hooks/daily-plans/derived/use-profile-daily-plans.ts
+++ b/apps/web/core/hooks/daily-plans/derived/use-profile-daily-plans.ts
@@ -2,6 +2,14 @@ import { useMemo } from 'react';
 import { useAuthenticateUser } from '../../auth';
 import { IUseDailyPlanOptions, useEmployeeDailyPlansQuery, useMyDailyPlansQuery } from '../queries';
 
+/**
+ * Returns daily plans for a given employee or the current user.
+ * Automatically switches between `useMyDailyPlansQuery` and `useEmployeeDailyPlansQuery`
+ * based on whether `employeeId` matches the authenticated user.
+ *
+ * @param employeeId - Employee ID (optional, defaults to current user)
+ * @param options - Query options ({ enabled })
+ */
 export const useProfileDailyPlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
 	const { user } = useAuthenticateUser();

--- a/apps/web/core/hooks/daily-plans/derived/use-sorted-plans.ts
+++ b/apps/web/core/hooks/daily-plans/derived/use-sorted-plans.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import { IUseDailyPlanOptions } from '../queries';
+import { useProfileDailyPlans } from './use-profile-daily-plans';
+
+export const useAscSortedPlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const profileDailyPlans = useProfileDailyPlans(employeeId, { enabled });
+
+	const ascSortedPlans = useMemo(() => {
+		return [...(profileDailyPlans.items ? profileDailyPlans.items : [])].sort(
+			(a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+		);
+	}, [profileDailyPlans]);
+
+	return ascSortedPlans;
+};
+
+export const useDescSortedPlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const profileDailyPlans = useProfileDailyPlans(employeeId, { enabled });
+
+	const descSortedPlans = useMemo(() => {
+		return [...(profileDailyPlans.items ? profileDailyPlans.items : [])].sort(
+			(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+		);
+	}, [profileDailyPlans]);
+
+	return descSortedPlans;
+};
+
+export const useSortedPlan = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const profileDailyPlans = useProfileDailyPlans(employeeId, { enabled });
+	// NOTE: Replacement for sortedPlansState atom; generic sorted list
+	// used by multiple views (tabs, filters, etc.).
+	const sortedPlans = useMemo(() => {
+		return [...(profileDailyPlans.items ? profileDailyPlans.items : [])].sort(
+			(a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+		);
+	}, [profileDailyPlans]);
+
+	return sortedPlans;
+};

--- a/apps/web/core/hooks/daily-plans/derived/use-sorted-plans.ts
+++ b/apps/web/core/hooks/daily-plans/derived/use-sorted-plans.ts
@@ -2,6 +2,12 @@ import { useMemo } from 'react';
 import { IUseDailyPlanOptions } from '../queries';
 import { useProfileDailyPlans } from './use-profile-daily-plans';
 
+/**
+ * Returns daily plans sorted ascending by date (oldest first).
+ *
+ * @param employeeId - Employee ID (optional, defaults to current user)
+ * @param options - Query options ({ enabled })
+ */
 export const useAscSortedPlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
 	const profileDailyPlans = useProfileDailyPlans(employeeId, { enabled });
@@ -15,6 +21,12 @@ export const useAscSortedPlans = (employeeId?: string, options: IUseDailyPlanOpt
 	return ascSortedPlans;
 };
 
+/**
+ * Returns daily plans sorted descending by date (newest first).
+ *
+ * @param employeeId - Employee ID (optional, defaults to current user)
+ * @param options - Query options ({ enabled })
+ */
 export const useDescSortedPlans = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
 	const profileDailyPlans = useProfileDailyPlans(employeeId, { enabled });
@@ -28,6 +40,13 @@ export const useDescSortedPlans = (employeeId?: string, options: IUseDailyPlanOp
 	return descSortedPlans;
 };
 
+/**
+ * Returns daily plans sorted ascending by date.
+ * Alias for `useAscSortedPlans` - replaces legacy `sortedPlansState` atom.
+ *
+ * @param employeeId - Employee ID (optional, defaults to current user)
+ * @param options - Query options ({ enabled })
+ */
 export const useSortedPlan = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
 	const profileDailyPlans = useProfileDailyPlans(employeeId, { enabled });

--- a/apps/web/core/hooks/daily-plans/mutations/index.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/index.ts
@@ -1,0 +1,6 @@
+export * from './use-add-task-to-plan.mutation';
+export * from './use-create-daily-plan.mutation';
+export * from './use-delete-daily-plan.mutation';
+export * from './use-remove-task-from-many-plans.mutation';
+export * from './use-remove-task-from-plan.mutation';
+export * from './use-update-daily-plan.mutation';

--- a/apps/web/core/hooks/daily-plans/mutations/use-add-task-to-plan.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-add-task-to-plan.mutation.ts
@@ -8,6 +8,11 @@ import { toast } from 'sonner';
 import { useCurrentTeam } from '../../organizations/teams/use-current-team';
 import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
 
+/**
+ * Mutation to add a task to a daily plan.
+ * Auto-assigns the employee to the task if not already assigned.
+ * Invalidates daily plan cache on success.
+ */
 export const useAddTaskToPlanMutation = () => {
 	const activeTeam = useCurrentTeam();
 	const invalidateDailyPlanData = useInvalidateDailyPlanData();

--- a/apps/web/core/hooks/daily-plans/mutations/use-add-task-to-plan.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-add-task-to-plan.mutation.ts
@@ -1,0 +1,72 @@
+import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { queryKeys } from '@/core/query/keys';
+import { dailyPlanService, taskService } from '@/core/services/client/api';
+import { TDailyPlanTasksUpdate } from '@/core/types/schemas';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useCurrentTeam } from '../../organizations/teams/use-current-team';
+import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
+
+export const useAddTaskToPlanMutation = () => {
+	const activeTeam = useCurrentTeam();
+	const invalidateDailyPlanData = useInvalidateDailyPlanData();
+	const queryClient = useQueryClient();
+
+	const addTaskToPlanMutation = useMutation({
+		mutationFn: async ({ dailyPlanId, data }: { dailyPlanId: string; data: TDailyPlanTasksUpdate }) => {
+			const res = await dailyPlanService.addTaskToPlan(data, dailyPlanId);
+			return res;
+		},
+		onSuccess: async (_data, variables) => {
+			try {
+				const taskId = variables.data.taskId;
+				// Use employeeId from the request data to ensure we assign the correct employee
+				// when adding tasks to other employees' plans
+				const requestEmployeeId = variables.data.employeeId;
+
+				// Get the task from React Query cache
+				const tasksData = queryClient.getQueryData<{ items: TTask[]; total: number }>(
+					queryKeys.tasks.byTeam(activeTeam?.id)
+				);
+
+				const task = tasksData?.items?.find((t) => t.id === taskId);
+
+				if (task && requestEmployeeId) {
+					// Check if employee is already assigned to the task
+					const isAlreadyAssigned = task.members?.some((member) => member.id === requestEmployeeId);
+
+					if (!isAlreadyAssigned) {
+						// Get employee object from activeTeam.members
+						const employee = activeTeam?.members?.find((m) => m.employeeId === requestEmployeeId);
+						if (employee && employee.employeeId) {
+							// Add employee to task members (deduplicate by userId for idempotence)
+							const existingMembers = task.members ?? [];
+							const memberExists = existingMembers.some((m) => m.userId === employee.user?.id);
+
+							if (!memberExists) {
+								const updatedMembers = [...existingMembers, employee];
+								// Update task via taskService (will trigger invalidation)
+								await taskService.updateTask({
+									taskId: task.id,
+									data: { ...task, members: updatedMembers as any } // Type assertion needed due to Zod lazy schema
+								});
+								toast.success('Employee assigned to task');
+							}
+						}
+					}
+				}
+			} catch (error) {
+				// Log error but don't block the daily plan update
+				toast.error('Failed to auto-assign employee to task', {
+					description: getErrorMessage(error, 'Failed to auto-assign employee to task')
+				});
+				logErrorInDev('Failed to auto-assign employee to task:', error);
+			}
+
+			invalidateDailyPlanData();
+		}
+	});
+
+	return addTaskToPlanMutation;
+};

--- a/apps/web/core/hooks/daily-plans/mutations/use-create-daily-plan.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-create-daily-plan.mutation.ts
@@ -5,6 +5,10 @@ import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
 import { toast } from 'sonner';
 import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
 
+/**
+ * Mutation to create a new daily plan.
+ * Shows error toast on failure. Invalidates daily plan cache on success.
+ */
 export const useCreateDailyPlanMutation = () => {
 	const invalidateDailyPlanData = useInvalidateDailyPlanData();
 

--- a/apps/web/core/hooks/daily-plans/mutations/use-create-daily-plan.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-create-daily-plan.mutation.ts
@@ -1,0 +1,28 @@
+import { dailyPlanService } from '@/core/services/client/api';
+import { TCreateDailyPlan } from '@/core/types/schemas';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
+import { toast } from 'sonner';
+import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+
+export const useCreateDailyPlanMutation = () => {
+	const invalidateDailyPlanData = useInvalidateDailyPlanData();
+
+	const createDailyplanMutation = useMutation({
+		mutationFn: async (data: TCreateDailyPlan) => {
+			const res = await dailyPlanService.createDailyPlan(data);
+			return res;
+		},
+		onSuccess: () => {
+			invalidateDailyPlanData();
+		},
+		onError: (error) => {
+			toast.error('Failed to create daily plan', {
+				description: getErrorMessage(error, 'Failed to create daily plan')
+			});
+			logErrorInDev('Failed to create daily plan', error);
+		}
+	});
+
+	return createDailyplanMutation;
+};

--- a/apps/web/core/hooks/daily-plans/mutations/use-delete-daily-plan.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-delete-daily-plan.mutation.ts
@@ -2,6 +2,10 @@ import { dailyPlanService } from '@/core/services/client/api';
 import { useMutation } from '@tanstack/react-query';
 import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
 
+/**
+ * Mutation to delete a daily plan by ID.
+ * Invalidates daily plan cache on success.
+ */
 export const useDeleteDailyPlanMutation = () => {
 	const invalidateDailyPlanData = useInvalidateDailyPlanData();
 

--- a/apps/web/core/hooks/daily-plans/mutations/use-delete-daily-plan.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-delete-daily-plan.mutation.ts
@@ -1,0 +1,19 @@
+import { dailyPlanService } from '@/core/services/client/api';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
+
+export const useDeleteDailyPlanMutation = () => {
+	const invalidateDailyPlanData = useInvalidateDailyPlanData();
+
+	const deleteDailyPlanMutation = useMutation({
+		mutationFn: async (dailyPlanId: string) => {
+			const res = await dailyPlanService.deleteDailyPlan(dailyPlanId);
+			return res;
+		},
+		onSuccess: (data) => {
+			invalidateDailyPlanData();
+		}
+	});
+
+	return deleteDailyPlanMutation;
+};

--- a/apps/web/core/hooks/daily-plans/mutations/use-remove-task-from-many-plans.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-remove-task-from-many-plans.mutation.ts
@@ -3,6 +3,10 @@ import { TRemoveTaskFromPlansRequest } from '@/core/types/schemas';
 import { useMutation } from '@tanstack/react-query';
 import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
 
+/**
+ * Mutation to remove a task from multiple daily plans at once.
+ * Invalidates daily plan cache on success.
+ */
 export const useRemoveTaskFromManyPlansMutation = () => {
 	const invalidateDailyPlanData = useInvalidateDailyPlanData();
 

--- a/apps/web/core/hooks/daily-plans/mutations/use-remove-task-from-many-plans.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-remove-task-from-many-plans.mutation.ts
@@ -1,0 +1,20 @@
+import { dailyPlanService } from '@/core/services/client/api';
+import { TRemoveTaskFromPlansRequest } from '@/core/types/schemas';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
+
+export const useRemoveTaskFromManyPlansMutation = () => {
+	const invalidateDailyPlanData = useInvalidateDailyPlanData();
+
+	const removeTaskPlansMutation = useMutation({
+		mutationFn: async ({ taskId, data }: { taskId: string; data: TRemoveTaskFromPlansRequest }) => {
+			const res = await dailyPlanService.removeManyTaskFromPlans({ taskId, data });
+			return res;
+		},
+		onSuccess: (data) => {
+			invalidateDailyPlanData();
+		}
+	});
+
+	return removeTaskPlansMutation;
+};

--- a/apps/web/core/hooks/daily-plans/mutations/use-remove-task-from-plan.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-remove-task-from-plan.mutation.ts
@@ -3,6 +3,10 @@ import { TRemoveTaskFromPlansRequest } from '@/core/types/schemas';
 import { useMutation } from '@tanstack/react-query';
 import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
 
+/**
+ * Mutation to remove a task from a single daily plan.
+ * Invalidates daily plan cache on success.
+ */
 export const useRemoveTaskFromPlanMutation = () => {
 	const invalidateDailyPlanData = useInvalidateDailyPlanData();
 

--- a/apps/web/core/hooks/daily-plans/mutations/use-remove-task-from-plan.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-remove-task-from-plan.mutation.ts
@@ -1,0 +1,20 @@
+import { dailyPlanService } from '@/core/services/client/api';
+import { TRemoveTaskFromPlansRequest } from '@/core/types/schemas';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
+
+export const useRemoveTaskFromPlanMutation = () => {
+	const invalidateDailyPlanData = useInvalidateDailyPlanData();
+
+	const removeTaskFromPlanMutation = useMutation({
+		mutationFn: async ({ dailyPlanId, data }: { dailyPlanId: string; data: TRemoveTaskFromPlansRequest }) => {
+			const res = await dailyPlanService.removeTaskFromPlan(data, dailyPlanId);
+			return res;
+		},
+		onSuccess: (data) => {
+			invalidateDailyPlanData();
+		}
+	});
+
+	return removeTaskFromPlanMutation;
+};

--- a/apps/web/core/hooks/daily-plans/mutations/use-update-daily-plan.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-update-daily-plan.mutation.ts
@@ -1,0 +1,32 @@
+import { dailyPlanService } from '@/core/services/client/api';
+import { TUpdateDailyPlan } from '@/core/types/schemas';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
+
+export const useUpdateDailyPlanMutation = () => {
+	const invalidateDailyPlanData = useInvalidateDailyPlanData();
+
+	const updateDailyPlanMutation = useMutation({
+		mutationFn: async ({ dailyPlanId, data }: { dailyPlanId: string; data: TUpdateDailyPlan }) => {
+			// The server requires `employeeId` in all update requests.
+			// This value may represent either:
+			// - the current owner of the plan, or
+			// - a new owner, if the plan is being reassigned.
+			let employeeId = data?.employeeId;
+			if (!employeeId) {
+				// If `employeeId` is not provided in the payload, we fetch the existing plan
+				// to retrieve its current owner before sending the update request.
+				const plan = await dailyPlanService.getPlanById(dailyPlanId);
+				if (!plan.employeeId) throw new Error('Assign this plan to an employee before any update');
+				employeeId = plan.employeeId;
+			}
+			const res = await dailyPlanService.updateDailyPlan({ ...data, employeeId }, dailyPlanId);
+			return res;
+		},
+		onSuccess: (data) => {
+			invalidateDailyPlanData();
+		}
+	});
+
+	return updateDailyPlanMutation;
+};

--- a/apps/web/core/hooks/daily-plans/mutations/use-update-daily-plan.mutation.ts
+++ b/apps/web/core/hooks/daily-plans/mutations/use-update-daily-plan.mutation.ts
@@ -3,6 +3,11 @@ import { TUpdateDailyPlan } from '@/core/types/schemas';
 import { useMutation } from '@tanstack/react-query';
 import { useInvalidateDailyPlanData } from '../use-invalidate-daily-plan-data';
 
+/**
+ * Mutation to update an existing daily plan.
+ * Fetches current `employeeId` from server if not provided in payload.
+ * Invalidates daily plan cache on success.
+ */
 export const useUpdateDailyPlanMutation = () => {
 	const invalidateDailyPlanData = useInvalidateDailyPlanData();
 

--- a/apps/web/core/hooks/daily-plans/queries/constants.ts
+++ b/apps/web/core/hooks/daily-plans/queries/constants.ts
@@ -1,0 +1,2 @@
+/** Default garbage collection time for daily plan queries (1 hour) */
+export const DAILY_PLAN_QUERY_GC_TIME = 1000 * 60 * 60;

--- a/apps/web/core/hooks/daily-plans/queries/filter-tabs.d.ts
+++ b/apps/web/core/hooks/daily-plans/queries/filter-tabs.d.ts
@@ -1,0 +1,1 @@
+export type TFilterTabs = 'Today Tasks' | 'Future Tasks' | 'Past Tasks' | 'All Tasks' | 'Outstanding';

--- a/apps/web/core/hooks/daily-plans/queries/index.ts
+++ b/apps/web/core/hooks/daily-plans/queries/index.ts
@@ -1,0 +1,7 @@
+export * from './constants';
+export type * from './filter-tabs';
+export * from './use-all-daily-plans.query';
+export type * from './use-daily-plan-options';
+export * from './use-employee-daily-plans.query';
+export * from './use-my-daily-plans.query';
+export * from './use-plans-by-task.query';

--- a/apps/web/core/hooks/daily-plans/queries/use-all-daily-plans.query.ts
+++ b/apps/web/core/hooks/daily-plans/queries/use-all-daily-plans.query.ts
@@ -8,28 +8,8 @@ import { IUseDailyPlanOptions } from './use-daily-plan-options';
 import { DAILY_PLAN_QUERY_GC_TIME } from './constants';
 
 /**
- * Hook to fetch all daily plans for the current team.
- *
- * This hook retrieves team-wide daily plans, useful for:
- * - Admin views showing all team members' plans
- * - Team dashboard with aggregated plan data
- * - Reports and analytics
- *
- * @param options - Configuration options for the query
- * @returns React Query result with all team daily plans
- *
- * @example
- * ```tsx
- * // Basic usage
- * const { data, isLoading, error } = useAllDailyPlansQuery();
- *
- * // With conditional fetching
- * const { data } = useAllDailyPlansQuery({ enabled: isAdmin });
- *
- * // Accessing the plans
- * const plans = data?.items ?? [];
- * const totalCount = data?.total ?? 0;
- * ```
+ * Fetches all daily plans for the current team.
+ * Useful for manager views or team-wide dashboards.
  */
 export function useAllDailyPlansQuery(options: IUseDailyPlanOptions = {}) {
 	const { enabled = true } = options;

--- a/apps/web/core/hooks/daily-plans/queries/use-all-daily-plans.query.ts
+++ b/apps/web/core/hooks/daily-plans/queries/use-all-daily-plans.query.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { queryKeys } from '@/core/query/keys';
+import { dailyPlanService } from '@/core/services/client/api';
+import { useQuery } from '@tanstack/react-query';
+import { useCurrentTeam } from '../../organizations/teams/use-current-team';
+import { IUseDailyPlanOptions } from './use-daily-plan-options';
+import { DAILY_PLAN_QUERY_GC_TIME } from './constants';
+
+/**
+ * Hook to fetch all daily plans for the current team.
+ *
+ * This hook retrieves team-wide daily plans, useful for:
+ * - Admin views showing all team members' plans
+ * - Team dashboard with aggregated plan data
+ * - Reports and analytics
+ *
+ * @param options - Configuration options for the query
+ * @returns React Query result with all team daily plans
+ *
+ * @example
+ * ```tsx
+ * // Basic usage
+ * const { data, isLoading, error } = useAllDailyPlansQuery();
+ *
+ * // With conditional fetching
+ * const { data } = useAllDailyPlansQuery({ enabled: isAdmin });
+ *
+ * // Accessing the plans
+ * const plans = data?.items ?? [];
+ * const totalCount = data?.total ?? 0;
+ * ```
+ */
+export function useAllDailyPlansQuery(options: IUseDailyPlanOptions = {}) {
+	const { enabled = true } = options;
+	// Get current team context
+	const activeTeam = useCurrentTeam();
+	const teamId = activeTeam?.id ?? null;
+
+	const query = useQuery({
+		queryKey: queryKeys.dailyPlans.allPlans(teamId),
+		queryFn: async () => {
+			// Fetch all daily plans for the team
+			const res = await dailyPlanService.getAllDayPlans();
+
+			return res;
+		},
+		// Only enable when we have a team ID and enabled is true
+		enabled: enabled && !!teamId,
+		// Default stale time - plans don't change frequently
+		staleTime: DAILY_PLAN_QUERY_GC_TIME
+	});
+
+	return query;
+}

--- a/apps/web/core/hooks/daily-plans/queries/use-daily-plan-options.d.ts
+++ b/apps/web/core/hooks/daily-plans/queries/use-daily-plan-options.d.ts
@@ -1,0 +1,8 @@
+export interface IUseDailyPlanOptions {
+	/**
+	 * Controls whether the queries should be enabled.
+	 * Useful for lazy-loading daily plans only when needed (e.g., when accordion is expanded).
+	 * @default true
+	 */
+	enabled?: boolean;
+}

--- a/apps/web/core/hooks/daily-plans/queries/use-employee-daily-plans.query.ts
+++ b/apps/web/core/hooks/daily-plans/queries/use-employee-daily-plans.query.ts
@@ -10,29 +10,11 @@ import { IUseDailyPlanOptions } from './use-daily-plan-options';
 import { DAILY_PLAN_QUERY_GC_TIME } from './constants';
 
 /**
- * Hook to fetch daily plans for a specific employee.
+ * Fetches daily plans for a specific employee.
+ * Falls back to current user if no employeeId provided.
  *
- * Use this hook when viewing another team member's plans,
- * such as on their profile page or in a manager's view.
- *
- * @param options - Configuration options including employeeId
- * @returns React Query result with the employee's daily plans
- *
- * @example
- * ```tsx
- * // On a profile page
- * const { employeeId } = useParams();
- * const { data, isLoading } = useEmployeeDailyPlansQuery({ employeeId });
- *
- * // Conditional fetching
- * const { data } = useEmployeeDailyPlansQuery({
- *   employeeId: selectedEmployee?.id,
- *   enabled: !!selectedEmployee
- * });
- *
- * // Access plans
- * const employeePlans = data?.items ?? [];
- * ```
+ * @param employeeId - Target employee ID (optional, defaults to current user)
+ * @param options - Query options ({ enabled })
  */
 export const useEmployeeDailyPlansQuery = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
 	const { enabled = true } = options;
@@ -69,6 +51,10 @@ export const useEmployeeDailyPlansQuery = (employeeId?: string, options: IUseDai
 	});
 };
 
+/**
+ * Lazy version of useEmployeeDailyPlansQuery.
+ * Fetches on-demand via `getPlanByEmployeeId()` instead of automatically.
+ */
 export const useEmployeeDailyPlansQueryLazy = () => {
 	// Get current team context
 	const activeTeam = useCurrentTeam();

--- a/apps/web/core/hooks/daily-plans/queries/use-employee-daily-plans.query.ts
+++ b/apps/web/core/hooks/daily-plans/queries/use-employee-daily-plans.query.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { queryKeys } from '@/core/query/keys';
+import { dailyPlanService } from '@/core/services/client/api';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { useAuthenticateUser } from '../../auth';
+import { useCurrentTeam } from '../../organizations/teams/use-current-team';
+import { IUseDailyPlanOptions } from './use-daily-plan-options';
+import { DAILY_PLAN_QUERY_GC_TIME } from './constants';
+
+/**
+ * Hook to fetch daily plans for a specific employee.
+ *
+ * Use this hook when viewing another team member's plans,
+ * such as on their profile page or in a manager's view.
+ *
+ * @param options - Configuration options including employeeId
+ * @returns React Query result with the employee's daily plans
+ *
+ * @example
+ * ```tsx
+ * // On a profile page
+ * const { employeeId } = useParams();
+ * const { data, isLoading } = useEmployeeDailyPlansQuery({ employeeId });
+ *
+ * // Conditional fetching
+ * const { data } = useEmployeeDailyPlansQuery({
+ *   employeeId: selectedEmployee?.id,
+ *   enabled: !!selectedEmployee
+ * });
+ *
+ * // Access plans
+ * const employeePlans = data?.items ?? [];
+ * ```
+ */
+export const useEmployeeDailyPlansQuery = (employeeId?: string, options: IUseDailyPlanOptions = {}) => {
+	const { enabled = true } = options;
+	const { user } = useAuthenticateUser();
+
+	const _employeeId = useMemo(
+		() => employeeId ?? user?.employeeId ?? user?.employee?.id,
+		[employeeId, user?.employeeId, user?.employee?.id]
+	);
+
+	// Get current team context
+	const activeTeam = useCurrentTeam();
+	const teamId = activeTeam?.id ?? null;
+
+	return useQuery({
+		queryKey: queryKeys.dailyPlans.byEmployee(_employeeId ?? null, teamId),
+		queryFn: async () => {
+			// Safety check - should not reach here if enabled logic is correct
+			if (!_employeeId) {
+				throw new Error('Employee ID is required to fetch daily plans');
+			}
+
+			// Fetch daily plans for the specific employee
+			const response = await dailyPlanService.getDayPlansByEmployee({ employeeId: _employeeId });
+
+			return response;
+		},
+
+		// Only enable when we have both _employeeId and teamId
+		enabled: enabled && !!_employeeId && !!teamId,
+
+		// Default stale time
+		staleTime: DAILY_PLAN_QUERY_GC_TIME // 1 hour
+	});
+};
+
+export const useEmployeeDailyPlansQueryLazy = () => {
+	// Get current team context
+	const activeTeam = useCurrentTeam();
+	const teamId = activeTeam?.id ?? null;
+
+	// utility for lazy query
+	const queryClient = useQueryClient();
+	const [queryKey, setQueryKey] = useState<ReturnType<typeof queryKeys.dailyPlans.byEmployee> | null>(null);
+	const state = queryClient.getQueryState(queryKey ?? ['_none']);
+	const status = useMemo(
+		() => ({
+			isError: state?.status == 'error',
+			isPending: state?.status == 'pending',
+			isSuccess: state?.status == 'success',
+			isLoading: state?.status == 'pending' && state?.fetchStatus == 'fetching'
+		}),
+		[state?.status, state?.fetchStatus]
+	);
+
+	const getPlanByEmployeeId = (employeeId: string) => {
+		return queryClient.fetchQuery({
+			queryKey: queryKeys.dailyPlans.byEmployee(employeeId ?? null, teamId),
+			queryFn: async ({ queryKey }) => {
+				setQueryKey(queryKey);
+				if (!employeeId) throw new Error('Required parameters missing');
+				return await dailyPlanService.getDayPlansByEmployee({ employeeId });
+			},
+			gcTime: DAILY_PLAN_QUERY_GC_TIME
+		});
+	};
+
+	return { getPlanByEmployeeId, ...state, ...status };
+};

--- a/apps/web/core/hooks/daily-plans/queries/use-my-daily-plans.query.ts
+++ b/apps/web/core/hooks/daily-plans/queries/use-my-daily-plans.query.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { queryKeys } from '@/core/query/keys';
+import { dailyPlanService } from '@/core/services/client/api';
+import { useQuery } from '@tanstack/react-query';
+import { useCurrentTeam } from '../../organizations/teams/use-current-team';
+import { IUseDailyPlanOptions } from './use-daily-plan-options';
+import { DAILY_PLAN_QUERY_GC_TIME } from './constants';
+
+/**
+ * Hook to fetch daily plans for the currently authenticated user.
+ *
+ * This hook is the primary way to get the logged-in user's plans.
+ * Use this for:
+ * - Personal dashboard
+ * - "My Plans" views
+ * - Home modal daily plan section
+ *
+ * @returns React Query result with current user's daily plans
+ *
+ * @example
+ * ```tsx
+ * // Basic usage
+ * const { data, isLoading } = useMyDailyPlansQuery();
+ *
+ * // With lazy loading (e.g., accordion)
+ * const [isExpanded, setIsExpanded] = useState(false);
+ * const { data } = useMyDailyPlansQuery({ enabled: isExpanded });
+ *
+ * // Access plans
+ * const myPlans = data?.items ?? [];
+ * ```
+ */
+export function useMyDailyPlansQuery(options: IUseDailyPlanOptions = {}) {
+	const { enabled = true } = options;
+
+	// Get current team context
+	const activeTeam = useCurrentTeam();
+	const teamId = activeTeam?.id ?? null;
+
+	return useQuery({
+		queryKey: queryKeys.dailyPlans.myPlans(teamId),
+
+		queryFn: async () => {
+			// Fetch daily plans for the current user
+			const response = await dailyPlanService.getMyDailyPlans();
+
+			return response;
+		},
+
+		// Only enable when we have a team ID and enabled is true
+		enabled: enabled && !!teamId,
+		// Default stale time - user's plans may change more frequently
+		staleTime: DAILY_PLAN_QUERY_GC_TIME
+	});
+}

--- a/apps/web/core/hooks/daily-plans/queries/use-my-daily-plans.query.ts
+++ b/apps/web/core/hooks/daily-plans/queries/use-my-daily-plans.query.ts
@@ -8,28 +8,8 @@ import { IUseDailyPlanOptions } from './use-daily-plan-options';
 import { DAILY_PLAN_QUERY_GC_TIME } from './constants';
 
 /**
- * Hook to fetch daily plans for the currently authenticated user.
- *
- * This hook is the primary way to get the logged-in user's plans.
- * Use this for:
- * - Personal dashboard
- * - "My Plans" views
- * - Home modal daily plan section
- *
- * @returns React Query result with current user's daily plans
- *
- * @example
- * ```tsx
- * // Basic usage
- * const { data, isLoading } = useMyDailyPlansQuery();
- *
- * // With lazy loading (e.g., accordion)
- * const [isExpanded, setIsExpanded] = useState(false);
- * const { data } = useMyDailyPlansQuery({ enabled: isExpanded });
- *
- * // Access plans
- * const myPlans = data?.items ?? [];
- * ```
+ * Fetches daily plans for the currently authenticated user.
+ * Primary hook for personal dashboards and "My Plans" views.
  */
 export function useMyDailyPlansQuery(options: IUseDailyPlanOptions = {}) {
 	const { enabled = true } = options;

--- a/apps/web/core/hooks/daily-plans/queries/use-plans-by-task.query.ts
+++ b/apps/web/core/hooks/daily-plans/queries/use-plans-by-task.query.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { queryKeys } from '@/core/query/keys';
+import { dailyPlanService } from '@/core/services/client/api';
+import { useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { DAILY_PLAN_QUERY_GC_TIME } from './constants';
+
+export const usePlansByTaskLazyQuery = () => {
+	// utility for lazy query
+	const queryClient = useQueryClient();
+	const [queryKey, setQueryKey] = useState<ReturnType<typeof queryKeys.dailyPlans.byTask> | null>(null);
+	const state = queryClient.getQueryState(queryKey ?? ['_none']);
+	const status = useMemo(
+		() => ({
+			isError: state?.status == 'error',
+			isPending: state?.status == 'pending',
+			isSuccess: state?.status == 'success',
+			isLoading: state?.status == 'pending' && state?.fetchStatus == 'fetching'
+		}),
+		[state?.status, state?.fetchStatus]
+	);
+
+	const getPlansByTaskId = (taskId: string) => {
+		return queryClient.fetchQuery({
+			queryKey: queryKeys.dailyPlans.byTask(taskId),
+			queryFn: async ({ queryKey }) => {
+				setQueryKey(queryKey);
+				if (!taskId) throw new Error('Required parameters missing');
+				const res = await dailyPlanService.getPlansByTask({ taskId });
+				return res;
+			},
+			gcTime: DAILY_PLAN_QUERY_GC_TIME
+		});
+	};
+
+	return { getPlansByTaskId, ...state, ...status };
+};

--- a/apps/web/core/hooks/daily-plans/queries/use-plans-by-task.query.ts
+++ b/apps/web/core/hooks/daily-plans/queries/use-plans-by-task.query.ts
@@ -3,9 +3,13 @@
 import { queryKeys } from '@/core/query/keys';
 import { dailyPlanService } from '@/core/services/client/api';
 import { useQueryClient } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { DAILY_PLAN_QUERY_GC_TIME } from './constants';
 
+/**
+ * Lazy query to fetch daily plans containing a specific task.
+ * Fetches on-demand via `getPlansByTaskId()`.
+ */
 export const usePlansByTaskLazyQuery = () => {
 	// utility for lazy query
 	const queryClient = useQueryClient();
@@ -21,18 +25,21 @@ export const usePlansByTaskLazyQuery = () => {
 		[state?.status, state?.fetchStatus]
 	);
 
-	const getPlansByTaskId = (taskId: string) => {
-		return queryClient.fetchQuery({
-			queryKey: queryKeys.dailyPlans.byTask(taskId),
-			queryFn: async ({ queryKey }) => {
-				setQueryKey(queryKey);
-				if (!taskId) throw new Error('Required parameters missing');
-				const res = await dailyPlanService.getPlansByTask({ taskId });
-				return res;
-			},
-			gcTime: DAILY_PLAN_QUERY_GC_TIME
-		});
-	};
+	const getPlansByTaskId = useCallback(
+		(taskId: string) => {
+			return queryClient.fetchQuery({
+				queryKey: queryKeys.dailyPlans.byTask(taskId),
+				queryFn: async ({ queryKey }) => {
+					setQueryKey(queryKey);
+					if (!taskId) throw new Error('Required parameters missing');
+					const res = await dailyPlanService.getPlansByTask({ taskId });
+					return res;
+				},
+				gcTime: DAILY_PLAN_QUERY_GC_TIME
+			});
+		},
+		[queryClient]
+	);
 
 	return { getPlansByTaskId, ...state, ...status };
 };

--- a/apps/web/core/hooks/daily-plans/use-daily-plan.ts
+++ b/apps/web/core/hooks/daily-plans/use-daily-plan.ts
@@ -1,17 +1,12 @@
 'use client';
 
-import { useAtom, useAtomValue } from 'jotai';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { activeTeamState, dailyPlanListState, tasksByTeamState } from '@/core/stores';
+import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { queryKeys } from '@/core/query/keys';
+import { dailyPlanListState, tasksByTeamState } from '@/core/stores';
 import {
 	IDailyPlanTasksUpdate,
 	IRemoveTaskFromManyPlansRequest
 } from '@/core/types/interfaces/task/daily-plan/daily-plan';
-import { useFirstLoad } from '../common/use-first-load';
-import { dailyPlanService, taskService } from '../../services/client/api';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '@/core/query/keys';
-import { TTask } from '@/core/types/schemas/task/task.schema';
 import {
 	TCreateDailyPlan,
 	TDailyPlan,
@@ -19,10 +14,16 @@ import {
 	TRemoveTaskFromPlansRequest,
 	TUpdateDailyPlan
 } from '@/core/types/schemas/task/daily-plan.schema';
-import { useConditionalUpdateEffect, useQueryCall } from '../common';
-import { useUserQuery } from '../queries/user-user.query';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { dailyPlanService, taskService } from '../../services/client/api';
+import { useConditionalUpdateEffect, useQueryCall } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useUserQuery } from '../queries/user-user.query';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export type FilterTabs = 'Today Tasks' | 'Future Tasks' | 'Past Tasks' | 'All Tasks' | 'Outstanding';
 
@@ -48,7 +49,7 @@ export interface UseDailyPlanOptions {
  */
 export function useDailyPlan(defaultEmployeeId: string | null = null, options?: UseDailyPlanOptions) {
 	const { data: user } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const targetEmployeeId = defaultEmployeeId || user?.employee?.id;
 	const [employeeId, setEmployeeId] = useState(targetEmployeeId || '');
 	const queryClient = useQueryClient();

--- a/apps/web/core/hooks/daily-plans/use-daily-plan.ts
+++ b/apps/web/core/hooks/daily-plans/use-daily-plan.ts
@@ -2,7 +2,7 @@
 
 import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
 import { queryKeys } from '@/core/query/keys';
-import { dailyPlanListState, tasksByTeamState } from '@/core/stores';
+import { dailyPlanListState } from '@/core/stores';
 import {
 	IDailyPlanTasksUpdate,
 	IRemoveTaskFromManyPlansRequest
@@ -16,14 +16,15 @@ import {
 } from '@/core/types/schemas/task/daily-plan.schema';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { dailyPlanService, taskService } from '../../services/client/api';
 import { useConditionalUpdateEffect, useQueryCall } from '../common';
 import { useFirstLoad } from '../common/use-first-load';
-import { useUserQuery } from '../queries/user-user.query';
 import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useSortedTasksByCreation } from '../organizations/teams/use-sorted-tasks';
+import { useUserQuery } from '../queries/user-user.query';
 
 export type FilterTabs = 'Today Tasks' | 'Future Tasks' | 'Past Tasks' | 'All Tasks' | 'Outstanding';
 
@@ -53,7 +54,7 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 	const targetEmployeeId = defaultEmployeeId || user?.employee?.id;
 	const [employeeId, setEmployeeId] = useState(targetEmployeeId || '');
 	const queryClient = useQueryClient();
-	const allTeamTasks = useAtomValue(tasksByTeamState);
+	const allTeamTasks = useSortedTasksByCreation();
 
 	// Extract options with defaults
 	const { enabled = true } = options || {};

--- a/apps/web/core/hooks/daily-plans/use-daily-plan.ts
+++ b/apps/web/core/hooks/daily-plans/use-daily-plan.ts
@@ -1,30 +1,42 @@
 'use client';
 
-import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
 import { queryKeys } from '@/core/query/keys';
 import { dailyPlanListState } from '@/core/stores';
 import {
 	IDailyPlanTasksUpdate,
 	IRemoveTaskFromManyPlansRequest
 } from '@/core/types/interfaces/task/daily-plan/daily-plan';
-import {
-	TCreateDailyPlan,
-	TDailyPlan,
-	TDailyPlanTasksUpdate,
-	TRemoveTaskFromPlansRequest,
-	TUpdateDailyPlan
-} from '@/core/types/schemas/task/daily-plan.schema';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { TCreateDailyPlan, TUpdateDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
+import { useQueryClient } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { toast } from 'sonner';
-import { dailyPlanService, taskService } from '../../services/client/api';
-import { useConditionalUpdateEffect, useQueryCall } from '../common';
+import { useCallback, useEffect, useState } from 'react';
+import { dailyPlanService } from '../../services/client/api';
+import { useConditionalUpdateEffect } from '../common';
 import { useFirstLoad } from '../common/use-first-load';
 import { useCurrentTeam } from '../organizations/teams/use-current-team';
-import { useSortedTasksByCreation } from '../organizations/teams/use-sorted-tasks';
 import { useUserQuery } from '../queries/user-user.query';
+import {
+	useFuturePlans,
+	useOutstandingPlans,
+	usePastPlans,
+	useProfileDailyPlans,
+	useSortedPlan,
+	useTodayPlan
+} from './derived';
+import {
+	useAddTaskToPlanMutation,
+	useCreateDailyPlanMutation,
+	useDeleteDailyPlanMutation,
+	useRemoveTaskFromManyPlansMutation,
+	useRemoveTaskFromPlanMutation,
+	useUpdateDailyPlanMutation
+} from './mutations';
+import {
+	useAllDailyPlansQuery,
+	useEmployeeDailyPlansQuery,
+	useMyDailyPlansQuery,
+	usePlansByTaskLazyQuery
+} from './queries';
 
 export type FilterTabs = 'Today Tasks' | 'Future Tasks' | 'Past Tasks' | 'All Tasks' | 'Outstanding';
 
@@ -54,7 +66,6 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 	const targetEmployeeId = defaultEmployeeId || user?.employee?.id;
 	const [employeeId, setEmployeeId] = useState(targetEmployeeId || '');
 	const queryClient = useQueryClient();
-	const allTeamTasks = useSortedTasksByCreation();
 
 	// Extract options with defaults
 	const { enabled = true } = options || {};
@@ -66,186 +77,26 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		}
 	}, [targetEmployeeId, employeeId]);
 	// Queries
-	const getDayPlansByEmployeeQuery = useQuery({
-		queryKey: queryKeys.dailyPlans.byEmployee(targetEmployeeId, activeTeam?.id),
-		queryFn: async () => {
-			if (!targetEmployeeId) {
-				throw new Error('Employee ID is required to fetch daily plans');
-			}
-			const res = await dailyPlanService.getDayPlansByEmployee({ employeeId: targetEmployeeId });
-			return res;
-		},
-		enabled: enabled && !!targetEmployeeId,
-		gcTime: 1000 * 60 * 60 // 1 hour
-	});
+	const getDayPlansByEmployeeQuery = useEmployeeDailyPlansQuery(targetEmployeeId, { enabled });
 
-	const getMyDailyPlansQuery = useQuery({
-		queryKey: queryKeys.dailyPlans.myPlans(activeTeam?.id),
-		queryFn: async () => {
-			const res = await dailyPlanService.getMyDailyPlans();
-			return res;
-		},
-		enabled: enabled && !!activeTeam?.id,
-		gcTime: 1000 * 60 * 60
-	});
+	const getMyDailyPlansQuery = useMyDailyPlansQuery({ enabled });
 
-	const getAllDayPlansQuery = useQuery({
-		queryKey: queryKeys.dailyPlans.allPlans(activeTeam?.id),
-		queryFn: async () => {
-			const res = await dailyPlanService.getAllDayPlans();
-			return res;
-		},
-		enabled: enabled && !!activeTeam?.id,
-		gcTime: 1000 * 60 * 60
-	});
+	const getAllDayPlansQuery = useAllDailyPlansQuery({ enabled });
 
-	const { loading: getPlansByTaskQueryLoading, queryCall: getPlansByTaskQuery } = useQueryCall((taskId: string) =>
-		queryClient.fetchQuery({
-			queryKey: queryKeys.dailyPlans.byTask(taskId),
-			queryFn: async () => {
-				const res = await dailyPlanService.getPlansByTask({ taskId });
-				return res;
-			},
-			gcTime: 1000 * 60 * 60
-		})
-	);
+	const { isLoading: getPlansByTaskQueryLoading, getPlansByTaskId: getPlansByTaskQuery } = usePlansByTaskLazyQuery();
 
 	// Mutations
-	const createDailyplanMutation = useMutation({
-		mutationFn: async (data: TCreateDailyPlan) => {
-			const res = await dailyPlanService.createDailyPlan(data);
-			return res;
-		},
-		onSuccess: () => {
-			invalidateDailyPlanData();
-		},
-		onError: (error) => {
-			toast.error('Failed to create daily plan', {
-				description: getErrorMessage(error, 'Failed to create daily plan')
-			});
-			logErrorInDev('Failed to create daily plan', error);
-		}
-	});
+	const createDailyplanMutation = useCreateDailyPlanMutation();
 
-	const updateDailyPlanMutation = useMutation({
-		mutationFn: async ({ dailyPlanId, data }: { dailyPlanId: string; data: TUpdateDailyPlan }) => {
-			// The server requires `employeeId` in all update requests.
-			// This value may represent either:
-			// - the current owner of the plan, or
-			// - a new owner, if the plan is being reassigned.
-			let employeeId = data?.employeeId;
-			if (!employeeId) {
-				// If `employeeId` is not provided in the payload, we fetch the existing plan
-				// to retrieve its current owner before sending the update request.
-				const plan = await dailyPlanService.getPlanById(dailyPlanId);
-				if (!plan.employeeId) throw new Error('Assign this plan to an employee before any update');
-				employeeId = plan.employeeId;
-			}
-			const res = await dailyPlanService.updateDailyPlan({ ...data, employeeId }, dailyPlanId);
-			return res;
-		},
-		onSuccess: (data) => {
-			invalidateDailyPlanData();
-		}
-	});
+	const updateDailyPlanMutation = useUpdateDailyPlanMutation();
 
-	const addTaskToPlanMutation = useMutation({
-		mutationFn: async ({ dailyPlanId, data }: { dailyPlanId: string; data: TDailyPlanTasksUpdate }) => {
-			const res = await dailyPlanService.addTaskToPlan(data, dailyPlanId);
-			return res;
-		},
-		onSuccess: async (_data, variables) => {
-			try {
-				const taskId = variables.data.taskId;
-				// Use employeeId from the request data to ensure we assign the correct employee
-				// when adding tasks to other employees' plans
-				const requestEmployeeId = variables.data.employeeId;
+	const addTaskToPlanMutation = useAddTaskToPlanMutation();
 
-				// Get the task from React Query cache
-				const tasksData = queryClient.getQueryData<{ items: TTask[]; total: number }>(
-					queryKeys.tasks.byTeam(activeTeam?.id)
-				);
+	const removeTaskFromPlanMutation = useRemoveTaskFromPlanMutation();
 
-				const task = tasksData?.items?.find((t) => t.id === taskId);
+	const removeTaskPlansMutation = useRemoveTaskFromManyPlansMutation();
 
-				if (task && requestEmployeeId) {
-					// Check if employee is already assigned to the task
-					const isAlreadyAssigned = task.members?.some((member) => member.id === requestEmployeeId);
-
-					if (!isAlreadyAssigned) {
-						// Get employee object from activeTeam.members
-						const employee = activeTeam?.members?.find((m) => m.employeeId === requestEmployeeId);
-						if (employee && employee.employeeId) {
-							// Add employee to task members (deduplicate by userId for idempotence)
-							const existingMembers = task.members ?? [];
-							const memberExists = existingMembers.some((m) => m.userId === employee.user?.id);
-
-							if (!memberExists) {
-								const updatedMembers = [...existingMembers, employee];
-								// Update task via taskService (will trigger invalidation)
-								await taskService.updateTask({
-									taskId: task.id,
-									data: { ...task, members: updatedMembers as any } // Type assertion needed due to Zod lazy schema
-								});
-								toast.success('Employee assigned to task');
-							}
-						}
-					}
-				}
-			} catch (error) {
-				// Log error but don't block the daily plan update
-				toast.error('Failed to auto-assign employee to task', {
-					description: getErrorMessage(error, 'Failed to auto-assign employee to task')
-				});
-				logErrorInDev('Failed to auto-assign employee to task:', error);
-			}
-
-			invalidateDailyPlanData();
-		}
-	});
-
-	const removeTaskFromPlanMutation = useMutation({
-		mutationFn: async ({ dailyPlanId, data }: { dailyPlanId: string; data: TRemoveTaskFromPlansRequest }) => {
-			const res = await dailyPlanService.removeTaskFromPlan(data, dailyPlanId);
-			return res;
-		},
-		onSuccess: (data) => {
-			invalidateDailyPlanData();
-		}
-	});
-
-	const removeTaskPlansMutation = useMutation({
-		mutationFn: async ({ taskId, data }: { taskId: string; data: TRemoveTaskFromPlansRequest }) => {
-			const res = await dailyPlanService.removeManyTaskFromPlans({ taskId, data });
-			return res;
-		},
-		onSuccess: (data) => {
-			invalidateDailyPlanData();
-		}
-	});
-
-	const deleteDailyPlanMutation = useMutation({
-		mutationFn: async (dailyPlanId: string) => {
-			const res = await dailyPlanService.deleteDailyPlan(dailyPlanId);
-			return res;
-		},
-		onSuccess: (data) => {
-			invalidateDailyPlanData();
-		}
-	});
-
-	const invalidateDailyPlanData = useCallback(() => {
-		// Invalidate ALL task queries to ensure synchronization across all contexts
-		// Invalidate ALL daily plan queries to ensure synchronization across all contexts
-		// This includes myPlans, allPlans, byEmployee, byTask, etc.
-		// Similar to invalidateTeamTasksData() in use-team-tasks.ts
-		queryClient.invalidateQueries({
-			queryKey: queryKeys.tasks.all
-		});
-		queryClient.invalidateQueries({
-			queryKey: queryKeys.dailyPlans.all
-		});
-	}, [queryClient]);
+	const deleteDailyPlanMutation = useDeleteDailyPlanMutation();
 
 	//  TEAM-WIDE atom - Keep for backward compatibility
 	const [dailyPlan, setDailyPlan] = useAtom(dailyPlanListState);
@@ -265,13 +116,7 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 	//  NOTE: Calculate profileDailyPlans from React Query.
 	//  Per-employee plans are no longer stored in global atoms; they are derived
 	//  from queries to keep views in sync (Home modal, Profile tab, etc.).
-	const profileDailyPlans = useMemo(() => {
-		const isViewingOtherEmployee = targetEmployeeId && targetEmployeeId !== user?.employee?.id;
-
-		return isViewingOtherEmployee
-			? getDayPlansByEmployeeQuery.data || { items: [], total: 0 }
-			: getMyDailyPlansQuery.data || { items: [], total: 0 };
-	}, [targetEmployeeId, user?.employee?.id, getDayPlansByEmployeeQuery.data, getMyDailyPlansQuery.data]);
+	const profileDailyPlans = useProfileDailyPlans(targetEmployeeId, { enabled });
 
 	// All day plans
 	const getAllDayPlans = useCallback(async () => {
@@ -417,145 +262,21 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		[deleteDailyPlanMutation]
 	);
 
-	// NOTE: Replacement for ascSortedPlansState atom; keeps plans sorted
-	// by date ascending for future/past calculations.
-	const ascSortedPlans = useMemo(() => {
-		return [...(profileDailyPlans.items ? profileDailyPlans.items : [])].sort(
-			(a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
-		);
-	}, [profileDailyPlans]);
-
-	const futurePlans = useMemo(() => {
-		return ascSortedPlans?.filter((plan) => {
-			const planDate = new Date(plan.date);
-			const today = new Date();
-			today.setHours(23, 59, 59, 0); // Set today time to exclude timestamps in comparization
-			// NOTE_FIX: Use > instead of >= to exclude today's plans from future plans
-			// Future plans should only include dates AFTER today, not today itself
-			return planDate.getTime() > today.getTime();
-		});
-	}, [ascSortedPlans]);
-
-	// NOTE: Replacement for descSortedPlansState atom; keeps plans sorted
-	// by date descending for past calculations.
-	const descSortedPlans = useMemo(() => {
-		return [...(profileDailyPlans.items ? profileDailyPlans.items : [])].sort(
-			(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-		);
-	}, [profileDailyPlans]);
+	const futurePlans = useFuturePlans(targetEmployeeId, { enabled });
 
 	// NOTE: Replacement for pastPlansState atom; exposes strictly past plans
 	// for Outstanding and history-related views.
-	const pastPlans = useMemo(() => {
-		return descSortedPlans?.filter((plan) => {
-			const planDate = new Date(plan.date);
-			const today = new Date();
-			today.setHours(0, 0, 0, 0); // Set today time to exclude timestamps in comparization
-			return planDate.getTime() < today.getTime();
-		});
-	}, [descSortedPlans]);
+	const pastPlans = usePastPlans(targetEmployeeId, { enabled });
 
-	const todayPlan = useMemo(() => {
-		// NOTE: Replacement for todayPlanState atom.
-		// We keep the same ISO-date prefix logic so counters/charts using
-		// "today" are not affected by this refactor.
-		return [...(profileDailyPlans.items ? profileDailyPlans.items : [])].filter((plan) =>
-			plan.date?.toString()?.startsWith(new Date()?.toISOString().split('T')[0])
-		);
-	}, [profileDailyPlans]);
-
-	// NOTE: Replacement for todayTasksState atom; derived locally from todayPlan.
-	const todayTasks = useMemo(() => {
-		return todayPlan.flatMap((plan) => plan.tasks ?? []);
-	}, [todayPlan]);
-
-	// NOTE: Replacement for futureTasksState atom; keeps future task list
-	// local to this hook instead of global Jotai.
-	const futureTasks = useMemo(() => {
-		return futurePlans.flatMap((plan) => plan.tasks ?? []);
-	}, [futurePlans]);
+	const todayPlan = useTodayPlan(targetEmployeeId, { enabled });
 
 	// NOTE: Replacement for outstandingPlansState atom; keeps "outstanding"
 	// logic close to daily-plan queries instead of global Jotai stores.
-	const outstandingPlans = useMemo(() => {
-		// Build a Set of task IDs from today/future to avoid repeated linear searches (O(1) lookup instead of O(n²))
-		const usedIds = new Set<string>([...todayTasks, ...futureTasks].map((t: TTask) => t.id));
-
-		// PART 1: Past plans with incomplete tasks not in today/future
-		const pastPlansWithIncompleteTasks = [...(profileDailyPlans.items ? profileDailyPlans.items : [])]
-			// Exclude today plans
-			.filter((plan) => !plan.date?.toString()?.startsWith(new Date()?.toISOString().split('T')[0]))
-			// Exclude future plans (keep only past plans)
-			.filter((plan) => {
-				const planDate = new Date(plan.date);
-				const today = new Date();
-				today.setHours(23, 59, 59, 0);
-				return planDate.getTime() <= today.getTime();
-			})
-			.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
-			.map((plan) => ({
-				...plan,
-				// Include only non-completed tasks
-				tasks: plan.tasks?.filter((task) => task.status !== 'completed')
-			}))
-			.map((plan) => ({
-				...plan,
-				// Include only tasks not added yet to today/future plans
-				tasks: plan.tasks?.filter((_task) => !usedIds.has(_task.id))
-			}))
-			.filter((plan) => plan.tasks?.length && plan.tasks.length > 0);
-
-		// PART 2: Tasks assigned to member that are NOT in ANY plan
-		// Build a Set of ALL task IDs that are in ANY plan (today, future, past)
-		const allPlannedTaskIds = new Set<string>(
-			profileDailyPlans.items?.flatMap((plan) => plan.tasks?.map((t) => t.id) ?? []) ?? []
-		);
-
-		// Filter tasks assigned to the target employee that are NOT in any plan
-		const tasksNotInAnyPlan = allTeamTasks.filter((task) => {
-			// Must be assigned to the target employee (match by employeeId, not current user)
-			const isAssignedToTargetEmployee =
-				!!targetEmployeeId && task.members?.some((member) => member.id === targetEmployeeId);
-			// Must NOT be in any plan
-			const isNotInAnyPlan = !allPlannedTaskIds.has(task.id);
-			// Must have time tracked OR estimation set
-			const hasTimeOrEstimate =
-				(task.totalWorkedTime && task.totalWorkedTime > 0) || (task.estimate && task.estimate > 0);
-
-			return isAssignedToTargetEmployee && isNotInAnyPlan && hasTimeOrEstimate;
-		});
-
-		// Create a virtual plan for tasks not in any plan (if any exist)
-		const virtualPlanForUnplannedTasks: TDailyPlan[] =
-			tasksNotInAnyPlan.length > 0
-				? [
-						{
-							id: 'outstanding-no-plan',
-							date: new Date().toISOString(),
-							tasks: tasksNotInAnyPlan,
-							workTimePlanned: 0,
-							status: 'open',
-							tenantId: activeTeam?.tenantId ?? null,
-							organizationId: activeTeam?.organizationId ?? null,
-							employeeId: targetEmployeeId ?? null,
-							employee: null,
-							organizationTeamId: activeTeam?.id ?? null,
-							organizationTeam: null
-						}
-					]
-				: [];
-
-		// Combine past plans with incomplete tasks + virtual plan for unplanned tasks
-		return [...pastPlansWithIncompleteTasks, ...virtualPlanForUnplannedTasks];
-	}, [profileDailyPlans, todayTasks, futureTasks, allTeamTasks, activeTeam, targetEmployeeId]);
+	const outstandingPlans = useOutstandingPlans(targetEmployeeId, { enabled });
 
 	// NOTE: Replacement for sortedPlansState atom; generic sorted list
 	// used by multiple views (tabs, filters, etc.).
-	const sortedPlans = useMemo(() => {
-		return [...(profileDailyPlans.items ? profileDailyPlans.items : [])].sort(
-			(a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
-		);
-	}, [profileDailyPlans]);
+	const sortedPlans = useSortedPlan(targetEmployeeId, { enabled });
 
 	const handleFirstLoad = useCallback(async () => {
 		await loadAllDayPlans();

--- a/apps/web/core/hooks/daily-plans/use-daily-plan.ts
+++ b/apps/web/core/hooks/daily-plans/use-daily-plan.ts
@@ -50,15 +50,87 @@ export interface UseDailyPlanOptions {
 }
 
 /**
- * NOTE: This hook replaces several legacy Jotai atoms
- * (myDailyPlanListState, profileDailyPlanListState, employeePlansListState, taskPlans).
- * Team-wide plans still use dailyPlanListState; per-employee plans and
- * derived views now rely on React Query so Home modal and Profile "Plans"
- * tab stay in sync for the selected employee
+ * @deprecated This monolithic hook is deprecated and will be removed in a future release.
+ * Use the specialized hooks directly for better performance and maintainability.
  *
- * @param defaultEmployeeId - Optional employee ID to fetch plans for. Defaults to current user's employee ID.
- * @param options - Optional configuration object
- * @param options.enabled - Controls whether queries should be enabled. Defaults to true for backward compatibility.
+ * ## 🚀 Migration Guide
+ *
+ * ### Queries - Use these hooks directly:
+ * | Old (useDailyPlan)                  | New (Direct Hook)                              |
+ * |-------------------------------------|------------------------------------------------|
+ * | `getAllDayPlans()`                  | `useAllDailyPlansQuery()`                      |
+ * | `getAllDayPlansLoading`             | `useAllDailyPlansQuery().isLoading`            |
+ * | `getMyDailyPlans()`                 | `useMyDailyPlansQuery()`                       |
+ * | `getMyDailyPlansLoading`            | `useMyDailyPlansQuery().isLoading`             |
+ * | `getEmployeeDayPlans(employeeId)`   | `useEmployeeDailyPlansQuery(employeeId)`       |
+ * | `getDayPlansByEmployeeLoading`      | `useEmployeeDailyPlansQuery().isLoading`       |
+ * | `getPlansByTask(taskId)`            | `usePlansByTaskLazyQuery()`                    |
+ * | `getPlansByTaskLoading`             | `usePlansByTaskLazyQuery().isLoading`          |
+ *
+ * ### Mutations - Use these hooks directly:
+ * | Old (useDailyPlan)                  | New (Direct Hook)                              |
+ * |-------------------------------------|------------------------------------------------|
+ * | `createDailyPlan(data)`             | `useCreateDailyPlanMutation().mutateAsync()`   |
+ * | `createDailyPlanLoading`            | `useCreateDailyPlanMutation().isPending`       |
+ * | `updateDailyPlan(data, id)`         | `useUpdateDailyPlanMutation().mutateAsync()`   |
+ * | `updateDailyPlanLoading`            | `useUpdateDailyPlanMutation().isPending`       |
+ * | `addTaskToPlan(data, id)`           | `useAddTaskToPlanMutation().mutateAsync()`     |
+ * | `addTaskToPlanLoading`              | `useAddTaskToPlanMutation().isPending`         |
+ * | `removeTaskFromPlan(data, id)`      | `useRemoveTaskFromPlanMutation().mutateAsync()`|
+ * | `removeTaskFromPlanLoading`         | `useRemoveTaskFromPlanMutation().isPending`    |
+ * | `removeManyTaskPlans(data, taskId)` | `useRemoveTaskFromManyPlansMutation().mutateAsync()` |
+ * | `removeManyTaskFromPlanLoading`     | `useRemoveTaskFromManyPlansMutation().isPending`|
+ * | `deleteDailyPlan(id)`               | `useDeleteDailyPlanMutation().mutateAsync()`   |
+ * | `deleteDailyPlanLoading`            | `useDeleteDailyPlanMutation().isPending`       |
+ *
+ * ### Derived Data - Use these hooks directly:
+ * | Old (useDailyPlan)                  | New (Direct Hook)                              |
+ * |-------------------------------------|------------------------------------------------|
+ * | `profileDailyPlans`                 | `useProfileDailyPlans(employeeId)`             |
+ * | `myDailyPlans`                      | `useProfileDailyPlans()` (current user)        |
+ * | `todayPlan`                         | `useTodayPlan(employeeId)`                     |
+ * | `futurePlans`                       | `useFuturePlans(employeeId)`                   |
+ * | `pastPlans`                         | `usePastPlans(employeeId)`                     |
+ * | `outstandingPlans`                  | `useOutstandingPlans(employeeId)`              |
+ * | `sortedPlans`                       | `useSortedPlan(employeeId)`                    |
+ *
+ * ### Legacy Jotai State (for backward compatibility only):
+ * | Old (useDailyPlan)                  | New (Direct Usage)                             |
+ * |-------------------------------------|------------------------------------------------|
+ * | `dailyPlan`                         | `useAtom(dailyPlanListState)`                  |
+ * | `setDailyPlan`                      | `useAtom(dailyPlanListState)[1]`               |
+ *
+ * ## 📦 Example Migration
+ *
+ * ### Before (deprecated):
+ * ```tsx
+ * const {
+ *   todayPlan,
+ *   createDailyPlan,
+ *   createDailyPlanLoading,
+ *   getMyDailyPlans
+ * } = useDailyPlan();
+ *
+ * const handleCreate = async () => {
+ *   await createDailyPlan({ date: new Date() });
+ *   await getMyDailyPlans();
+ * };
+ * ```
+ *
+ * ### After (recommended):
+ * ```tsx
+ * const todayPlan = useTodayPlan();
+ * const { mutateAsync: createDailyPlan, isPending } = useCreateDailyPlanMutation();
+ * const { data: myPlans } = useMyDailyPlansQuery();
+ *
+ * const handleCreate = async () => {
+ *   await createDailyPlan({ date: new Date() });
+ *   // No need to manually refetch - cache is invalidated automatically
+ * };
+ * ```
+ *
+ * @param defaultEmployeeId - Employee ID to fetch plans for (defaults to current user)
+ * @param options - Configuration options ({ enabled })
  */
 export function useDailyPlan(defaultEmployeeId: string | null = null, options?: UseDailyPlanOptions) {
 	const { data: user } = useUserQuery();
@@ -118,7 +190,10 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 	//  from queries to keep views in sync (Home modal, Profile tab, etc.).
 	const profileDailyPlans = useProfileDailyPlans(targetEmployeeId, { enabled });
 
-	// All day plans
+	/**
+	 * @deprecated Use `useAllDailyPlansQuery().refetch()` instead.
+	 * This wrapper adds no additional logic.
+	 */
 	const getAllDayPlans = useCallback(async () => {
 		try {
 			const res = await getAllDayPlansQuery.refetch();
@@ -133,6 +208,10 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		}
 	}, [getAllDayPlansQuery]);
 
+	/**
+	 * @deprecated Use `useAllDailyPlansQuery()` with Jotai sync if needed.
+	 * This wrapper adds no additional logic beyond syncing to legacy atom.
+	 */
 	const loadAllDayPlans = useCallback(async () => {
 		const allDayPlans = await getAllDayPlansQuery.refetch();
 
@@ -141,8 +220,10 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		}
 	}, [getAllDayPlansQuery, setDailyPlan]);
 
-	// My day plans
-
+	/**
+	 * @deprecated Use `useMyDailyPlansQuery().refetch()` instead.
+	 * This wrapper adds no additional logic.
+	 */
 	const getMyDailyPlans = useCallback(async () => {
 		try {
 			const res = await getMyDailyPlansQuery.refetch();
@@ -157,14 +238,19 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		}
 	}, [getMyDailyPlansQuery]);
 
-	// Loader function for pre-caching in init-state.tsx
-	// Does NOT update atoms - data is available via React Query cache
+	/**
+	 * @deprecated Use `useMyDailyPlansQuery()` directly.
+	 * Data is automatically cached by React Query.
+	 */
 	const loadMyDailyPlans = useCallback(async () => {
 		await getMyDailyPlans();
 		// Data is automatically available via React Query cache
 	}, [getMyDailyPlans]);
 
-	// Employee day plans
+	/**
+	 * @deprecated Use `useEmployeeDailyPlansQuery(employeeId)` instead.
+	 * This wrapper adds no additional logic.
+	 */
 	const getEmployeeDayPlans = useCallback(
 		async (newEmployeeId: string) => {
 			try {
@@ -193,8 +279,10 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		[queryClient, activeTeam?.id, setEmployeeId]
 	);
 
-	// Loader function for pre-caching in init-state.tsx
-	// Does NOT update atoms - data is available via React Query cache
+	/**
+	 * @deprecated Use `useEmployeeDailyPlansQuery(employeeId)` directly.
+	 * Data is automatically cached by React Query.
+	 */
 	const loadEmployeeDayPlans = useCallback(async () => {
 		if (targetEmployeeId) {
 			await getEmployeeDayPlans(targetEmployeeId);
@@ -218,6 +306,10 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		[getPlansByTaskQuery]
 	);
 
+	/**
+	 * @deprecated Use `useCreateDailyPlanMutation().mutateAsync(data)` instead.
+	 * This wrapper only adds `organizationTeamId` - include it in your data directly.
+	 */
 	const createDailyPlan = useCallback(
 		async (data: TCreateDailyPlan) => {
 			if (user?.tenantId) {
@@ -227,6 +319,10 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		[createDailyplanMutation, user?.tenantId, activeTeam?.id]
 	);
 
+	/**
+	 * @deprecated Use `useUpdateDailyPlanMutation().mutateAsync({ data, dailyPlanId })` instead.
+	 * This wrapper adds no additional logic.
+	 */
 	const updateDailyPlan = useCallback(
 		async (data: TUpdateDailyPlan, planId: string) => {
 			return await updateDailyPlanMutation.mutateAsync({ data, dailyPlanId: planId });
@@ -234,6 +330,10 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		[updateDailyPlanMutation]
 	);
 
+	/**
+	 * @deprecated Use `useAddTaskToPlanMutation().mutateAsync({ data, dailyPlanId })` instead.
+	 * This wrapper adds no additional logic.
+	 */
 	const addTaskToPlan = useCallback(
 		async (data: IDailyPlanTasksUpdate, planId: string) => {
 			return await addTaskToPlanMutation.mutateAsync({ data, dailyPlanId: planId });
@@ -241,6 +341,10 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		[addTaskToPlanMutation]
 	);
 
+	/**
+	 * @deprecated Use `useRemoveTaskFromPlanMutation().mutateAsync({ data, dailyPlanId })` instead.
+	 * This wrapper adds no additional logic.
+	 */
 	const removeTaskFromPlan = useCallback(
 		async (data: IDailyPlanTasksUpdate, planId: string) => {
 			return await removeTaskFromPlanMutation.mutateAsync({ data, dailyPlanId: planId });
@@ -248,6 +352,10 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		[removeTaskFromPlanMutation]
 	);
 
+	/**
+	 * @deprecated Use `useRemoveTaskFromManyPlansMutation().mutateAsync({ data, taskId })` instead.
+	 * This wrapper adds no additional logic.
+	 */
 	const removeManyTaskPlans = useCallback(
 		async (data: IRemoveTaskFromManyPlansRequest, taskId: string) => {
 			return await removeTaskPlansMutation.mutateAsync({ data, taskId });
@@ -255,6 +363,10 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		[removeTaskPlansMutation]
 	);
 
+	/**
+	 * @deprecated Use `useDeleteDailyPlanMutation().mutateAsync(planId)` instead.
+	 * This wrapper adds no additional logic.
+	 */
 	const deleteDailyPlan = useCallback(
 		async (planId: string) => {
 			return await deleteDailyPlanMutation.mutateAsync(planId);
@@ -262,22 +374,46 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 		[deleteDailyPlanMutation]
 	);
 
+	/**
+	 * Plans scheduled for future dates.
+	 * @deprecated Use `useFuturePlans(employeeId)` directly.
+	 */
 	const futurePlans = useFuturePlans(targetEmployeeId, { enabled });
 
-	// NOTE: Replacement for pastPlansState atom; exposes strictly past plans
-	// for Outstanding and history-related views.
+	/**
+	 * NOTE: Replacement for pastPlansState atom; exposes strictly past plans
+	 * for Outstanding and history-related views.
+	 * Plans from past dates.
+	 * @deprecated Use `usePastPlans(employeeId)` directly.
+	 */
 	const pastPlans = usePastPlans(targetEmployeeId, { enabled });
 
+	/**
+	 * Today's plan for the employee.
+	 * @deprecated Use `useTodayPlan(employeeId)` directly.
+	 */
 	const todayPlan = useTodayPlan(targetEmployeeId, { enabled });
 
-	// NOTE: Replacement for outstandingPlansState atom; keeps "outstanding"
-	// logic close to daily-plan queries instead of global Jotai stores.
+	/**
+	 * NOTE: Replacement for outstandingPlansState atom; keeps "outstanding"
+	 *logic close to daily-plan queries instead of global Jotai stores.
+	 * Plans with incomplete tasks past their due date.
+	 * @deprecated Use `useOutstandingPlans(employeeId)` directly.
+	 */
 	const outstandingPlans = useOutstandingPlans(targetEmployeeId, { enabled });
 
-	// NOTE: Replacement for sortedPlansState atom; generic sorted list
-	// used by multiple views (tabs, filters, etc.).
+	/**
+	 * NOTE: Replacement for sortedPlansState atom; generic sorted list
+	 * used by multiple views (tabs, filters, etc.).
+	 * Plans sorted by date.
+	 * @deprecated Use `useSortedPlan(employeeId)` directly.
+	 */
 	const sortedPlans = useSortedPlan(targetEmployeeId, { enabled });
 
+	/**
+	 * @deprecated Queries are now automatically managed by React Query.
+	 * Use individual query hooks with `enabled` option for conditional fetching.
+	 */
 	const handleFirstLoad = useCallback(async () => {
 		await loadAllDayPlans();
 		//  Data is automatically loaded by React Query - no need to manually load
@@ -285,62 +421,184 @@ export function useDailyPlan(defaultEmployeeId: string | null = null, options?: 
 	}, [firstLoadDailyPlanData, loadAllDayPlans]);
 
 	return {
-		//  TEAM-WIDE data (kept for backward compatibility)
+		/**
+		 * Legacy Jotai State (backward compatibility)
+		 *  @deprecated Use `useAtom(dailyPlanListState)` directly
+		 */
 		dailyPlan,
+		/**
+		 * @deprecated Use `useAtom(dailyPlanListState)[1]` directly.
+		 */
 		setDailyPlan,
 
-		//  LOCAL data (calculated from React Query)
+		/**
+		 * Current employee's daily plans.
+		 * @deprecated Use `useProfileDailyPlans(employeeId)` directly.
+		 */
 		profileDailyPlans,
 
-		//  BACKWARD COMPATIBILITY - Alias for components still using myDailyPlans
+		/**
+		 * Alias for profileDailyPlans.
+		 * @deprecated Use `useProfileDailyPlans()` directly.
+		 */
 		myDailyPlans: profileDailyPlans,
 
-		//  EMPLOYEE-SPECIFIC data (from React Query, not atoms)
+		/**
+		 * Raw employee plans from query.
+		 * @deprecated Use `useEmployeeDailyPlansQuery(employeeId).data?.items` directly.
+		 */
 		employeePlans: getDayPlansByEmployeeQuery.data?.items ?? [],
 
 		//  Queries
+		/**
+		 * Fetches all team daily plans.
+		 * @deprecated Use `useAllDailyPlansQuery().refetch()` directly.
+		 */
 		getAllDayPlans,
+		/**
+		 * @deprecated Use `useAllDailyPlansQuery().isLoading` directly.
+		 */
 		getAllDayPlansLoading: getAllDayPlansQuery.isLoading,
 
+		/**
+		 * Fetches current user's daily plans.
+		 * @deprecated Use `useMyDailyPlansQuery().refetch()` directly.
+		 */
 		getMyDailyPlans,
+		/**
+		 * @deprecated Use `useMyDailyPlansQuery().isLoading` directly.
+		 */
 		getMyDailyPlansLoading: getMyDailyPlansQuery.isLoading,
 
+		/**
+		 * Fetches daily plans for a specific employee.
+		 * @deprecated Use `useEmployeeDailyPlansQuery(employeeId)` directly.
+		 */
 		getEmployeeDayPlans,
+		/**
+		 * @deprecated Use `useEmployeeDailyPlansQuery().isLoading` directly.
+		 */
 		getDayPlansByEmployeeLoading: getDayPlansByEmployeeQuery.isLoading,
 
+		/**
+		 * Fetches plans containing a specific task.
+		 * @deprecated Use `usePlansByTaskLazyQuery().getPlansByTaskId(taskId)` directly.
+		 */
 		getPlansByTask,
+		/**
+		 * @deprecated Use `usePlansByTaskLazyQuery().isLoading` directly.
+		 */
 		getPlansByTaskLoading: getPlansByTaskQueryLoading,
 
 		//  Mutations
+		/**
+		 * Creates a new daily plan.
+		 * @deprecated Use `useCreateDailyPlanMutation().mutateAsync(data)` directly.
+		 */
 		createDailyPlan,
+		/**
+		 * @deprecated Use `useCreateDailyPlanMutation().isPending` directly.
+		 */
 		createDailyPlanLoading: createDailyplanMutation.isPending,
 
+		/**
+		 * Updates an existing daily plan.
+		 * @deprecated Use `useUpdateDailyPlanMutation().mutateAsync({ data, dailyPlanId })` directly.
+		 */
 		updateDailyPlan,
+		/**
+		 * @deprecated Use `useUpdateDailyPlanMutation().isPending` directly.
+		 */
 		updateDailyPlanLoading: updateDailyPlanMutation.isPending,
 
+		/**
+		 * Adds a task to a daily plan.
+		 * @deprecated Use `useAddTaskToPlanMutation().mutateAsync({ data, dailyPlanId })` directly.
+		 */
 		addTaskToPlan,
+		/**
+		 * @deprecated Use `useAddTaskToPlanMutation().isPending` directly.
+		 */
 		addTaskToPlanLoading: addTaskToPlanMutation.isPending,
 
+		/**
+		 * Removes a task from a daily plan.
+		 * @deprecated Use `useRemoveTaskFromPlanMutation().mutateAsync({ data, dailyPlanId })` directly.
+		 */
 		removeTaskFromPlan,
+		/**
+		 * @deprecated Use `useRemoveTaskFromPlanMutation().isPending` directly.
+		 */
 		removeTaskFromPlanLoading: removeTaskFromPlanMutation.isPending,
 
+		/**
+		 * Removes a task from multiple daily plans.
+		 * @deprecated Use `useRemoveTaskFromManyPlansMutation().mutateAsync({ data, taskId })` directly.
+		 */
 		removeManyTaskPlans,
+		/**
+		 * @deprecated Use `useRemoveTaskFromManyPlansMutation().isPending` directly.
+		 */
 		removeManyTaskFromPlanLoading: removeTaskPlansMutation.isPending,
 
+		/**
+		 * Deletes a daily plan.
+		 * @deprecated Use `useDeleteDailyPlanMutation().mutateAsync(planId)` directly.
+		 */
 		deleteDailyPlan,
+		/**
+		 * @deprecated Use `useDeleteDailyPlanMutation().isPending` directly.
+		 */
 		deleteDailyPlanLoading: deleteDailyPlanMutation.isPending,
 
 		//  DERIVED VALUES (calculated locally with useMemo)
+		/**
+		 * Plans scheduled for future dates.
+		 * @deprecated Use `useFuturePlans(employeeId)` directly.
+		 */
 		futurePlans,
+		/**
+		 * Plans from past dates.
+		 * @deprecated Use `usePastPlans(employeeId)` directly.
+		 */
 		pastPlans,
+		/**
+		 * Plans with incomplete tasks past their due date.
+		 * @deprecated Use `useOutstandingPlans(employeeId)` directly.
+		 */
 		outstandingPlans,
+		/**
+		 * Today's plan for the employee.
+		 * @deprecated Use `useTodayPlan(employeeId)` directly.
+		 */
 		todayPlan,
+		/**
+		 * Plans sorted by date.
+		 * @deprecated Use `useSortedPlan(employeeId)` directly.
+		 */
 		sortedPlans,
 
 		//  Loaders (for pre-caching in init-state.tsx)
+
+		/**
+		 * Pre-loads all team plans into cache.
+		 * @deprecated Queries are auto-managed by React Query. Use `useAllDailyPlansQuery()` with `enabled` option.
+		 */
 		loadAllDayPlans,
+		/**
+		 * Pre-loads current user's plans into cache.
+		 * @deprecated Queries are auto-managed by React Query. Use `useMyDailyPlansQuery()` with `enabled` option.
+		 */
 		loadMyDailyPlans,
+		/**
+		 * Pre-loads specific employee's plans into cache.
+		 * @deprecated Queries are auto-managed by React Query. Use `useEmployeeDailyPlansQuery(employeeId)` with `enabled` option.
+		 */
 		loadEmployeeDayPlans,
+		/**
+		 * Initializes daily plan data on first app load.
+		 * @deprecated Queries are auto-managed by React Query. Remove manual initialization.
+		 */
 		firstLoadDailyPlanData: handleFirstLoad
 	};
 }

--- a/apps/web/core/hooks/daily-plans/use-invalidate-daily-plan-data.ts
+++ b/apps/web/core/hooks/daily-plans/use-invalidate-daily-plan-data.ts
@@ -1,0 +1,22 @@
+import { queryKeys } from '@/core/query/keys';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+export const useInvalidateDailyPlanData = () => {
+	const queryClient = useQueryClient();
+
+	const invalidateDailyPlanData = useCallback(() => {
+		// Invalidate ALL task queries to ensure synchronization across all contexts
+		// Invalidate ALL daily plan queries to ensure synchronization across all contexts
+		// This includes myPlans, allPlans, byEmployee, byTask, etc.
+		// Similar to invalidateTeamTasksData() in use-team-tasks.ts
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.tasks.all
+		});
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.dailyPlans.all
+		});
+	}, [queryClient]);
+
+	return invalidateDailyPlanData;
+};

--- a/apps/web/core/hooks/organizations/teams/use-active-team-managers.ts
+++ b/apps/web/core/hooks/organizations/teams/use-active-team-managers.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useCurrentTeam } from './use-current-team';
+import { ERoleName } from '@/core/types/generics/enums/role';
+
+// const { managers: activeTeamManagers } = useActiveTeamManagers();
+export const useActiveTeamManagers = () => {
+	const activeTeam = useCurrentTeam();
+
+	const managers = useMemo(() => {
+		const members = activeTeam?.members;
+		return (
+			members?.filter(
+				(member) =>
+					member?.role?.name === ERoleName.MANAGER ||
+					member?.role?.name === ERoleName.SUPER_ADMIN ||
+					member?.role?.name === ERoleName.ADMIN
+			) || []
+		);
+	}, [activeTeam]);
+
+	return { managers };
+};

--- a/apps/web/core/hooks/organizations/teams/use-active-team.ts
+++ b/apps/web/core/hooks/organizations/teams/use-active-team.ts
@@ -1,17 +1,18 @@
 'use client';
 
-import { useCallback } from 'react';
 import { TeamItem } from '@/core/components/teams/team-item';
 import { useTranslations } from 'next-intl';
-import { useOrganizationTeams } from './use-organization-teams';
-import { useTimer } from '../../activities';
+import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
-import { useAtomValue } from 'jotai';
-import { activeTeamState } from '@/core/stores';
+import { useTimer } from '../../activities';
+import { useSetActiveTeam } from './use-set-active-team';
+import { useGetOrganizationTeamQuery } from './use-get-organization-teams-query';
 
 export const useActiveTeam = () => {
-	const activeTeam = useAtomValue(activeTeamState);
-	const { setActiveTeam } = useOrganizationTeams();
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
+
+	const setActiveTeam = useSetActiveTeam();
 	const { timerStatus, stopTimer } = useTimer();
 	const t = useTranslations();
 	const onChangeActiveTeam = useCallback(

--- a/apps/web/core/hooks/organizations/teams/use-auth-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-auth-team-tasks.ts
@@ -1,15 +1,14 @@
 import { getTotalTasks } from '@/core/components/tasks/daily-plan';
 import { useDailyPlan } from '@/core/hooks';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { tasksByTeamState } from '@/core/stores';
 import { TUser } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 import { useCurrentTeam } from './use-current-team';
+import { useSortedTasksByCreation } from './use-sorted-tasks';
 
 export function useAuthTeamTasks(user: TUser | undefined) {
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasksByCreation();
 	const { data: authenticatedUser } = useUserQuery();
 
 	const activeTeam = useCurrentTeam();

--- a/apps/web/core/hooks/organizations/teams/use-auth-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-auth-team-tasks.ts
@@ -1,17 +1,18 @@
-import { useDailyPlan } from '@/core/hooks';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
-import { useMemo } from 'react';
-import { useAtomValue } from 'jotai';
 import { getTotalTasks } from '@/core/components/tasks/daily-plan';
+import { useDailyPlan } from '@/core/hooks';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { tasksByTeamState } from '@/core/stores';
 import { TUser } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useAtomValue } from 'jotai';
+import { useMemo } from 'react';
+import { useCurrentTeam } from './use-current-team';
 
 export function useAuthTeamTasks(user: TUser | undefined) {
 	const tasks = useAtomValue(tasksByTeamState);
 	const { data: authenticatedUser } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	// Use provided user or fallback to authenticated user
 	const targetUser = user || authenticatedUser;
 	const currentMember = activeTeam?.members?.find((member) => member.employee?.userId === targetUser?.id);

--- a/apps/web/core/hooks/organizations/teams/use-auth-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-auth-team-tasks.ts
@@ -1,11 +1,11 @@
 import { getTotalTasks } from '@/core/components/tasks/daily-plan';
-import { useDailyPlan } from '@/core/hooks';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { TUser } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useMemo } from 'react';
 import { useCurrentTeam } from './use-current-team';
 import { useSortedTasksByCreation } from './use-sorted-tasks';
+import { useFuturePlans, useTodayPlan } from '../../daily-plans/derived';
 
 export function useAuthTeamTasks(user: TUser | undefined) {
 	const tasks = useSortedTasksByCreation();
@@ -16,7 +16,8 @@ export function useAuthTeamTasks(user: TUser | undefined) {
 	const targetUser = user || authenticatedUser;
 	const currentMember = activeTeam?.members?.find((member) => member.employee?.userId === targetUser?.id);
 	const employeeId = targetUser?.employee?.id ?? targetUser?.employeeId ?? currentMember?.employee?.id ?? '';
-	const { futurePlans, todayPlan } = useDailyPlan(employeeId);
+	const futurePlans = useFuturePlans(employeeId ?? undefined);
+	const todayPlan = useTodayPlan(employeeId ?? undefined);
 
 	const assignedTasks = useMemo(() => {
 		if (!targetUser) return [];

--- a/apps/web/core/hooks/organizations/teams/use-create-task.mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-create-task.mutation.ts
@@ -1,0 +1,25 @@
+import { taskService } from '@/core/services/client/api';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateTeamTasks } from './use-invalidate-team-tasks';
+
+/**
+ * Mutation hook for creating a new task.
+ * Automatically invalidates tasks and daily plans cache on success.
+ *
+ * @returns TanStack mutation object with createTask mutationFn
+ */
+export const useCreateTaskMutation = () => {
+	const invalidateTeamTasksData = useInvalidateTeamTasks();
+
+	return useMutation({
+		mutationFn: async (taskData: Parameters<typeof taskService.createTask>[0]) => {
+			return await taskService.createTask({
+				...taskData,
+				...(taskData?.description ? { description: `<p>${taskData?.description}</p>` } : {})
+			});
+		},
+		onSuccess: () => {
+			invalidateTeamTasksData();
+		}
+	});
+};

--- a/apps/web/core/hooks/organizations/teams/use-current-active-task.ts
+++ b/apps/web/core/hooks/organizations/teams/use-current-active-task.ts
@@ -1,0 +1,7 @@
+import { useGetCurrentActiveTaskQuery } from './use-get-team-task.query';
+
+export const useCurrentActiveTask = () => {
+	const { data: task, isLoading, isError } = useGetCurrentActiveTaskQuery();
+
+	return { task, isLoading, isError };
+};

--- a/apps/web/core/hooks/organizations/teams/use-current-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-current-team-tasks.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { useCurrentTeamTasksQuery } from './use-get-team-task.query';
+
+/**
+ * Hook that provides access to current team's tasks from the query cache.
+ * Returns an empty array as fallback when no data is available.
+ *
+ * @returns Object containing:
+ *  - tasks: Array of tasks for the current team
+ *  - total: Total count of tasks
+ *  - isLoading: Loading state
+ *  - isError: Error state
+ */
+export const useCurrentTeamTasks = () => {
+	const { data: teamTasksResult, isLoading, isError } = useCurrentTeamTasksQuery();
+
+	const tasks = useMemo(() => teamTasksResult?.items ?? [], [teamTasksResult]);
+	const total = useMemo(() => teamTasksResult?.total ?? 0, [teamTasksResult]);
+
+	return { tasks, total, isLoading, isError };
+};

--- a/apps/web/core/hooks/organizations/teams/use-current-team.ts
+++ b/apps/web/core/hooks/organizations/teams/use-current-team.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useGetOrganizationTeamQuery } from './use-get-organization-teams-query';
+
+export const useCurrentTeam = () => {
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
+
+	return activeTeam;
+};

--- a/apps/web/core/hooks/organizations/teams/use-current-team.ts
+++ b/apps/web/core/hooks/organizations/teams/use-current-team.ts
@@ -3,6 +3,26 @@
 import { useMemo } from 'react';
 import { useGetOrganizationTeamQuery } from './use-get-organization-teams-query';
 
+/**
+ * Retrieves the currently active team for the authenticated user.
+ *
+ * @description
+ * Extracts and memoizes the active team from `useGetOrganizationTeamQuery`.
+ * Returns `null` if no team is currently selected.
+ *
+ * @example
+ * ```tsx
+ * const activeTeam = useCurrentTeam();
+ *
+ * if (!activeTeam) return <p>No team selected</p>;
+ * return <h1>{activeTeam.name}</h1>;
+ * ```
+ *
+ * @see {@link useGetOrganizationTeamQuery} - Underlying query hook
+ * @see {@link useSetActiveTeam} - Change the active team
+ *
+ * @returns {TOrganizationTeam  | null} Active team or `null`
+ */
 export const useCurrentTeam = () => {
 	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
 	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);

--- a/apps/web/core/hooks/organizations/teams/use-delete-employee-from-tasks.mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-delete-employee-from-tasks.mutation.ts
@@ -4,9 +4,23 @@ import { useInvalidateTeamTasks } from './use-invalidate-team-tasks';
 
 /**
  * Mutation hook for removing an employee from all assigned tasks.
- * Useful when unassigning or offboarding an employee.
  *
- * @returns TanStack mutation object with deleteEmployeeFromTasks mutationFn
+ * @description
+ * Useful when unassigning an employee.
+ * Automatically invalidates team tasks cache on success.
+ *
+ * @example
+ * ```tsx
+ * const { mutate: removeEmployee } = useDeleteEmployeeFromTasksMutation();
+ *
+ * const handleUnassigning = (employeeId: string) => {
+ *   removeEmployee(employeeId);
+ * };
+ * ```
+ *
+ * @see {@link useInvalidateTeamTasks} - Cache invalidation utility
+ *
+ * @returns TanStack mutation object
  */
 export const useDeleteEmployeeFromTasksMutation = () => {
 	const invalidateTeamTasksData = useInvalidateTeamTasks();

--- a/apps/web/core/hooks/organizations/teams/use-delete-employee-from-tasks.mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-delete-employee-from-tasks.mutation.ts
@@ -1,0 +1,22 @@
+import { taskService } from '@/core/services/client/api';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateTeamTasks } from './use-invalidate-team-tasks';
+
+/**
+ * Mutation hook for removing an employee from all assigned tasks.
+ * Useful when unassigning or offboarding an employee.
+ *
+ * @returns TanStack mutation object with deleteEmployeeFromTasks mutationFn
+ */
+export const useDeleteEmployeeFromTasksMutation = () => {
+	const invalidateTeamTasksData = useInvalidateTeamTasks();
+
+	const mutation = useMutation({
+		mutationFn: async (employeeId: string) => {
+			return await taskService.deleteEmployeeFromTasks(employeeId);
+		},
+		onSuccess: invalidateTeamTasksData
+	});
+
+	return mutation;
+};

--- a/apps/web/core/hooks/organizations/teams/use-delete-organization-team-mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-delete-organization-team-mutation.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamService } from '@/core/services/client/api/organizations/teams';
+import { ZodValidationError } from '@/core/types/schemas/utils/validation';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+import { useAuthenticateUser } from '../../auth';
+
+export const useDeleteOrganizationTeamMutation = () => {
+	const queryClient = useQueryClient();
+
+	const { logOut } = useAuthenticateUser();
+
+	const deleteOrganizationTeamTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+	const clearDeleteTimeout = useCallback(() => {
+		if (deleteOrganizationTeamTimeoutRef.current) {
+			clearTimeout(deleteOrganizationTeamTimeoutRef.current);
+			deleteOrganizationTeamTimeoutRef.current = null;
+		}
+	}, []);
+
+	useEffect(() => {
+		return () => clearDeleteTimeout();
+	}, [clearDeleteTimeout]);
+
+	return useMutation({
+		mutationFn: (id: string) => {
+			return organizationTeamService.deleteOrganizationTeam(id);
+		},
+		mutationKey: queryKeys.organizationTeams.mutations.delete(null),
+		onSuccess: async (response) => {
+			// Preserve critical side-effect - loadTeamsData() for complete refetch
+			toast.success('Team deleted successfully', {
+				description: `Team "${response.data.name}" has been deleted. You will be logged out of the application to choose a new workspace.`
+			});
+
+			// Clear previous timeout if any
+			clearDeleteTimeout();
+
+			// Set a new timeout
+			deleteOrganizationTeamTimeoutRef.current = setTimeout(() => {
+				logOut();
+
+				queryClient.invalidateQueries({
+					queryKey: queryKeys.organizationTeams.all
+				});
+
+				// Clear ref after execution
+				deleteOrganizationTeamTimeoutRef.current = null;
+			}, 3000);
+		},
+		onError: (error) => {
+			// Enhanced error handling
+			if (error instanceof ZodValidationError) {
+				toast.error('Delete team validation failed', {
+					description: JSON.stringify({
+						message: error.message,
+						issues: error.issues
+					})
+				});
+				console.error('Delete team validation failed:', {
+					message: error.message,
+					issues: error.issues
+				});
+				return;
+			}
+			toast.error('Delete team validation failed');
+			// Original error will be thrown and handled by calling code
+		}
+	});
+};

--- a/apps/web/core/hooks/organizations/teams/use-delete-task.mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-delete-task.mutation.ts
@@ -1,0 +1,22 @@
+import { taskService } from '@/core/services/client/api';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateTeamTasks } from './use-invalidate-team-tasks';
+
+/**
+ * Hook providing a mutation to delete a task by its ID.
+ * Automatically invalidates team tasks and daily plans queries on success.
+ *
+ * @returns TanStack mutation object for task deletion
+ *
+ * @example
+ * const { mutate: deleteTask, isPending } = useDeleteTaskMutation();
+ * deleteTask('task-123');
+ */
+export const useDeleteTaskMutation = () => {
+	const invalidateTeamTasksData = useInvalidateTeamTasks();
+
+	return useMutation({
+		mutationFn: (taskId: string) => taskService.deleteTask(taskId),
+		onSuccess: invalidateTeamTasksData
+	});
+};

--- a/apps/web/core/hooks/organizations/teams/use-edit-organization-team-mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-edit-organization-team-mutation.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamService } from '@/core/services/client/api/organizations/teams';
+import { organizationTeamsState } from '@/core/stores';
+import { TOrganizationTeamUpdate } from '@/core/types/schemas';
+import { ZodValidationError } from '@/core/types/schemas/utils/validation';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+import { toast } from 'sonner';
+import { useGetOrganizationTeamById } from './use-get-organization-teams-query';
+
+export const useEditOrganizationTeamMutation = () => {
+	const queryClient = useQueryClient();
+	const setTeams = useSetAtom(organizationTeamsState);
+
+	const getTeamById = useGetOrganizationTeamById();
+
+	return useMutation({
+		mutationFn: (data: Partial<TOrganizationTeamUpdate>) => {
+			return organizationTeamService.editOrganizationTeam(data);
+		},
+		mutationKey: queryKeys.organizationTeams.mutations.edit(null),
+		onSuccess: async (response) => {
+			const { data: teamUpdated } = await getTeamById(response.data.id);
+			setTeams((currentTeams) => {
+				return (currentTeams ?? []).map((old) => (old.id == teamUpdated.id ? teamUpdated : old));
+			});
+
+			// Invalidate queries for cache consistency
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.organizationTeams.all
+			});
+		},
+		onError: (error) => {
+			// Enhanced error handling
+			if (error instanceof ZodValidationError) {
+				toast.error('Edit team validation failed:', {
+					description: JSON.stringify({
+						message: error.message,
+						issues: error.issues
+					})
+				});
+				console.error('Edit team validation failed:', {
+					message: error.message,
+					issues: error.issues
+				});
+				return;
+			}
+			toast.error('Edit team validation failed');
+			// Original error will be thrown and handled by calling code
+		}
+	});
+};

--- a/apps/web/core/hooks/organizations/teams/use-edit-organization-team-mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-edit-organization-team-mutation.ts
@@ -10,6 +10,29 @@ import { useSetAtom } from 'jotai';
 import { toast } from 'sonner';
 import { useGetOrganizationTeamById } from './use-get-organization-teams-query';
 
+/**
+ * Mutation hook for editing an organization team.
+ *
+ * @description
+ * Updates team data via API, refreshes Jotai state with full team details,
+ * and invalidates React Query cache. Handles Zod validation errors with toast notifications.
+ *
+ * @example
+ * ```tsx
+ * const { mutate: editTeam, isPending } = useEditOrganizationTeamMutation();
+ *
+ * const handleSubmit = (data: Partial<TOrganizationTeamUpdate>) => {
+ *   editTeam(data, {
+ *     onSuccess: () => toast.success('Team updated!')
+ *   });
+ * };
+ * ```
+ *
+ * @see {@link useGetOrganizationTeamById} - Fetches updated team details
+ * @see {@link organizationTeamsState} - Jotai state updated on success
+ *
+ * @returns TanStack mutation object
+ */
 export const useEditOrganizationTeamMutation = () => {
 	const queryClient = useQueryClient();
 	const setTeams = useSetAtom(organizationTeamsState);

--- a/apps/web/core/hooks/organizations/teams/use-get-organization-teams-query.ts
+++ b/apps/web/core/hooks/organizations/teams/use-get-organization-teams-query.ts
@@ -27,7 +27,7 @@ const buildTeamListSignature = (teams: TOrganizationTeam[]) => {
 			const memberRolesSignature = t.members?.map((m) => `${m.id}:${m.role?.name ?? 'none'}`).join(',') || '';
 			return `${t.id}:${t.updatedAt ?? ''}:${t.name}:${t.shareProfileView ?? ''}:${t.requirePlanToTrack ?? ''}:${t.public ?? ''}:${t.color ?? ''}:${t.emoji ?? ''}:${t.prefix ?? ''}:${t.members?.length ?? 0}:${memberRolesSignature}`;
 		})
-		.sort()
+		.sort((a, b) => a.localeCompare(b))
 		.join('|');
 };
 

--- a/apps/web/core/hooks/organizations/teams/use-get-organization-teams-query.ts
+++ b/apps/web/core/hooks/organizations/teams/use-get-organization-teams-query.ts
@@ -1,0 +1,144 @@
+'use client';
+import { setActiveProjectIdCookie } from '@/core/lib/helpers/cookies';
+
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamService } from '@/core/services/client/api/organizations/teams';
+import {
+	activeTeamIdState,
+	isTeamMemberJustDeletedState,
+	isTeamMemberState,
+	organizationTeamsState
+} from '@/core/stores';
+import { TOrganizationTeam } from '@/core/types/schemas';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useEffect } from 'react';
+
+const buildTeamListSignature = (teams: TOrganizationTeam[]) => {
+	// CRITICAL FIX: Create a signature based on ALL mutable fields
+	// This ensures we detect changes in team properties even when members are undefined
+	// Includes: id, updatedAt, name, settings (shareProfileView, requirePlanToTrack, public),
+	// visual properties (color, emoji, prefix), members count, AND member roles
+	// NOTE: Including member roles is essential to detect when roles are loaded/changed
+	return teams
+		.map((t) => {
+			// Include member role information to detect role changes
+			const memberRolesSignature = t.members?.map((m) => `${m.id}:${m.role?.name ?? 'none'}`).join(',') || '';
+			return `${t.id}:${t.updatedAt ?? ''}:${t.name}:${t.shareProfileView ?? ''}:${t.requirePlanToTrack ?? ''}:${t.public ?? ''}:${t.color ?? ''}:${t.emoji ?? ''}:${t.prefix ?? ''}:${t.members?.length ?? 0}:${memberRolesSignature}`;
+		})
+		.sort()
+		.join('|');
+};
+
+export const useGetOrganizationTeamsQuery = () => {
+	const { data: user } = useUserQuery();
+
+	const setTeams = useSetAtom(organizationTeamsState);
+	const setIsTeamMemberJustDeleted = useSetAtom(isTeamMemberJustDeletedState);
+	const setIsTeamMember = useSetAtom(isTeamMemberState);
+
+	const teamsQuery = useQuery({
+		queryKey: queryKeys.organizationTeams.all,
+		queryFn: async () => {
+			return await organizationTeamService.getOrganizationTeams();
+		},
+		enabled: !!(user?.employee?.organizationId && user?.employee?.tenantId),
+		staleTime: 1000 * 60 * 10, // PERFORMANCE FIX: Increased to 10 minutes to reduce refetching
+		gcTime: 1000 * 60 * 30, // PERFORMANCE FIX: Increased to 30 minutes
+		refetchOnWindowFocus: false, // PERFORMANCE FIX: Disable aggressive refetching
+		refetchOnReconnect: false // PERFORMANCE FIX: Disable aggressive refetching
+	});
+
+	// ===== SYNCHRONIZATION WITH JOTAI (Backward Compatibility) =====
+	// Sync organization teams data with Jotai state
+	useEffect(() => {
+		if (teamsQuery.data?.data?.items) {
+			setTeams((currentTeams) => {
+				const currentSignature = buildTeamListSignature(currentTeams);
+				const updatedSignature = buildTeamListSignature(teamsQuery.data.data.items);
+
+				return currentSignature == updatedSignature ? currentTeams : teamsQuery.data.data.items;
+			});
+
+			// Handle case where user might be removed from all teams
+			if (teamsQuery.data?.data?.items.length === 0) {
+				setIsTeamMember(false);
+				setIsTeamMemberJustDeleted(true);
+			}
+		}
+		// NOTE: Do NOT include teamsQuery.data in dependencies
+		// It causes infinite loops because React Query returns new references
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [teamsQuery.dataUpdatedAt, setTeams, setIsTeamMemberJustDeleted, setIsTeamMember]);
+
+	return teamsQuery;
+};
+
+export const useGetOrganizationTeamQuery = () => {
+	const { data: user } = useUserQuery();
+
+	const activeTeamId = useAtomValue(activeTeamIdState);
+	const setTeams = useSetAtom(organizationTeamsState);
+
+	const teamQuery = useQuery({
+		queryKey: queryKeys.organizationTeams.detail(activeTeamId),
+		queryFn: async () => {
+			if (!activeTeamId) {
+				throw new Error('Team ID is required');
+			}
+			return await organizationTeamService.getOrganizationTeam(activeTeamId);
+		},
+		enabled: !!(activeTeamId && user?.employee?.organizationId && user?.employee?.tenantId),
+		staleTime: 1000 * 60 * 10, // PERFORMANCE FIX: Increased to 10 minutes
+		gcTime: 1000 * 60 * 30, // PERFORMANCE FIX: Increased to 30 minutes
+		refetchOnWindowFocus: false, // PERFORMANCE FIX: Disable aggressive refetching
+		refetchOnReconnect: false // PERFORMANCE FIX: Disable aggressive refetching
+	});
+
+	// ===== SYNCHRONIZATION WITH JOTAI (Backward Compatibility) =====
+	// Sync specific team data with Jotai state
+	useEffect(() => {
+		if (teamQuery.data?.data) {
+			setTeams((currentTeams) => {
+				const targetedTeam = currentTeams.find((team) => team?.id == teamQuery.data.data?.id);
+				if (!targetedTeam) return [...currentTeams, teamQuery.data?.data];
+
+				const currentSignature = buildTeamListSignature([targetedTeam]);
+				const updatedSignature = buildTeamListSignature([teamQuery.data.data]);
+
+				const updatedTeamList =
+					currentSignature == updatedSignature
+						? currentTeams
+						: currentTeams.map((team) => (team.id == targetedTeam.id ? teamQuery.data.data : team));
+
+				return updatedTeamList;
+			});
+
+			// Set Project Id to cookie
+			if (teamQuery.data?.data?.projects?.length) {
+				setActiveProjectIdCookie(teamQuery.data.data.projects[0].id);
+			}
+		}
+		// NOTE: Do NOT include organizationTeamQuery.data in dependencies
+		// It causes infinite loops because React Query returns new references
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [teamQuery.dataUpdatedAt]);
+
+	return teamQuery;
+};
+
+export const useGetOrganizationTeamById = () => {
+	const queryClient = useQueryClient();
+
+	const query = async (teamId: string) => {
+		return queryClient.fetchQuery({
+			queryKey: queryKeys.organizationTeams.detail(teamId),
+			queryFn: () => organizationTeamService.getOrganizationTeam(teamId),
+			staleTime: 1000 * 60 * 1,
+			gcTime: 1000 * 60 * 30 // PERFORMANCE FIX: Increased to 30 minutes
+		});
+	};
+
+	return query;
+};

--- a/apps/web/core/hooks/organizations/teams/use-get-task-by-employee-id.query.ts
+++ b/apps/web/core/hooks/organizations/teams/use-get-task-by-employee-id.query.ts
@@ -1,0 +1,67 @@
+import { queryKeys } from '@/core/query/keys';
+import { taskService } from '@/core/services/client/api';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCurrentTeam } from './use-current-team';
+import { useMemo, useState } from 'react';
+
+/**
+ * Query hook to fetch tasks assigned to a specific employee.
+ * Automatically refetches when employeeId or activeTeam changes.
+ *
+ * @param employeeId - The employee's unique identifier
+ * @returns TanStack query object with employee's tasks data
+ */
+export const useGetTasksByEmployeeIdQuery = (employeeId: string) => {
+	const activeTeam = useCurrentTeam();
+
+	const query = useQuery({
+		queryKey: queryKeys.tasks.byEmployee(employeeId, activeTeam?.id),
+		queryFn: async () => {
+			if (!activeTeam?.id) throw new Error('Required parameters missing');
+
+			return await taskService.getTasksByEmployeeId({ employeeId });
+		},
+		gcTime: 1000 * 60 * 60
+	});
+
+	return query;
+};
+
+/**
+ * Lazy query hook for on-demand employee tasks fetching.
+ * Returns a callable function instead of auto-fetching.
+ *
+ * @returns Function that fetches tasks when invoked with employeeId
+ */
+export const useGetTasksByEmployeeIdQueryLazy = () => {
+	const queryClient = useQueryClient();
+	const activeTeam = useCurrentTeam();
+
+	const [queryKey, setQueryKey] = useState<ReturnType<typeof queryKeys.tasks.byEmployee> | null>(null);
+	const state = queryClient.getQueryState(queryKey ?? ['_none']);
+
+	const status = useMemo(
+		() => ({
+			isError: state?.status == 'error',
+			isPending: state?.status == 'pending',
+			isSuccess: state?.status == 'success',
+			isLoading: state?.status == 'pending' && state?.fetchStatus == 'fetching'
+		}),
+		[state?.status, state?.fetchStatus]
+	);
+
+	const getTasksByEmployeeIdQuery = (employeeId: string) => {
+		return queryClient.fetchQuery({
+			queryKey: queryKeys.tasks.byEmployee(employeeId, activeTeam?.id),
+			queryFn: async ({ queryKey }) => {
+				setQueryKey(queryKey);
+				if (!activeTeam?.id) throw new Error('Required parameters missing');
+
+				return await taskService.getTasksByEmployeeId({ employeeId });
+			},
+			gcTime: 1000 * 60 * 60
+		});
+	};
+
+	return { getTasksByEmployeeIdQuery, ...state, ...status };
+};

--- a/apps/web/core/hooks/organizations/teams/use-get-team-task.query.ts
+++ b/apps/web/core/hooks/organizations/teams/use-get-team-task.query.ts
@@ -1,0 +1,116 @@
+import { activeTeamTaskId } from '@/core/stores';
+import { queryKeys } from '@/core/query/keys';
+import { taskService } from '@/core/services/client/api';
+import { useAtomValue } from 'jotai';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCurrentTeam } from './use-current-team';
+import { useMemo, useState } from 'react';
+
+/** Default garbage collection time for task queries (1 hour) */
+const TASK_QUERY_GC_TIME = 1000 * 60 * 60;
+
+/**
+ * Fetches all tasks for the current team's first project.
+ *
+ * Uses the active team context to determine which project's tasks to fetch.
+ * Query is automatically disabled when no team is selected.
+ *
+ * @returns TanStack Query result with paginated task data
+ *
+ * @example
+ * const { data, isLoading, error } = useCurrentTeamTasksQuery();
+ * const tasks = data?.items ?? [];
+ */
+export const useCurrentTeamTasksQuery = () => {
+	const activeTeam = useCurrentTeam();
+
+	return useQuery({
+		queryKey: queryKeys.tasks.byTeam(activeTeam?.id),
+		queryFn: async () => {
+			if (!activeTeam?.id) {
+				throw new Error('Required parameters missing');
+			}
+
+			const projectId = activeTeam?.projects && activeTeam.projects.length > 0 ? activeTeam.projects[0].id : '';
+
+			return await taskService.getTasks({ projectId });
+		},
+		enabled: !!activeTeam?.id,
+		gcTime: TASK_QUERY_GC_TIME
+	});
+};
+
+/**
+ * Fetches the currently active task details by ID.
+ *
+ * Reads the active task ID from Jotai store and fetches full task data.
+ * Query is automatically disabled when no task is active.
+ *
+ * @returns TanStack Query result with task details
+ *
+ * @example
+ * const { data: activeTask, isLoading } = useGetCurrentActiveTaskQuery();
+ * if (activeTask) {
+ *   console.log('Working on:', activeTask.title);
+ * }
+ */
+export const useGetCurrentActiveTaskQuery = () => {
+	const { id: taskId } = useAtomValue(activeTeamTaskId);
+
+	return useQuery({
+		queryKey: queryKeys.tasks.detail(taskId),
+		queryFn: async () => {
+			if (!taskId) {
+				throw new Error('Task ID is required');
+			}
+
+			return await taskService.getTaskById(taskId);
+		},
+		enabled: !!taskId,
+		gcTime: TASK_QUERY_GC_TIME
+	});
+};
+
+export const useGetTaskByIdQuery = (taskId?: string) => {
+	const query = useQuery({
+		queryKey: queryKeys.tasks.byTeam(taskId),
+		queryFn: async () => {
+			if (!taskId) throw new Error('Required parameters missing');
+			return await taskService.getTaskById(taskId);
+		},
+		enabled: !!taskId,
+		gcTime: TASK_QUERY_GC_TIME
+	});
+
+	return query;
+};
+
+export const useGetTaskByIdQueryLazy = () => {
+	const queryClient = useQueryClient();
+	const [queryKey, setQueryKey] = useState<ReturnType<typeof queryKeys.tasks.byTeam> | null>(null);
+	const state = queryClient.getQueryState(queryKey ?? ['_none']);
+
+	const status = useMemo(
+		() => ({
+			isError: state?.status == 'error',
+			isPending: state?.status == 'pending',
+			isSuccess: state?.status == 'success',
+			isLoading: state?.status == 'pending' && state?.fetchStatus == 'fetching'
+		}),
+		[state?.status, state?.fetchStatus]
+	);
+
+	const getTaskById = (taskId: string) => {
+		return queryClient.fetchQuery({
+			queryKey: queryKeys.tasks.byTeam(taskId),
+			queryFn: async ({ queryKey }) => {
+				setQueryKey(queryKey);
+				if (!taskId) throw new Error('Required parameters missing');
+				return await taskService.getTaskById(taskId);
+			},
+			gcTime: TASK_QUERY_GC_TIME
+		});
+	};
+
+	return { getTaskById, ...state, ...status };
+};

--- a/apps/web/core/hooks/organizations/teams/use-handle-status-update.ts
+++ b/apps/web/core/hooks/organizations/teams/use-handle-status-update.ts
@@ -1,0 +1,79 @@
+'use client';
+import {
+	getActiveTaskIdCookie,
+	getActiveUserTaskCookie,
+	setActiveTaskIdCookie,
+	setActiveUserTaskCookie
+} from '@/core/lib/helpers/index';
+import { ITaskStatusField } from '@/core/types/interfaces/task/task-status/task-status-field';
+import { ITaskStatusStack } from '@/core/types/interfaces/task/task-status/task-status-stack';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useCallback } from 'react';
+import { useUpdateTaskMutation } from './use-update-task.mutation';
+import { useSetActiveTask } from './use-set-active-task';
+
+/**
+ * Hook for handling task status field updates with cookie cleanup.
+ * Manages side effects when closing tasks (clears active task cookies).
+ *
+ * @returns Callback function to update any task status field
+ */
+export const useHandleStatusUpdate = () => {
+	const { mutateAsync: updateTask, ...query } = useUpdateTaskMutation();
+	const { setActiveTask } = useSetActiveTask();
+
+	/**
+	 * Updates a specific status field on a task.
+	 * Handles special logic for closing tasks (clears active task cookies).
+	 *
+	 * @template T - The status field type being updated
+	 * @param status - The new status value to set
+	 * @param field - The field name to update (e.g., 'status', 'priority')
+	 * @param taskStatusId - Optional new taskStatusId to associate
+	 * @param task - The task object to update
+	 * @param loader - Unused parameter (kept for API compatibility)
+	 * @returns Promise from updateTask mutation or undefined if no update needed
+	 */
+	const handleStatusUpdate = useCallback(
+		<T extends ITaskStatusField>(
+			status: ITaskStatusStack[T],
+			field: T,
+			taskStatusId: TTask['taskStatusId'],
+			task?: TTask | null,
+			loader?: boolean
+		) => {
+			// Skip update if task doesn't exist or status hasn't changed
+			if (task && status !== (task as any)[field]) {
+				// Special handling: clear active task cookies when closing a task
+				if (field === 'status' && status === 'closed') {
+					const active_user_task = getActiveUserTaskCookie();
+
+					// Clear user's active task cookie if it matches this task
+					if (active_user_task?.taskId === task.id) {
+						setActiveUserTaskCookie({
+							taskId: '',
+							userId: ''
+						});
+					}
+					const active_task_id = getActiveTaskIdCookie();
+
+					// Clear global active task cookie if it matches this task
+					if (active_task_id === task.id) {
+						setActiveTaskIdCookie('');
+					}
+				}
+
+				// Persist the status update via mutation
+				return updateTask({
+					taskId: task.id,
+					taskData: { ...task, taskStatusId: taskStatusId ?? task.taskStatusId, [field]: status }
+				}).then((task) => {
+					setActiveTask(task);
+					return task;
+				});
+			}
+		},
+		[updateTask]
+	);
+	return { handleStatusUpdate, ...query };
+};

--- a/apps/web/core/hooks/organizations/teams/use-invalidate-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-invalidate-team-tasks.ts
@@ -1,0 +1,30 @@
+// hooks/use-invalidate-team-tasks.ts
+import { queryKeys } from '@/core/query/keys';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { useCurrentTeam } from './use-current-team';
+
+/**
+ * Hook providing a function to invalidate all task-related queries.
+ * Useful after any task mutation to refresh UI state.
+ *
+ * @returns Memoized invalidation function
+ */
+export const useInvalidateTeamTasks = () => {
+	const queryClient = useQueryClient();
+	const activeTeam = useCurrentTeam();
+
+	const invalidateTeamTasksData = useCallback(() => {
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.tasks.all
+		});
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.tasks.byTeam(activeTeam?.id)
+		});
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.dailyPlans.all
+		});
+	}, [activeTeam?.id, queryClient]);
+
+	return invalidateTeamTasksData;
+};

--- a/apps/web/core/hooks/organizations/teams/use-is-team-manager.ts
+++ b/apps/web/core/hooks/organizations/teams/use-is-team-manager.ts
@@ -4,6 +4,25 @@ import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { useMemo } from 'react';
 import { useGetOrganizationTeamQuery } from './use-get-organization-teams-query';
 
+/**
+ * Hook to determine if the current user is a manager of the active team.
+ *
+ * @description
+ * Checks if the authenticated user has the 'MANAGER' role within the
+ * currently active organization team's members list.
+ *
+ * @example
+ * ```tsx
+ * const isManager = useIsTeamManager();
+ *
+ * return isManager ? <ManagerDashboard /> : <MemberView />;
+ * ```
+ *
+ * @see {@link useGetOrganizationTeamQuery} - Provides active team data
+ * @see {@link useUserQuery} - Provides current user data
+ *
+ * @returns `true` if user is a team manager, `false` otherwise
+ */
 export const useIsTeamManager = () => {
 	const { data: user } = useUserQuery();
 	const { data: activeTeam } = useGetOrganizationTeamQuery();

--- a/apps/web/core/hooks/organizations/teams/use-is-team-manager.ts
+++ b/apps/web/core/hooks/organizations/teams/use-is-team-manager.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useMemo } from 'react';
+import { useGetOrganizationTeamQuery } from './use-get-organization-teams-query';
+
+export const useIsTeamManager = () => {
+	const { data: user } = useUserQuery();
+	const { data: activeTeam } = useGetOrganizationTeamQuery();
+
+	const isTeamManager = useMemo(() => {
+		const members = activeTeam?.data?.members || [];
+		return members.some((member) => {
+			const $u = user;
+			const isUser = member.employee?.userId === $u?.id;
+			return isUser && member.role && member.role.name === 'MANAGER';
+		});
+	}, [user, activeTeam?.data?.members]);
+
+	return isTeamManager;
+};

--- a/apps/web/core/hooks/organizations/teams/use-load-teams-data.ts
+++ b/apps/web/core/hooks/organizations/teams/use-load-teams-data.ts
@@ -11,6 +11,32 @@ import { useSetAtom } from 'jotai';
 import { useCallback } from 'react';
 import { useSetActiveTeam } from './use-set-active-team';
 
+/**
+ * Returns an imperative function to load and initialize teams data.
+ *
+ * @description
+ * Handles the full team selection priority logic on app initialization:
+ * 1. Cookie (current session)
+ * 2. localStorage (user's last selected team)
+ * 3. User's `lastTeamId` from server
+ *
+ * Also handles edge cases where user was removed from their selected team.
+ *
+ * @example
+ * ```tsx
+ * const loadTeamsData = useLoadTeamsData();
+ *
+ * useEffect(() => {
+ *   loadTeamsData().then(() => console.log('Teams loaded'));
+ * }, [loadTeamsData]);
+ * ```
+ *
+ * @see {@link useSetActiveTeam} - Sets the active team with persistence
+ * @see {@link activeTeamIdState} - Jotai state for active team ID
+ * @see {@link isTeamMemberJustDeletedState} - Flags when user lost team access
+ *
+ * @returns Async function `() => Promise<TeamsResult | undefined>`
+ */
 export const useLoadTeamsData = () => {
 	const { data: user } = useUserQuery();
 	const setActiveTeamId = useSetAtom(activeTeamIdState);

--- a/apps/web/core/hooks/organizations/teams/use-load-teams-data.ts
+++ b/apps/web/core/hooks/organizations/teams/use-load-teams-data.ts
@@ -1,0 +1,97 @@
+'use client';
+import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
+
+import { LAST_WORKSPACE_AND_TEAM } from '@/core/constants/config/constants';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamService } from '@/core/services/client/api/organizations/teams';
+import { activeTeamIdState, isTeamMemberJustDeletedState, isTeamMemberState } from '@/core/stores';
+import { useQueryClient } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+import { useCallback } from 'react';
+import { useSetActiveTeam } from './use-set-active-team';
+
+export const useLoadTeamsData = () => {
+	const { data: user } = useUserQuery();
+	const setActiveTeamId = useSetAtom(activeTeamIdState);
+	const setIsTeamMemberJustDeleted = useSetAtom(isTeamMemberJustDeletedState);
+	const setIsTeamMember = useSetAtom(isTeamMemberState);
+	const setActiveTeam = useSetActiveTeam();
+
+	const queryClient = useQueryClient();
+
+	const loadTeamsData = useCallback(async () => {
+		if (!user?.employee?.organizationId || !user?.employee?.tenantId) {
+			return;
+		}
+
+		// TEAM SELECTION PRIORITY LOGIC
+		// 1. Try cookie first (current session)
+		let teamId = getActiveTeamIdCookie();
+
+		// 2. Fallback to localStorage (user's last selected team)
+		if (!teamId && typeof window !== 'undefined') {
+			teamId = window.localStorage.getItem(LAST_WORKSPACE_AND_TEAM) || '';
+		}
+
+		// 3. Fallback to user's last team from server
+		if (!teamId && user?.lastTeamId) {
+			teamId = user.lastTeamId;
+		}
+
+		setActiveTeamId(teamId);
+
+		try {
+			// Trigger React Query refetch for teams
+			const teamsResult = await queryClient.fetchQuery({
+				queryKey: queryKeys.organizationTeams.all,
+				queryFn: async () => {
+					return await organizationTeamService.getOrganizationTeams();
+				}
+			});
+
+			const latestTeams = teamsResult.data?.items || [];
+
+			if (latestTeams.length === 0) {
+				setIsTeamMember(false);
+				setIsTeamMemberJustDeleted(true);
+			}
+
+			// Handle case where user might be removed from selected team
+			const selectedTeamExists = latestTeams.find((team: any) => team.id === teamId);
+
+			if (!selectedTeamExists && teamId && latestTeams.length) {
+				setIsTeamMemberJustDeleted(true);
+				// Only fallback to first team if the selected team truly doesn't exist
+				setActiveTeam(latestTeams[0]);
+			} else if (!latestTeams.length) {
+				teamId = '';
+			}
+
+			// Fetch specific team details if teamId exists
+			if (teamId) {
+				await queryClient.fetchQuery({
+					queryKey: queryKeys.organizationTeams.detail(teamId),
+					queryFn: async () => {
+						return await organizationTeamService.getOrganizationTeam(teamId);
+					}
+				});
+			}
+
+			return teamsResult;
+		} catch (error) {
+			console.error('Error loading teams data:', error);
+			throw error;
+		}
+	}, [
+		queryClient,
+		user?.employee?.organizationId,
+		user?.employee?.tenantId,
+		setActiveTeamId,
+		setIsTeamMember,
+		setIsTeamMemberJustDeleted,
+		setActiveTeam
+	]);
+
+	return loadTeamsData;
+};

--- a/apps/web/core/hooks/organizations/teams/use-organisation-teams.ts
+++ b/apps/web/core/hooks/organizations/teams/use-organisation-teams.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react';
+import { useGetOrganizationTeamsQuery } from './use-get-organization-teams-query';
+
+// const { teams } = useOrganisationTeams();
+export const useOrganisationTeams = () => {
+	const { data: teamsResult } = useGetOrganizationTeamsQuery();
+	const teams = useMemo(() => teamsResult?.data?.items ?? [], [teamsResult]);
+
+	return { teams };
+};

--- a/apps/web/core/hooks/organizations/teams/use-organisation-teams.ts
+++ b/apps/web/core/hooks/organizations/teams/use-organisation-teams.ts
@@ -1,7 +1,29 @@
 import { useMemo } from 'react';
 import { useGetOrganizationTeamsQuery } from './use-get-organization-teams-query';
 
-// const { teams } = useOrganisationTeams();
+/**
+ * Simplified accessor hook for all organization teams.
+ *
+ * @description
+ * Extracts and memoizes the teams array from the query result.
+ * Provides a cleaner API for components that just need the teams list.
+ *
+ * @example
+ * ```tsx
+ * const { teams } = useOrganisationTeams();
+ *
+ * return (
+ *   <ul>
+ *     {teams.map((team) => <li key={team.id}>{team.name}</li>)}
+ *   </ul>
+ * );
+ * ```
+ *
+ * @see {@link useGetOrganizationTeamsQuery} - Underlying query hook
+ * @see {@link useCurrentTeam} - Get the active team instead
+ *
+ * @returns Object containing `teams` array (empty array if loading/error)
+ */
 export const useOrganisationTeams = () => {
 	const { data: teamsResult } = useGetOrganizationTeamsQuery();
 	const teams = useMemo(() => teamsResult?.data?.items ?? [], [teamsResult]);

--- a/apps/web/core/hooks/organizations/teams/use-organization-teams-employee.ts
+++ b/apps/web/core/hooks/organizations/teams/use-organization-teams-employee.ts
@@ -1,14 +1,14 @@
-import { useCallback } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useOrganizationTeams } from './use-organization-teams';
-import { organizationTeamEmployeeService } from '@/core/services/client/api/organizations/teams';
-import { queryKeys } from '@/core/query/keys';
-import { toast } from 'sonner';
-import { TOrganizationTeamEmployee, TOrganizationTeamEmployeeUpdate } from '@/core/types/schemas';
 import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamEmployeeService } from '@/core/services/client/api/organizations/teams';
+import { TOrganizationTeamEmployee, TOrganizationTeamEmployeeUpdate } from '@/core/types/schemas';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useLoadTeamsData } from './use-load-teams-data';
 
 export function useOrganizationEmployeeTeams() {
-	const { loadTeamsData } = useOrganizationTeams();
+	const loadTeamsData = useLoadTeamsData();
 	const queryClient = useQueryClient();
 
 	// React Query mutation for delete organization employee team

--- a/apps/web/core/hooks/organizations/teams/use-organization-teams-managers.ts
+++ b/apps/web/core/hooks/organizations/teams/use-organization-teams-managers.ts
@@ -1,8 +1,8 @@
-import { useAtomValue } from 'jotai';
 import { filterValue } from '@/core/stores/teams/all-teams';
+import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
-import { useOrganizationTeams } from './use-organization-teams';
 import { useAuthenticateUser } from '../../auth';
+import { useGetOrganizationTeamsQuery } from './use-get-organization-teams-query';
 /**
  * Provides a hook that returns the teams managed by the authenticated user, along with the ability to filter those teams based on the timer status of their members.
  *
@@ -12,7 +12,10 @@ import { useAuthenticateUser } from '../../auth';
  */
 export function useOrganizationAndTeamManagers() {
 	const { user } = useAuthenticateUser();
-	const { teams } = useOrganizationTeams();
+
+	const { data: teamsResult } = useGetOrganizationTeamsQuery();
+	const teams = useMemo(() => teamsResult?.data?.items ?? [], [teamsResult]);
+
 	const { value: filtered } = useAtomValue(filterValue);
 
 	/**

--- a/apps/web/core/hooks/organizations/teams/use-public-organization-teams.ts
+++ b/apps/web/core/hooks/organizations/teams/use-public-organization-teams.ts
@@ -1,27 +1,29 @@
+import { queryKeys } from '@/core/query/keys';
+import { publicOrganizationTeamService } from '@/core/services/client/api/organizations';
 import {
+	organizationTeamsState,
 	publicActiveTeamState,
-	activeTeamState,
 	taskLabelsListState,
 	taskPrioritiesListState,
 	taskSizesListState,
 	taskStatusesState,
-	teamTasksState,
-	organizationTeamsState
+	teamTasksState
 } from '@/core/stores';
-import isEqual from 'lodash/isEqual';
-import cloneDeep from 'lodash/cloneDeep';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useOrganizationTeams } from './use-organization-teams';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '@/core/query/keys';
-import { publicOrganizationTeamService } from '@/core/services/client/api/organizations';
+import { useAtom, useSetAtom } from 'jotai';
+import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCurrentTeam } from './use-current-team';
+import { useOrganisationTeams } from './use-organisation-teams';
+import { useGetOrganizationTeamsQuery } from './use-get-organization-teams-query';
 
 export function usePublicOrganizationTeams() {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
-	const [teams, setTeams] = useAtom(organizationTeamsState);
-	const { getOrganizationTeamsLoading } = useOrganizationTeams();
+	const [, setTeams] = useAtom(organizationTeamsState);
+	const { teams } = useOrganisationTeams();
+	const { isPending: getOrganizationTeamsLoading } = useGetOrganizationTeamsQuery();
 	const setAllTasks = useSetAtom(teamTasksState);
 	const setTaskStatuses = useSetAtom(taskStatusesState);
 	const setTaskSizes = useSetAtom(taskSizesListState);

--- a/apps/web/core/hooks/organizations/teams/use-remove-user-from-all-team-mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-remove-user-from-all-team-mutation.ts
@@ -7,6 +7,32 @@ import { toast } from 'sonner';
 import { useAuthenticateUser } from '../../auth';
 import { useLoadTeamsData } from './use-load-teams-data';
 
+/**
+ * Mutation hook to remove a user from ALL organization teams.
+ *
+ * @description
+ * Removes the specified user from every team in the organization.
+ * Handles critical auth side-effects in specific order:
+ * 1. Reload teams data
+ * 2. Refresh auth token (permissions changed)
+ * 3. Update user data from API
+ *
+ * @example
+ * ```tsx
+ * const { mutate: removeUserFromAll, isPending } = useRemoveUserFromAllTeamMutation();
+ *
+ * const handleRemoveCompletely = (userId: string) => {
+ *   removeUserFromAll(userId, {
+ *     onSuccess: () => console.log('User removed from all teams'),
+ *   });
+ * };
+ * ```
+ *
+ * @see {@link useLoadTeamsData} - Reloads teams after removal
+ * @see {@link useAuthenticateUser} - Handles auth refresh sequence
+ *
+ * @returns TanStack mutation object with `mutate(userId: string)`
+ */
 export const useRemoveUserFromAllTeamMutation = () => {
 	const queryClient = useQueryClient();
 	const { refreshUserData, refreshToken } = useAuthenticateUser();

--- a/apps/web/core/hooks/organizations/teams/use-remove-user-from-all-team-mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-remove-user-from-all-team-mutation.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { queryKeys } from '@/core/query/keys';
+import { organizationTeamService } from '@/core/services/client/api/organizations/teams';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useAuthenticateUser } from '../../auth';
+import { useLoadTeamsData } from './use-load-teams-data';
+
+export const useRemoveUserFromAllTeamMutation = () => {
+	const queryClient = useQueryClient();
+	const { refreshUserData, refreshToken } = useAuthenticateUser();
+
+	const loadTeamsData = useLoadTeamsData();
+
+	return useMutation({
+		mutationFn: (userId: string) => {
+			return organizationTeamService.removeUserFromAllTeams(userId);
+		},
+		mutationKey: queryKeys.organizationTeams.mutations.removeUser(null),
+		onSuccess: async (response) => {
+			// Service returns simple DeleteResponse, no complex validation needed
+			// Just ensure response exists
+
+			// Preserve ALL critical side-effects in exact order
+			// 1. First: Reload teams data
+			await loadTeamsData();
+
+			// 2. Then: Critical auth refresh sequence
+			try {
+				await refreshToken();
+				// 3. Finally: Update user data from API
+				refreshUserData();
+			} catch (error) {
+				toast.error('Failed to refresh token after removing user from team');
+				console.error('Failed to refresh token after removing user from team:', error);
+			}
+
+			// Invalidate queries for cache consistency
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.organizationTeams.all
+			});
+		},
+		onError: (error) => {
+			// Enhanced error handling
+			toast.error('Remove user from all teams failed', {
+				description: error.message
+			});
+			console.error('Remove user from all teams failed:', error);
+			// Original error will be thrown and handled by calling code
+		}
+	});
+};

--- a/apps/web/core/hooks/organizations/teams/use-set-active-task.ts
+++ b/apps/web/core/hooks/organizations/teams/use-set-active-task.ts
@@ -1,0 +1,151 @@
+import { setActiveTaskIdCookie, setActiveUserTaskCookie } from '@/core/lib/helpers/cookies';
+import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { activeTeamTaskId, memberActiveTaskIdState } from '@/core/stores';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import { useUserQuery } from '../../queries/user-user.query';
+import { useCurrentTeam } from './use-current-team';
+import { useOrganizationEmployeeTeams } from './use-organization-teams-employee';
+import { useSortedTasksByCreation } from './use-sorted-tasks';
+import { useUpdateTaskMutation } from './use-update-task.mutation';
+
+/**
+ * Hook providing functionality to set the active task for the current user.
+ *
+ * Handles:
+ * - Local state updates (Jotai atom + cookies)
+ * - Server synchronization with retry logic
+ * - Optimistic UI with rollback on failure
+ * - Multi-device support via server persistence
+ *
+ * @returns Object containing setActiveTask function and pending state
+ */
+export const useSetActiveTask = () => {
+	const { updateOrganizationTeamEmployeeActiveTask } = useOrganizationEmployeeTeams();
+	const tasks = useSortedTasksByCreation();
+	const activeTeam = useCurrentTeam();
+	const memberActiveTaskId = useAtomValue(memberActiveTaskIdState);
+	const [activeTaskId, setActiveTaskId] = useAtom(activeTeamTaskId);
+
+	const { mutateAsync: updateTask } = useUpdateTaskMutation();
+	const { data: user } = useUserQuery();
+	const [isPending, setIsPending] = useState(false);
+
+	const setActiveUserTaskCookieCb = useCallback(
+		(taskId: string | null) => {
+			if (taskId && user?.id) {
+				setActiveUserTaskCookie({ taskId, userId: user?.id });
+			} else {
+				setActiveUserTaskCookie({ taskId: '', userId: '' });
+			}
+		},
+		[user]
+	);
+
+	const setActiveTask = useCallback(
+		async (task: TTask | null) => {
+			if (task?.id == activeTaskId?.id) return;
+
+			setIsPending(true);
+			try {
+				/**
+				 * Unassign previous active task
+				 */
+				if (memberActiveTaskId && user) {
+					const _task = tasks.find((t) => t.id === memberActiveTaskId);
+
+					if (_task) {
+						await updateTask({
+							taskData: {
+								..._task,
+								members: _task.members?.filter((m) => m.id !== user?.employee?.id)
+							},
+							taskId: _task?.id
+						});
+					}
+				}
+
+				if (task) {
+					/**
+					 * Sync active task to server for multi-device support.
+					 * Cookies are already set above, so local persistence works even if API fails.
+					 * Retry up to 3 times because activeTeam.members may not be loaded yet on first render.
+					 */
+					const MAX_RETRIES = 3;
+					const RETRY_DELAY_MS = 500;
+
+					try {
+						let success = false;
+
+						// Use activeTeam to get fresh values on each retry attempt.
+						// Using activeTeam directly would capture the stale closure value.
+						for (let attempt = 1; attempt <= MAX_RETRIES && !success; attempt++) {
+							const currentEmployeeDetails = activeTeam?.members?.find(
+								(member: TOrganizationTeamEmployee) => member.employeeId === user?.employee?.id
+							);
+
+							if (currentEmployeeDetails?.id) {
+								await updateOrganizationTeamEmployeeActiveTask(currentEmployeeDetails.id, {
+									organizationId: task.organizationId,
+									activeTaskId: task.id,
+									organizationTeamId: activeTeam?.id,
+									tenantId: activeTeam?.tenantId ?? ''
+								});
+								success = true;
+							} else if (attempt < MAX_RETRIES) {
+								await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+							}
+						}
+
+						if (!success) {
+							// All retries exhausted - members may not be loaded yet.
+							// Local state (cookies + Jotai) is already persisted, only server sync failed.
+							logErrorInDev(
+								'[setActiveTask] Failed to sync after retries - members may not be loaded',
+								null
+							);
+						}
+
+						if (success) {
+							toast.success('Active task updated', {
+								description: `"${task.title}" is now your active task`
+							});
+
+							// Short delay to let React Query stabilize before clearing isUpdatingActiveTask.
+							// The expectedActiveTaskIdRef provides the main protection against stale data,
+							// this delay is just an extra safety buffer for edge cases.
+							// NOTE: Do NOT invalidate queries here - updateActiveTaskMutation already handles it.
+							await new Promise((resolve) => setTimeout(resolve, 600));
+						}
+
+						setActiveTaskIdCookie(task?.id || '');
+						setActiveUserTaskCookieCb(task?.id ?? null);
+						setActiveTaskId(() => ({ id: task?.id ?? null }));
+					} catch (error) {
+						logErrorInDev('[setActiveTask] API call failed:', error);
+						toast.error('Failed to update active task', {
+							description: getErrorMessage(error)
+						});
+					}
+				}
+			} finally {
+				setIsPending(false);
+			}
+		},
+		[
+			setActiveUserTaskCookieCb,
+			updateOrganizationTeamEmployeeActiveTask,
+			activeTeam,
+			memberActiveTaskId,
+			user,
+			tasks,
+			updateTask,
+			setIsPending
+		]
+	);
+
+	return { setActiveTask, isPending };
+};

--- a/apps/web/core/hooks/organizations/teams/use-set-active-team.ts
+++ b/apps/web/core/hooks/organizations/teams/use-set-active-team.ts
@@ -9,6 +9,35 @@ import { useCallback } from 'react';
 import { useAuthenticateUser } from '../../auth';
 import { useSettings } from '../../users';
 
+/**
+ * Returns a function to set the active team with full persistence.
+ *
+ * @description
+ * Sets the active team and persists to multiple layers:
+ * - Cookies (teamId, organizationId, projectId)
+ * - localStorage (for cross-tab persistence)
+ * - Server (user's lastTeamId via API)
+ * - Jotai state (for immediate UI reactivity)
+ *
+ * Order of operations is important: state update happens LAST
+ * to ensure all persistence layers are synchronized first.
+ *
+ * @example
+ * ```tsx
+ * const setActiveTeam = useSetActiveTeam();
+ *
+ * const handleTeamSwitch = (team: TOrganizationTeam) => {
+ *   setActiveTeam(team);
+ *   router.push('/dashboard');
+ * };
+ * ```
+ *
+ * @see {@link activeTeamIdState} - Jotai state updated by this hook
+ * @see {@link useCurrentTeam} - Get the currently active team
+ * @see {@link useLoadTeamsData} - Initial team loading logic
+ *
+ * @returns Callback function `(team: TOrganizationTeam) => void`
+ */
 export const useSetActiveTeam = () => {
 	const { user } = useAuthenticateUser();
 	const setActiveTeamId = useSetAtom(activeTeamIdState);

--- a/apps/web/core/hooks/organizations/teams/use-set-active-team.ts
+++ b/apps/web/core/hooks/organizations/teams/use-set-active-team.ts
@@ -1,0 +1,41 @@
+'use client';
+import { setActiveProjectIdCookie, setActiveTeamIdCookie, setOrganizationIdCookie } from '@/core/lib/helpers/cookies';
+
+import { LAST_WORKSPACE_AND_TEAM } from '@/core/constants/config/constants';
+import { activeTeamIdState } from '@/core/stores';
+import { TOrganizationTeam } from '@/core/types/schemas';
+import { useSetAtom } from 'jotai';
+import { useCallback } from 'react';
+import { useAuthenticateUser } from '../../auth';
+import { useSettings } from '../../users';
+
+export const useSetActiveTeam = () => {
+	const { user } = useAuthenticateUser();
+	const setActiveTeamId = useSetAtom(activeTeamIdState);
+	const { updateAvatar: updateUserLastTeam } = useSettings();
+
+	const setActiveTeam = useCallback(
+		(team: TOrganizationTeam) => {
+			setActiveTeamIdCookie(team?.id);
+			setOrganizationIdCookie(team?.organizationId || '');
+
+			// Set Project Id to cookie
+			// TODO: Make it dynamic when we add Dropdown in Navbar
+			if (team && team?.projects && team.projects.length) {
+				setActiveProjectIdCookie(team.projects[0].id);
+			}
+			window && window?.localStorage.setItem(LAST_WORKSPACE_AND_TEAM, team.id);
+			// Only update user last team if it's different to avoid unnecessary API calls
+			if (user && user.lastTeamId !== team.id) {
+				updateUserLastTeam({ id: user.id, lastTeamId: team.id });
+			}
+
+			// Set active team ID AFTER teams are updated to ensure proper synchronization
+			// This must be called at the end (Update store)
+			setActiveTeamId(team?.id);
+		},
+		[setActiveTeamId, updateUserLastTeam, user]
+	);
+
+	return setActiveTeam;
+};

--- a/apps/web/core/hooks/organizations/teams/use-sorted-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-sorted-tasks.ts
@@ -1,0 +1,43 @@
+import moment from 'moment';
+import { useCurrentTeamTasks } from './use-current-team-tasks';
+import { useMemo } from 'react';
+
+type SortableTaskField = 'createdAt' | 'updatedAt' | 'dueDate';
+type SortOrder = 'asc' | 'desc';
+
+/**
+ * Hook that returns current team's tasks sorted by a specified date field.
+ *
+ * @param field - Date field to sort by (default: 'createdAt')
+ * @param order - Sort order (default: 'desc' for newest first)
+ * @returns Sorted array of tasks
+ *
+ * @example
+ * const newestFirst = useSortedTasks('createdAt', 'desc');
+ * const oldestFirst = useSortedTasks('createdAt', 'asc');
+ * const byDueDate = useSortedTasks('dueDate', 'asc');
+ */
+export const useSortedTasks = (field: SortableTaskField = 'createdAt', order: SortOrder = 'desc') => {
+	const { tasks } = useCurrentTeamTasks();
+
+	const sortedTasks = useMemo(() => {
+		const multiplier = order === 'desc' ? 1 : -1;
+
+		return [...tasks].sort((a, b) => {
+			const dateA = a[field];
+			const dateB = b[field];
+
+			// Handle null/undefined dates (push them to the end)
+			if (!dateA && !dateB) return 0;
+			if (!dateA) return 1;
+			if (!dateB) return -1;
+
+			return multiplier * moment(dateB).diff(moment(dateA));
+		});
+	}, [tasks, field, order]);
+
+	return sortedTasks;
+};
+
+// Convenience alias for backward compatibility
+export const useSortedTasksByCreation = () => useSortedTasks('createdAt', 'desc');

--- a/apps/web/core/hooks/organizations/teams/use-team-invitations.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-invitations.ts
@@ -1,27 +1,23 @@
 'use client';
 
-import {
-	fetchingTeamInvitationsState,
-	getTeamInvitationsState,
-	myInvitationsState,
-	teamInvitationsState
-} from '@/core/stores';
+import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
+import { queryKeys } from '@/core/query/keys';
+import { fetchingTeamInvitationsState, myInvitationsState, teamInvitationsState } from '@/core/stores';
+import { EInviteAction } from '@/core/types/generics/enums/invite';
+import { IInviteVerifyCode, InviteUserParams, TeamInvitationsQueryParams } from '@/core/types/interfaces/user/invite';
+import { TAcceptInvitationRequest, TValidateInviteRequest } from '@/core/types/schemas/user/invite.schema';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useSetAtom } from 'jotai';
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo } from 'react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../../common/use-first-load';
+import { toast } from 'sonner';
 import { inviteService } from '../../../services/client/api/organizations/teams/invites';
 import { useAuthenticateUser } from '../../auth';
-import { EInviteAction } from '@/core/types/generics/enums/invite';
-import { toast } from 'sonner';
-import { queryKeys } from '@/core/query/keys';
-import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
-import { IInviteVerifyCode, InviteUserParams, TeamInvitationsQueryParams } from '@/core/types/interfaces/user/invite';
 import { useQueryCall } from '../../common';
-import { TAcceptInvitationRequest, TValidateInviteRequest } from '@/core/types/schemas/user/invite.schema';
-import { useIsMemberManager } from './use-team-member';
+import { useFirstLoad } from '../../common/use-first-load';
 import { useUserQuery } from '../../queries/user-user.query';
-import { useRouter } from 'next/navigation';
+import { useIsMemberManager } from './use-team-member';
+import { useTeamMemberInvitation } from './use-team-member-invitations';
 
 export function useTeamInvitations() {
 	const queryClient = useQueryClient();
@@ -29,7 +25,7 @@ export function useTeamInvitations() {
 
 	const setTeamInvitations = useSetAtom(teamInvitationsState);
 	const [myInvitationsList, setMyInvitationsList] = useAtom(myInvitationsState);
-	const teamInvitations = useAtomValue(getTeamInvitationsState);
+	const teamInvitations = useTeamMemberInvitation();
 	const [fetchingInvitations, setFetchingInvitations] = useAtom(fetchingTeamInvitationsState);
 
 	const activeTeamId = getActiveTeamIdCookie();

--- a/apps/web/core/hooks/organizations/teams/use-team-member-card.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-member-card.ts
@@ -1,10 +1,9 @@
 'use client';
-import { activeTeamState, activeTeamTaskState, allTaskStatisticsState } from '@/core/stores';
+import { activeTeamTaskState, allTaskStatisticsState } from '@/core/stores';
 import { getPublicState } from '@/core/stores/common/public';
 import { useCallback, useMemo, useState } from 'react';
 import { useAtomValue } from 'jotai';
 import { useSyncRef } from '../../common/use-sync-ref';
-import { useOrganizationTeams } from './use-organization-teams';
 import { useIsMemberManager } from './use-team-member';
 import cloneDeep from 'lodash/cloneDeep';
 import { useTeamTasks } from './use-team-tasks';
@@ -14,6 +13,8 @@ import { Nullable } from '@/core/types/generics/utils';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { ERoleName } from '@/core/types/generics/enums/role';
+import { useUpdateOrganizationTeam } from './use-update-organization-team';
+import { useGetOrganizationTeamQuery } from './use-get-organization-teams-query';
 
 /**
  * It returns a bunch of data about a team member, including whether or not the user is the team
@@ -32,8 +33,10 @@ export function useTeamMemberCard(member: TOrganizationTeamEmployee | undefined)
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 
-	const activeTeam = useAtomValue(activeTeamState);
-	const { updateOrganizationTeam, updateOTeamLoading } = useOrganizationTeams();
+	const { data: activeTeamResult } = useGetOrganizationTeamQuery();
+	const activeTeam = useMemo(() => activeTeamResult?.data ?? null, [activeTeamResult]);
+
+	const { updateOrganizationTeam, loading: updateOTeamLoading } = useUpdateOrganizationTeam();
 
 	const activeTeamRef = useSyncRef(activeTeam);
 

--- a/apps/web/core/hooks/organizations/teams/use-team-member-invitations.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-member-invitations.ts
@@ -3,6 +3,36 @@ import { useAtomValue } from 'jotai';
 import { useCurrentTeam } from './use-current-team';
 import { useMemo } from 'react';
 
+/**
+ * Returns pending invitations excluding users already in the team.
+ *
+ * @description
+ * Filters team invitations to show only those for users who are NOT
+ * already members of the active team. Prevents showing duplicate
+ * invitations for existing members.
+ *
+ * Compares invitation emails against member employee user emails.
+ *
+ * @example
+ * ```tsx
+ * const pendingInvitations = useTeamMemberInvitation();
+ *
+ * return (
+ *   <div>
+ *     <h3>Pending Invitations ({pendingInvitations.length})</h3>
+ *     {pendingInvitations.map((invite) => (
+ *       <InvitationCard key={invite.id} invitation={invite} />
+ *     ))}
+ *   </div>
+ * );
+ * ```
+ *
+ * @see {@link teamInvitationsState} - Source atom for all invitations
+ * @see {@link useCurrentTeam} - Active team with members list
+ * @see {@link useGetTeamInvitationsQuery} - Query that populates the atom
+ *
+ * @returns Filtered array of `TInvite[]` excluding existing members
+ */
 export const useTeamMemberInvitation = () => {
 	const invitations = useAtomValue(teamInvitationsState);
 	const activeTeam = useCurrentTeam();

--- a/apps/web/core/hooks/organizations/teams/use-team-member-invitations.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-member-invitations.ts
@@ -1,0 +1,14 @@
+import { teamInvitationsState } from '@/core/stores';
+import { useAtomValue } from 'jotai';
+import { useCurrentTeam } from './use-current-team';
+import { useMemo } from 'react';
+
+export const useTeamMemberInvitation = () => {
+	const invitations = useAtomValue(teamInvitationsState);
+	const activeTeam = useCurrentTeam();
+	const members = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
+
+	return invitations.filter((invite) => {
+		return !members.find((me: any) => me?.employee?.user?.email === invite?.email);
+	});
+};

--- a/apps/web/core/hooks/organizations/teams/use-team-member.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-member.ts
@@ -1,13 +1,12 @@
 'use client';
-import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 
-import { activeTeamState } from '@/core/stores';
 import { ERoleName } from '@/core/types/generics/enums/role';
 import { TUser } from '@/core/types/schemas';
+import { useCurrentTeam } from './use-current-team';
 
 export function useIsMemberManager(user?: TUser | null) {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const activeManager = useMemo(() => {
 		if (!user || !activeTeam?.members) return undefined;

--- a/apps/web/core/hooks/organizations/teams/use-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-tasks.ts
@@ -1,39 +1,39 @@
 'use client';
 /* eslint-disable no-mixed-spaces-and-tabs */
+import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
 import {
 	getActiveTaskIdCookie,
 	getActiveUserTaskCookie,
 	setActiveTaskIdCookie,
 	setActiveUserTaskCookie
 } from '@/core/lib/helpers/index';
-import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { queryKeys } from '@/core/query/keys';
 import { taskService } from '@/core/services/client/api';
 import {
-	activeTeamState,
 	activeTeamTaskId,
+	activeTeamTaskState,
 	detailedTaskState,
 	memberActiveTaskIdState,
-	activeTeamTaskState,
 	tasksByTeamState,
-	teamTasksState,
-	taskStatusesState
+	taskStatusesState,
+	teamTasksState
 } from '@/core/stores';
-import isEqual from 'lodash/isEqual';
-import { useCallback, useRef, useState } from 'react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useOrganizationEmployeeTeams } from './use-organization-teams-employee';
-import { useAuthenticateUser } from '../../auth';
-import { useFirstLoad, useConditionalUpdateEffect, useSyncRef, useQueryCall } from '../../common';
+import { EIssueType, ETaskPriority, ETaskSize } from '@/core/types/generics/enums/task';
+import { PaginationResponse } from '@/core/types/interfaces/common/data-response';
 import { ITaskStatusField } from '@/core/types/interfaces/task/task-status/task-status-field';
 import { ITaskStatusStack } from '@/core/types/interfaces/task/task-status/task-status-stack';
 import { ETaskStatusName, TEmployee, TOrganizationTeamEmployee, TTag } from '@/core/types/schemas';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '@/core/query/keys';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { PaginationResponse } from '@/core/types/interfaces/common/data-response';
-import { useUserQuery } from '../../queries/user-user.query';
-import { EIssueType, ETaskPriority, ETaskSize } from '@/core/types/generics/enums/task';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import isEqual from 'lodash/isEqual';
+import { useCallback, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { useAuthenticateUser } from '../../auth';
+import { useConditionalUpdateEffect, useFirstLoad, useQueryCall, useSyncRef } from '../../common';
+import { useUserQuery } from '../../queries/user-user.query';
+import { useOrganizationEmployeeTeams } from './use-organization-teams-employee';
+import { useCurrentTeam } from './use-current-team';
 
 /**
  * A React hook that provides functionality for managing team tasks, including creating, updating, deleting, and fetching tasks.
@@ -83,7 +83,7 @@ export function useTeamTasks() {
 	const memberActiveTaskId = useAtomValue(memberActiveTaskIdState);
 	const $memberActiveTaskId = useSyncRef(memberActiveTaskId);
 	const taskStatuses = useAtomValue(taskStatusesState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const activeTeamRef = useSyncRef(activeTeam);
 	const [selectedEmployeeId, setSelectedEmployeeId] = useState(user?.employee?.id);
 	const [selectedOrganizationTeamId, setSelectedOrganizationTeamId] = useState(activeTeam?.id);

--- a/apps/web/core/hooks/organizations/teams/use-teams-state.ts
+++ b/apps/web/core/hooks/organizations/teams/use-teams-state.ts
@@ -1,10 +1,11 @@
 'use client';
-import { organizationTeamsState } from '@/core/stores';
-import { useCallback } from 'react';
-import { useAtom } from 'jotai';
-import { useSyncRef } from '../../common';
-import { TOrganizationTeam } from '@/core/types/schemas';
 import { mergePreservingOrder } from '@/core/lib/utils/team-members.utils';
+import { organizationTeamsState } from '@/core/stores';
+import { TOrganizationTeam } from '@/core/types/schemas';
+import { useAtom } from 'jotai';
+import { useCallback } from 'react';
+import { useSyncRef } from '../../common';
+import { useOrganisationTeams } from './use-organisation-teams';
 
 /**
  * It updates the `teams` state with the `members` status from the `team` status API
@@ -14,7 +15,8 @@ import { mergePreservingOrder } from '@/core/lib/utils/team-members.utils';
  * setTeamUpdate: A function that can be used to update the teams state.
  */
 export function useTeamsState() {
-	const [teams, setTeams] = useAtom(organizationTeamsState);
+	const [, setTeams] = useAtom(organizationTeamsState);
+	const { teams } = useOrganisationTeams();
 	const teamsRef = useSyncRef(teams);
 
 	const setTeamsUpdate = useCallback(

--- a/apps/web/core/hooks/organizations/teams/use-update-task.mutation.ts
+++ b/apps/web/core/hooks/organizations/teams/use-update-task.mutation.ts
@@ -1,0 +1,50 @@
+import { queryKeys } from '@/core/query/keys';
+import { taskService } from '@/core/services/client/api';
+import { teamTasksState } from '@/core/stores';
+import { PaginationResponse } from '@/core/types/interfaces/common/data-response';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+import { useCurrentTeam } from './use-current-team';
+import { useInvalidateTeamTasks } from './use-invalidate-team-tasks';
+
+/**
+ * Mutation hook for updating an existing task.
+ * Performs optimistic cache update and syncs Jotai store on success.
+ *
+ * @returns TanStack mutation object with updateTask mutationFn
+ */
+export const useUpdateTaskMutation = () => {
+	const queryClient = useQueryClient();
+	const activeTeam = useCurrentTeam();
+	const setAllTasks = useSetAtom(teamTasksState);
+
+	const invalidateTeamTasksData = useInvalidateTeamTasks();
+
+	const mutation = useMutation({
+		mutationFn: async ({ taskId, taskData }: { taskId: string; taskData: Partial<TTask> }) => {
+			return await taskService.updateTask({ taskId, data: taskData });
+		},
+		/**
+		 * Updates cache optimistically and syncs global state on success.
+		 */
+		onSuccess: (updatedTask, { taskId }) => {
+			queryClient.setQueryData(queryKeys.tasks.byTeam(activeTeam?.id), (oldTasks: PaginationResponse<TTask>) => {
+				if (!oldTasks) return oldTasks;
+
+				const updatedItems = oldTasks?.items?.map((task) =>
+					task.id === taskId ? { ...task, ...updatedTask } : task
+				);
+
+				// Sync Jotai store to keep global state consistent
+				setAllTasks(updatedItems);
+
+				return updatedItems ? { items: updatedItems, total: updatedItems.length } : oldTasks;
+			});
+			// Invalidate both tasks and daily plans to ensure UI synchronization
+			invalidateTeamTasksData();
+		}
+	});
+
+	return mutation;
+};

--- a/apps/web/core/hooks/queries/user-user.query.ts
+++ b/apps/web/core/hooks/queries/user-user.query.ts
@@ -1,14 +1,17 @@
+'use client';
+
 import { queryKeys } from '@/core/query/keys';
 import { userService } from '@/core/services/client/api';
 import { useQuery } from '@tanstack/react-query';
 
 import { getAccessTokenCookie } from '@/core/lib/helpers/cookies';
-import { useCallback } from 'react';
+
 export const useUserQuery = () => {
-	const checkTokenExist = useCallback((): boolean => {
+	const checkTokenExist = (): boolean => {
 		const token = getAccessTokenCookie();
 		return typeof token === 'string' && token.length > 0;
-	}, [getAccessTokenCookie]);
+	};
+
 	return useQuery({
 		queryKey: queryKeys.users.me,
 		queryFn: async () => {

--- a/apps/web/core/hooks/tasks/use-active-task-status.ts
+++ b/apps/web/core/hooks/tasks/use-active-task-status.ts
@@ -1,19 +1,21 @@
 'use client';
+import { useStatusValue, useSyncRef } from '@/core/hooks';
+import { taskUpdateQueue } from '@/core/lib/utils/task.utils';
+import { taskLabelsListState, taskStatusesState } from '@/core/stores';
+import {
+	clearOptimisticValueAtom,
+	getOptimisticValueAtom,
+	setOptimisticValueAtom
+} from '@/core/stores/tasks/task-optimistic-updates';
+import { ITag } from '@/core/types/interfaces/tag/tag';
+import { IActiveTaskStatuses, TStatus } from '@/core/types/interfaces/task/task-card';
 import { ITaskStatusField } from '@/core/types/interfaces/task/task-status/task-status-field';
 import { ITaskStatusStack } from '@/core/types/interfaces/task/task-status/task-status-stack';
-import { useStatusValue, useSyncRef, useTeamTasks } from '@/core/hooks';
-import { ITag } from '@/core/types/interfaces/tag/tag';
-import { TStatus, IActiveTaskStatuses } from '@/core/types/interfaces/task/task-card';
-import { taskUpdateQueue } from '@/core/lib/utils/task.utils';
-import { useCallback, useState, useEffect } from 'react';
-import { toast } from 'sonner';
 import { useAtomValue, useSetAtom } from 'jotai';
-import {
-	setOptimisticValueAtom,
-	clearOptimisticValueAtom,
-	getOptimisticValueAtom
-} from '@/core/stores/tasks/task-optimistic-updates';
-import { activeTeamTaskState, taskLabelsListState, taskStatusesState } from '@/core/stores';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { useCurrentActiveTask } from '../organizations/teams/use-current-active-task';
+import { useHandleStatusUpdate } from '../organizations/teams/use-handle-status-update';
 
 /**
  * Hook for managing loading states in task dropdown components
@@ -74,8 +76,8 @@ export function useActiveTaskStatus<T extends ITaskStatusField>(
 	status: TStatus<ITaskStatusStack[T]>,
 	field: T
 ) {
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
-	const { handleStatusUpdate } = useTeamTasks();
+	const { task: activeTeamTask } = useCurrentActiveTask();
+	const { handleStatusUpdate } = useHandleStatusUpdate();
 	const taskLabels = useAtomValue(taskLabelsListState);
 
 	const taskStatuses = useAtomValue(taskStatusesState);

--- a/apps/web/core/hooks/tasks/use-active-team-task.ts
+++ b/apps/web/core/hooks/tasks/use-active-team-task.ts
@@ -1,13 +1,14 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { queryKeys } from '@/core/query/keys';
+import { taskService } from '@/core/services/client/api';
+import { activeTeamTaskState, getPublicState, tasksByTeamState } from '@/core/stores';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useQuery } from '@tanstack/react-query';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { activeTeamState, activeTeamTaskState, getPublicState, tasksByTeamState } from '@/core/stores';
-import { useUserQuery } from '@/core/hooks/queries/user-user.query';
-import { taskService } from '@/core/services/client/api';
-import { queryKeys } from '@/core/query/keys';
-import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useEffect, useMemo } from 'react';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 /**
  * Result interface for the useActiveTeamTask hook
@@ -39,7 +40,7 @@ export const useActiveTeamTask = (): UseActiveTeamTaskResult => {
 	// Jotai state - instant updates
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const setActiveTeamTask = useSetAtom(activeTeamTaskState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const tasks = useAtomValue(tasksByTeamState);
 	const publicTeam = useAtomValue(getPublicState);
 

--- a/apps/web/core/hooks/tasks/use-auto-assign-task.ts
+++ b/apps/web/core/hooks/tasks/use-auto-assign-task.ts
@@ -1,11 +1,12 @@
 'use client';
 
+import { activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState, timerStatusState } from '@/core/stores';
 import { useCallback, useEffect } from 'react';
 import { useFirstLoad, useSyncRef } from '../common';
 import { useTeamTasks } from '../organizations';
-import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
 
 /**
@@ -13,7 +14,7 @@ import { useUserQuery } from '../queries/user-user.query';
  */
 export function useAutoAssignTask() {
 	const { firstLoad, firstLoadData } = useFirstLoad();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const timerStatus = useAtomValue(timerStatusState);
 	const { data: authUser } = useUserQuery();

--- a/apps/web/core/hooks/tasks/use-auto-assign-task.ts
+++ b/apps/web/core/hooks/tasks/use-auto-assign-task.ts
@@ -1,13 +1,15 @@
 'use client';
 
-import { activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { timerStatusState } from '@/core/stores';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect } from 'react';
-import { useFirstLoad, useSyncRef } from '../common';
-import { useTeamTasks } from '../organizations';
+import { useFirstLoad } from '../common';
+import { useCurrentActiveTask } from '../organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useUpdateTaskMutation } from '../organizations/teams/use-update-task.mutation';
 import { useUserQuery } from '../queries/user-user.query';
+import { useSetActiveTask } from '../organizations/teams/use-set-active-task';
 
 /**
  * Auto assign task to auth user when start tracking time
@@ -18,11 +20,10 @@ export function useAutoAssignTask() {
 
 	const timerStatus = useAtomValue(timerStatusState);
 	const { data: authUser } = useUserQuery();
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 
-	const { updateTask, updateLoading } = useTeamTasks();
-
-	const updateLoadingRef = useSyncRef(updateLoading);
+	const { mutateAsync: updateTask, isPending: updateLoading } = useUpdateTaskMutation();
+	const { setActiveTask } = useSetActiveTask();
 
 	/**
 	 * Assign task to the member
@@ -32,14 +33,14 @@ export function useAutoAssignTask() {
 			const exists = task.members?.some((t) => t.id === employeeId);
 			const newMember = activeTeam?.members?.find((m) => m.employeeId === employeeId);
 
-			if (exists || updateLoadingRef.current) return;
+			if (exists || updateLoading) return;
 
 			return updateTask({
-				...task,
-				members: [...(task.members || []), newMember ? newMember.employee : {}]
-			});
+				taskId: task?.id,
+				taskData: { ...task, members: [...(task.members || []), newMember ? newMember.employee : {}] }
+			}).then((task) => setActiveTask(task));
 		},
-		[updateTask, updateLoadingRef, activeTeam]
+		[updateTask, updateLoading, activeTeam]
 	);
 
 	useEffect(() => {

--- a/apps/web/core/hooks/tasks/use-detailed-task.ts
+++ b/apps/web/core/hooks/tasks/use-detailed-task.ts
@@ -1,0 +1,75 @@
+import { detailedTaskIdState } from '@/core/stores';
+import { queryKeys } from '@/core/query/keys';
+import { taskService } from '@/core/services/client/api';
+import { useAtom } from 'jotai';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+
+/** Default garbage collection time for task queries (1 hour) */
+const TASK_QUERY_GC_TIME = 1000 * 60 * 60;
+
+/**
+ * Manages the detailed task view state and data fetching.
+ *
+ * Combines Jotai state (which task is selected for detail view)
+ * with TanStack Query (fetching full task data from API).
+ *
+ * @returns Object containing:
+ * - `detailedTaskId`: Currently selected task ID (or null)
+ * - `setDetailedTaskId`: Function to change the selected task
+ * - `detailedTaskQuery`: TanStack Query result with full task data
+ * - `prefillDetailedTask`: Prefills cache with task data (for hover optimization)
+ *
+ * @example
+ * const { detailedTaskId, setDetailedTaskId, detailedTaskQuery, prefillDetailedTask } = useDetailedTask();
+ *
+ * // Prefill cache on hover (instant detail view later)
+ * <TaskCard onMouseEnter={() => prefillDetailedTask(task)} />
+ *
+ * // Open task detail panel
+ * setDetailedTaskId('task-123');
+ *
+ * // Access task data (already cached if prefilled!)
+ * if (detailedTaskQuery.data) {
+ *   console.log('Viewing:', detailedTaskQuery.data.title);
+ * }
+ *
+ * // Close detail panel
+ * setDetailedTaskId(null);
+ */
+export const useDetailedTask = () => {
+	const queryClient = useQueryClient();
+	const [detailedTaskId, setDetailedTaskId] = useAtom(detailedTaskIdState);
+
+	const detailedTaskQuery = useQuery({
+		queryKey: queryKeys.tasks.detail(detailedTaskId),
+		queryFn: async () => {
+			if (!detailedTaskId) {
+				throw new Error('Task ID is required');
+			}
+
+			return await taskService.getTaskById(detailedTaskId);
+		},
+		enabled: !!detailedTaskId,
+		gcTime: TASK_QUERY_GC_TIME
+	});
+
+	/**
+	 * Prefills the cache with task data.
+	 * Call this on hover to make detail view instant (no loading state).
+	 */
+	const prefillDetailedTask = useCallback(
+		(task: TTask) => {
+			queryClient.setQueryData(queryKeys.tasks.detail(task.id), task);
+		},
+		[queryClient]
+	);
+
+	return {
+		detailedTaskId,
+		setDetailedTaskId,
+		detailedTaskQuery,
+		prefillDetailedTask
+	};
+};

--- a/apps/web/core/hooks/tasks/use-favorites-task.ts
+++ b/apps/web/core/hooks/tasks/use-favorites-task.ts
@@ -1,10 +1,9 @@
-import { useAtomValue } from 'jotai';
-import { tasksByTeamState } from '@/core/stores/teams/team-tasks';
-import { useCallback, useMemo } from 'react';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useFavorites } from '../favorites';
 import { EBaseEntityEnum } from '@/core/types/generics/enums/entity';
 import { IFavoriteCreateRequest } from '@/core/types/interfaces/common/favorite';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useCallback, useMemo } from 'react';
+import { useFavorites } from '../favorites';
+import { useSortedTasksByCreation } from '../organizations/teams/use-sorted-tasks';
 import { useUserQuery } from '../queries/user-user.query';
 
 /**
@@ -19,7 +18,7 @@ import { useUserQuery } from '../queries/user-user.query';
  */
 
 export const useFavoriteTasks = () => {
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasksByCreation();
 	const { data: user } = useUserQuery();
 
 	const { currentEmployeeFavorites, createFavorite, deleteFavorite, createFavoriteLoading, deleteFavoriteLoading } =

--- a/apps/web/core/hooks/tasks/use-issue-types.ts
+++ b/apps/web/core/hooks/tasks/use-issue-types.ts
@@ -1,20 +1,21 @@
 'use client';
-import { issueTypesListState, activeTeamIdState, activeTeamState } from '@/core/stores';
-import { useCallback, useMemo } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
-import { issueTypeService } from '@/core/services/client/api/tasks/issue-type.service';
-import { IIssueTypesCreate } from '@/core/types/interfaces/task/issue-type';
 import { queryKeys } from '@/core/query/keys';
+import { issueTypeService } from '@/core/services/client/api/tasks/issue-type.service';
+import { activeTeamIdState, issueTypesListState } from '@/core/stores';
+import { IIssueTypesCreate } from '@/core/types/interfaces/task/issue-type';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useMemo } from 'react';
 import { useConditionalUpdateEffect } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
 
 export function useIssueType() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 	const { data: authUser } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const queryClient = useQueryClient();
 
 	const [issueTypes, setIssueTypes] = useAtom(issueTypesListState);

--- a/apps/web/core/hooks/tasks/use-kanban.ts
+++ b/apps/web/core/hooks/tasks/use-kanban.ts
@@ -1,12 +1,13 @@
 import { kanbanBoardState } from '@/core/stores/integrations/kanban';
-import { useTaskStatus } from '../tasks/use-task-status';
-import { useAtom } from 'jotai';
-import { useEffect, useState, useMemo, useCallback, useOptimistic, startTransition } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { useTeamTasks } from '../organizations';
 import { TStatusItem } from '@/core/types/interfaces/task/task-card';
 import { TTaskStatus } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useAtom } from 'jotai';
+import { useSearchParams } from 'next/navigation';
+import { startTransition, useCallback, useEffect, useMemo, useOptimistic, useState } from 'react';
+import { useCurrentTeamTasks } from '../organizations/teams/use-current-team-tasks';
+import { useUpdateTaskMutation } from '../organizations/teams/use-update-task.mutation';
+import { useTaskStatus } from '../tasks/use-task-status';
 
 export interface IKanban {
 	[key: string]: TTask[];
@@ -25,7 +26,8 @@ export function useKanban() {
 	});
 	const [kanbanBoard, setKanbanBoard] = useAtom(kanbanBoardState);
 	const taskStatusHook = useTaskStatus();
-	const { tasks: newTask, tasksFetching, updateTask } = useTeamTasks();
+	const { tasks: newTask, isLoading: tasksFetching } = useCurrentTeamTasks();
+	const { mutateAsync: updateTask } = useUpdateTaskMutation();
 	const [priority, setPriority] = useState<string[]>([]);
 	const [sizes, setSizes] = useState<string[]>([]);
 	const employee = useSearchParams().get('employee');

--- a/apps/web/core/hooks/tasks/use-task-estimations.ts
+++ b/apps/web/core/hooks/tasks/use-task-estimations.ts
@@ -1,15 +1,19 @@
 import { queryKeys } from '@/core/query/keys';
 import { taskEstimationsService } from '@/core/services/client/api/tasks/task-estimations.service';
+import { TCreateTaskEstimation, TTaskEstimation } from '@/core/types/schemas/task/task-estimation.schema';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useConditionalUpdateEffect } from '../common';
-import { detailedTaskState } from '@/core/stores';
-import { useAtom } from 'jotai';
-import { TCreateTaskEstimation, TTaskEstimation } from '@/core/types/schemas/task/task-estimation.schema';
+import { useDetailedTask } from './use-detailed-task';
+
 export function useTaskEstimations() {
 	const queryClient = useQueryClient();
-	const [detailedTask, setDetailedTask] = useAtom(detailedTaskState);
+	const {
+		detailedTaskQuery: { data: detailedTask },
+		detailedTaskId,
+		setDetailedTaskId
+	} = useDetailedTask();
 
 	const detailedTaskQueryData = queryClient.getQueryData(queryKeys.tasks.detail(detailedTask?.id)) as TTask;
 
@@ -78,13 +82,18 @@ export function useTaskEstimations() {
 		}
 	});
 
+	/**
+	 * Will never be executed,
+	 * because detailedTaskQueryData?.id and detailedTaskId will always be the same
+	 * but keep for backward compatibility
+	 */
 	useConditionalUpdateEffect(
 		() => {
-			if (detailedTaskQueryData) {
-				setDetailedTask(detailedTaskQueryData);
+			if (detailedTaskQueryData && detailedTaskQueryData?.id != detailedTaskId) {
+				setDetailedTaskId(detailedTaskQueryData?.id);
 			}
 		},
-		[detailedTaskQueryData],
+		[detailedTaskQueryData, detailedTaskId, setDetailedTaskId],
 		Boolean(detailedTaskQueryData)
 	);
 

--- a/apps/web/core/hooks/tasks/use-task-filter.ts
+++ b/apps/web/core/hooks/tasks/use-task-filter.ts
@@ -1,16 +1,18 @@
-import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
-import { I_UserProfilePage } from '../users';
-import { useDailyPlan, useLocalStorageState, useOutsideClick } from '@/core/hooks';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { usePathname } from 'next/navigation';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { DAILY_PLAN_SUGGESTION_MODAL_DATE } from '@/core/constants/config/constants';
-import { estimatedTotalTime, getTotalTasks } from '@/core/components/tasks/daily-plan';
-import intersection from 'lodash/intersection';
 import { ITab } from '@/core/components/pages/profile/task-filters';
-import { timeLogsDailyReportState, activeTeamManagersState, activeTeamState } from '@/core/stores';
+import { estimatedTotalTime, getTotalTasks } from '@/core/components/tasks/daily-plan';
+import { DAILY_PLAN_SUGGESTION_MODAL_DATE } from '@/core/constants/config/constants';
+import { useDailyPlan, useLocalStorageState, useOutsideClick } from '@/core/hooks';
+import { timeLogsDailyReportState } from '@/core/stores';
+import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
+import intersection from 'lodash/intersection';
+import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useActiveTeamManagers } from '../organizations/teams/use-active-team-managers';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
+import { I_UserProfilePage } from '../users';
 
 type IStatusType = 'status' | 'size' | 'priority' | 'label';
 type FilterType = 'status' | 'search' | undefined;
@@ -54,8 +56,8 @@ export function useTaskFilter(profile: I_UserProfilePage, options: UseTaskFilter
 	// 	[]
 	// );
 
-	const activeTeamManagers = useAtomValue(activeTeamManagersState);
-	const activeTeam = useAtomValue(activeTeamState);
+	const { managers: activeTeamManagers } = useActiveTeamManagers();
+	const activeTeam = useCurrentTeam();
 
 	const { data: user } = useUserQuery();
 

--- a/apps/web/core/hooks/tasks/use-task-filter.ts
+++ b/apps/web/core/hooks/tasks/use-task-filter.ts
@@ -1,7 +1,7 @@
 import { ITab } from '@/core/components/pages/profile/task-filters';
 import { estimatedTotalTime, getTotalTasks } from '@/core/components/tasks/daily-plan';
 import { DAILY_PLAN_SUGGESTION_MODAL_DATE } from '@/core/constants/config/constants';
-import { useDailyPlan, useLocalStorageState, useOutsideClick } from '@/core/hooks';
+import { useLocalStorageState, useOutsideClick } from '@/core/hooks';
 import { timeLogsDailyReportState } from '@/core/stores';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
@@ -13,6 +13,7 @@ import { useActiveTeamManagers } from '../organizations/teams/use-active-team-ma
 import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
 import { I_UserProfilePage } from '../users';
+import { useOutstandingPlans, useProfileDailyPlans, useTodayPlan } from '../daily-plans/derived';
 
 type IStatusType = 'status' | 'size' | 'priority' | 'label';
 type FilterType = 'status' | 'search' | undefined;
@@ -75,7 +76,10 @@ export function useTaskFilter(profile: I_UserProfilePage, options: UseTaskFilter
 		profile?.member?.employee?.id
 	]);
 
-	const { todayPlan, outstandingPlans, profileDailyPlans } = useDailyPlan(targetEmployeeId);
+	const todayPlan = useTodayPlan(targetEmployeeId ?? undefined);
+	const outstandingPlans = useOutstandingPlans(targetEmployeeId ?? undefined);
+	const profileDailyPlans = useProfileDailyPlans(targetEmployeeId ?? undefined);
+
 	const timeLogsDailyReport = useAtomValue(timeLogsDailyReportState);
 	const isManagerConnectedUser = useMemo(
 		() => activeTeamManagers.findIndex((member) => member.employee?.user?.id === user?.id),

--- a/apps/web/core/hooks/tasks/use-task-labels.ts
+++ b/apps/web/core/hooks/tasks/use-task-labels.ts
@@ -1,27 +1,28 @@
 'use client';
-import { taskLabelsListState, activeTeamIdState, activeTeamState } from '@/core/stores';
-import { useCallback, useMemo, useOptimistic, startTransition } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
 import {
 	generateDefaultColor,
 	getActiveTeamIdCookie,
 	getOrganizationIdCookie,
 	getTenantIdCookie
 } from '@/core/lib/helpers/index';
-import { taskLabelService } from '@/core/services/client/api/tasks/task-label.service';
-import { ITagCreate } from '@/core/types/interfaces/tag/tag';
-import { queryKeys } from '@/core/query/keys';
-import { useConditionalUpdateEffect } from '../common';
-import { useUserQuery } from '../queries/user-user.query';
 import { mergeTaskLabelData } from '@/core/lib/helpers/task';
+import { queryKeys } from '@/core/query/keys';
+import { taskLabelService } from '@/core/services/client/api/tasks/task-label.service';
+import { activeTeamIdState, taskLabelsListState } from '@/core/stores';
+import { ITagCreate } from '@/core/types/interfaces/tag/tag';
 import { OptimisticAction, TTag } from '@/core/types/schemas';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { startTransition, useCallback, useMemo, useOptimistic } from 'react';
+import { useConditionalUpdateEffect } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useUserQuery } from '../queries/user-user.query';
 
 export function useTaskLabels() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 	const { data: authUser } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	const queryClient = useQueryClient();
 

--- a/apps/web/core/hooks/tasks/use-task-priorities.ts
+++ b/apps/web/core/hooks/tasks/use-task-priorities.ts
@@ -1,20 +1,21 @@
 'use client';
-import { taskPrioritiesListState, activeTeamIdState, activeTeamState } from '@/core/stores';
-import { useCallback, useMemo } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
 import { getActiveTeamIdCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
-import { taskPriorityService } from '@/core/services/client/api/tasks/task-priority.service';
-import { ITaskPrioritiesCreate } from '@/core/types/interfaces/task/task-priority';
 import { queryKeys } from '@/core/query/keys';
+import { taskPriorityService } from '@/core/services/client/api/tasks/task-priority.service';
+import { activeTeamIdState, taskPrioritiesListState } from '@/core/stores';
+import { ITaskPrioritiesCreate } from '@/core/types/interfaces/task/task-priority';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useMemo } from 'react';
 import { useConditionalUpdateEffect } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
 import { useUserQuery } from '../queries/user-user.query';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export function useTaskPriorities() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 	const { data: authUser } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const queryClient = useQueryClient();
 
 	const [taskPriorities, setTaskPriorities] = useAtom(taskPrioritiesListState);

--- a/apps/web/core/hooks/tasks/use-task-related-issue-type.ts
+++ b/apps/web/core/hooks/tasks/use-task-related-issue-type.ts
@@ -1,20 +1,21 @@
 'use client';
-import { activeTeamState, taskRelatedIssueTypeListState, activeTeamIdState } from '@/core/stores';
-import { useCallback, useMemo } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
 import { getActiveTeamIdCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
-import { taskRelatedIssueTypeService } from '@/core/services/client/api/tasks/task-related-issue-type.service';
-import { ITaskRelatedIssueTypeCreate } from '@/core/types/interfaces/task/related-issue-type';
 import { queryKeys } from '@/core/query/keys';
+import { taskRelatedIssueTypeService } from '@/core/services/client/api/tasks/task-related-issue-type.service';
+import { activeTeamIdState, taskRelatedIssueTypeListState } from '@/core/stores';
+import { ITaskRelatedIssueTypeCreate } from '@/core/types/interfaces/task/related-issue-type';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useMemo } from 'react';
 import { useConditionalUpdateEffect } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
 import { useUserQuery } from '../queries/user-user.query';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export function useTaskRelatedIssueType() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 	const { data: authUser } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const queryClient = useQueryClient();
 
 	const [taskRelatedIssueType, setTaskRelatedIssueType] = useAtom(taskRelatedIssueTypeListState);

--- a/apps/web/core/hooks/tasks/use-task-sizes.ts
+++ b/apps/web/core/hooks/tasks/use-task-sizes.ts
@@ -1,21 +1,22 @@
 'use client';
-import { activeTeamIdState, activeTeamState } from '@/core/stores';
-import { taskSizesListState } from '@/core/stores/tasks/task-sizes';
-import { useCallback } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
-import { taskSizeService } from '@/core/services/client/api/tasks/task-size.service';
-import { ITaskSizesCreate } from '@/core/types/interfaces/task/task-size';
 import { queryKeys } from '@/core/query/keys';
+import { taskSizeService } from '@/core/services/client/api/tasks/task-size.service';
+import { activeTeamIdState } from '@/core/stores';
+import { taskSizesListState } from '@/core/stores/tasks/task-sizes';
+import { ITaskSizesCreate } from '@/core/types/interfaces/task/task-size';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback } from 'react';
 import { useConditionalUpdateEffect } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export function useTaskSizes() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
 	const [taskSizes, setTaskSizes] = useAtom(taskSizesListState);
 	const { firstLoadData: firstLoadTaskSizesData } = useFirstLoad();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const queryClient = useQueryClient();
 
 	const teamId = activeTeam?.id || activeTeamId;

--- a/apps/web/core/hooks/tasks/use-task-statistics.ts
+++ b/apps/web/core/hooks/tasks/use-task-statistics.ts
@@ -2,7 +2,6 @@
 import { statisticsService } from '@/core/services/client/api/timesheets/statistic.service';
 import {
 	activeTaskStatisticsState,
-	activeTeamTaskState,
 	allTaskStatisticsState,
 	tasksFetchingState,
 	tasksStatisticsState,
@@ -19,6 +18,7 @@ import { useFirstLoad } from '../common/use-first-load';
 import { useSyncRef } from '../common/use-sync-ref';
 import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
+import { useCurrentActiveTask } from '../organizations/teams/use-current-active-task';
 
 export function useTaskStatistics(addSeconds = 0) {
 	const { data: user } = useUserQuery();
@@ -37,7 +37,7 @@ export function useTaskStatistics(addSeconds = 0) {
 
 	// Dep status
 	const timerStatus = useAtomValue(timerStatusState);
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 
 	/**
 	 * Get employee all tasks statistics  (API Call)

--- a/apps/web/core/hooks/tasks/use-task-statistics.ts
+++ b/apps/web/core/hooks/tasks/use-task-statistics.ts
@@ -1,24 +1,24 @@
 'use client';
+import { statisticsService } from '@/core/services/client/api/timesheets/statistic.service';
 import {
 	activeTaskStatisticsState,
-	activeTeamState,
 	activeTeamTaskState,
 	allTaskStatisticsState,
 	tasksFetchingState,
 	tasksStatisticsState,
 	timerStatusState
 } from '@/core/stores';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useFirstLoad } from '../common/use-first-load';
-import debounce from 'lodash/debounce';
-import { useSyncRef } from '../common/use-sync-ref';
-import { statisticsService } from '@/core/services/client/api/timesheets/statistic.service';
-import { useRefreshIntervalV2 } from '../common';
 import { Nullable } from '@/core/types/generics/utils';
-import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useUserQuery } from '../queries/user-user.query';
 import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import debounce from 'lodash/debounce';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useRefreshIntervalV2 } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useSyncRef } from '../common/use-sync-ref';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useUserQuery } from '../queries/user-user.query';
 
 export function useTaskStatistics(addSeconds = 0) {
 	const { data: user } = useUserQuery();
@@ -29,7 +29,7 @@ export function useTaskStatistics(addSeconds = 0) {
 
 	const { firstLoad, firstLoadData: firstLoadtasksStatisticsData } = useFirstLoad();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 
 	// Refs
 	const initialLoad = useRef(false);
@@ -208,7 +208,12 @@ export function useTaskStatistics(addSeconds = 0) {
 
 		// Add local timer seconds (addSeconds) to the total worked time
 		// This ensures the progress bar updates in real-time as the timer runs locally
-		const estimation = getEstimation(null, activeTeamTask, totalWorkedTasksTimer + addSeconds, activeTeamTask?.estimate || 0);
+		const estimation = getEstimation(
+			null,
+			activeTeamTask,
+			totalWorkedTasksTimer + addSeconds,
+			activeTeamTask?.estimate || 0
+		);
 		return estimation;
 	}, [activeTeam?.members, activeTeamTask, getEstimation, addSeconds]);
 

--- a/apps/web/core/hooks/tasks/use-task-status.ts
+++ b/apps/web/core/hooks/tasks/use-task-status.ts
@@ -1,21 +1,22 @@
 'use client';
-import { taskStatusesState, activeTeamState, activeTeamIdState } from '@/core/stores';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../common/use-first-load';
 import { getActiveTeamIdCookie, getOrganizationIdCookie, getTenantIdCookie } from '@/core/lib/helpers/index';
+import { queryKeys } from '@/core/query/keys';
 import { taskStatusService } from '@/core/services/client/api/tasks/task-status.service';
-import { useCallbackRef, useConditionalUpdateEffect, useSyncRef } from '../common';
+import { activeTeamIdState, taskStatusesState } from '@/core/stores';
 import { TStatus, TStatusItem } from '@/core/types/interfaces/task/task-card';
 import { ITaskStatusCreate } from '@/core/types/interfaces/task/task-status/task-status';
-import { queryKeys } from '@/core/query/keys';
-import { ITaskStatusOrder } from '@/core/types/interfaces/task/task-status/task-status-order';
 import { ITaskStatusField } from '@/core/types/interfaces/task/task-status/task-status-field';
+import { ITaskStatusOrder } from '@/core/types/interfaces/task/task-status/task-status-order';
 import { ITaskStatusStack } from '@/core/types/interfaces/task/task-status/task-status-stack';
-import { useMapToTaskStatusValues } from './use-map-to-task-status-values';
-import { useUserQuery } from '../queries/user-user.query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import { useCallbackRef, useConditionalUpdateEffect, useSyncRef } from '../common';
+import { useFirstLoad } from '../common/use-first-load';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useUserQuery } from '../queries/user-user.query';
+import { useMapToTaskStatusValues } from './use-map-to-task-status-values';
 
 export function useTaskStatus() {
 	const activeTeamId = useAtomValue(activeTeamIdState);
@@ -23,7 +24,7 @@ export function useTaskStatus() {
 	const { firstLoadData: firstLoadTaskStatusesData } = useFirstLoad();
 	const { data: user } = useUserQuery();
 
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const queryClient = useQueryClient();
 
 	const teamId = activeTeam?.id || getActiveTeamIdCookie() || activeTeamId;

--- a/apps/web/core/hooks/tasks/use-timer-button.ts
+++ b/apps/web/core/hooks/tasks/use-timer-button.ts
@@ -1,21 +1,23 @@
 // core/hooks/task-card/useTimerButton.ts
-import { useCallback, useMemo, useState } from 'react';
-import { useStartStopTimerHandler, useTeamTasks, useTimerView } from '@/core/hooks';
+import { useStartStopTimerHandler, useTimerView } from '@/core/hooks';
 import { useTimerOptimisticUI } from '@/core/hooks/activities/use-timer-optimistic-ui';
-import { TOrganizationTeam } from '@/core/types/schemas/team/organization-team.schema';
-import { toast } from 'sonner';
-import { useTranslations } from 'next-intl';
+import { timerStatusState } from '@/core/stores';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { activeTeamTaskState, timerStatusState } from '@/core/stores';
+import { TOrganizationTeam } from '@/core/types/schemas/team/organization-team.schema';
 import { useAtomValue } from 'jotai';
+import { useTranslations } from 'next-intl';
+import { useCallback, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { useCurrentActiveTask } from '../organizations/teams/use-current-active-task';
+import { useSetActiveTask } from '../organizations/teams/use-set-active-task';
 
 // Custom hook to extract TimerButtonCall business logic
 export function useTimerButtonLogic({ task, activeTeam }: { task: TTask; activeTeam: TOrganizationTeam | null }) {
 	const [loading, setLoading] = useState(false);
 	const timerStatus = useAtomValue(timerStatusState);
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 	const { canTrack, disabled, startTimer, stopTimer, hasPlan } = useTimerView();
-	const { setActiveTask } = useTeamTasks();
+	const { setActiveTask } = useSetActiveTask();
 	const t = useTranslations();
 
 	// Use optimistic UI hook for timer button feedback

--- a/apps/web/core/hooks/users/use-profile-validation.ts
+++ b/apps/web/core/hooks/users/use-profile-validation.ts
@@ -1,13 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useAtomValue } from 'jotai';
-import { useRouter, usePathname } from 'next/navigation';
-import { toast } from 'sonner';
-import { useTranslations } from 'next-intl';
-import { activeTeamState } from '@/core/stores';
-import { useUserQuery } from '../queries/user-user.query';
 import { TOrganizationTeam } from '@/core/types/schemas/team/organization-team.schema';
+import { useTranslations } from 'next-intl';
+import { usePathname, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { useUserQuery } from '../queries/user-user.query';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 
 export type ProfileValidationState = 'loading' | 'valid' | 'not-found' | 'timeout' | 'unauthorized';
 
@@ -26,7 +25,7 @@ export interface ProfileValidationResult {
  */
 export function useProfileValidation(memberId: string | null) {
 	const { data: user } = useUserQuery();
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const router = useRouter();
 	const pathname = usePathname();
 	const t = useTranslations();

--- a/apps/web/core/hooks/users/use-user-details.ts
+++ b/apps/web/core/hooks/users/use-user-details.ts
@@ -1,20 +1,23 @@
 'use client';
 
-import { activeTeamTaskState } from '@/core/stores';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useAtomValue } from 'jotai';
 import { useCallback, useMemo } from 'react';
 import { useAuthenticateUser } from '../auth';
-import { useTeamTasks } from '../organizations';
 import { useAuthTeamTasks } from '../organizations/teams/use-auth-team-tasks';
+import { useCurrentActiveTask } from '../organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useCurrentTeamTasks } from '../organizations/teams/use-current-team-tasks';
+import { useUpdateTaskMutation } from '../organizations/teams/use-update-task.mutation';
 import { useGetTasksStatsData } from '../tasks';
+import { useSetActiveTask } from '../organizations/teams/use-set-active-task';
 
 export function useUserDetails(memberId: string) {
 	const activeTeam = useCurrentTeam();
-	const activeTeamTask = useAtomValue(activeTeamTaskState);
+	const { task: activeTeamTask } = useCurrentActiveTask();
 
-	const { updateTask, tasks } = useTeamTasks();
+	const { tasks } = useCurrentTeamTasks();
+	const { mutateAsync: updateTask } = useUpdateTaskMutation();
+	const { setActiveTask } = useSetActiveTask();
 
 	const { user: auth } = useAuthenticateUser();
 
@@ -57,9 +60,9 @@ export function useUserDetails(memberId: string) {
 			}
 
 			return updateTask({
-				...task,
-				members: [...(task.members || []), matchUser ? matchUser.employee : {}]
-			});
+				taskId: task?.id,
+				taskData: { ...task, members: [...(task.members || []), matchUser ? matchUser.employee : {}] }
+			}).then((task) => setActiveTask(task));
 		},
 		[updateTask, matchUser]
 	);

--- a/apps/web/core/hooks/users/use-user-details.ts
+++ b/apps/web/core/hooks/users/use-user-details.ts
@@ -1,16 +1,17 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
-import { useAuthTeamTasks } from '../organizations/teams/use-auth-team-tasks';
-import { useTeamTasks } from '../organizations';
-import { useAuthenticateUser } from '../auth';
-import { useGetTasksStatsData } from '../tasks';
+import { activeTeamTaskState } from '@/core/stores';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { activeTeamState, activeTeamTaskState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
+import { useCallback, useMemo } from 'react';
+import { useAuthenticateUser } from '../auth';
+import { useTeamTasks } from '../organizations';
+import { useAuthTeamTasks } from '../organizations/teams/use-auth-team-tasks';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useGetTasksStatsData } from '../tasks';
 
 export function useUserDetails(memberId: string) {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 
 	const { updateTask, tasks } = useTeamTasks();

--- a/apps/web/core/hooks/users/use-user-profile-page.ts
+++ b/apps/web/core/hooks/users/use-user-profile-page.ts
@@ -1,15 +1,16 @@
 'use client';
-import { activeTeamState, userDetailAccordion } from '@/core/stores';
+import { userDetailAccordion } from '@/core/stores';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
 import { useParams } from 'next/navigation';
 import { useCallback, useMemo } from 'react';
 import { useAuthTeamTasks, useTeamTasks } from '../organizations';
-import { useGetTasksStatsData } from '../tasks';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
 import { useUserQuery } from '../queries/user-user.query';
+import { useGetTasksStatsData } from '../tasks';
 
 export function useUserProfilePage() {
-	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const { activeTeamTask, updateTask, tasks } = useTeamTasks();
 	const userMemberId = useAtomValue(userDetailAccordion);
 

--- a/apps/web/core/hooks/users/use-user-selected-page.ts
+++ b/apps/web/core/hooks/users/use-user-selected-page.ts
@@ -3,13 +3,20 @@
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useCallback, useMemo } from 'react';
 import { useAuthenticateUser } from '../auth';
-import { useAuthTeamTasks, useTeamTasks } from '../organizations';
+import { useAuthTeamTasks } from '../organizations';
+import { useCurrentActiveTask } from '../organizations/teams/use-current-active-task';
 import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useCurrentTeamTasks } from '../organizations/teams/use-current-team-tasks';
+import { useUpdateTaskMutation } from '../organizations/teams/use-update-task.mutation';
 import { useGetTasksStatsData } from '../tasks';
+import { useSetActiveTask } from '../organizations/teams/use-set-active-task';
 
 export function useUserSelectedPage(memberId = '') {
 	const activeTeam = useCurrentTeam();
-	const { activeTeamTask, updateTask, tasks } = useTeamTasks();
+	const { tasks } = useCurrentTeamTasks();
+	const { task: activeTeamTask } = useCurrentActiveTask();
+	const { mutateAsync: updateTask } = useUpdateTaskMutation();
+	const { setActiveTask } = useSetActiveTask();
 
 	const { user: auth } = useAuthenticateUser();
 
@@ -52,9 +59,9 @@ export function useUserSelectedPage(memberId = '') {
 			}
 
 			return updateTask({
-				...task,
-				members: [...(task.members || []), matchUser ? matchUser.employee : {}]
-			});
+				taskId: task?.id,
+				taskData: { ...task, members: [...(task.members || []), matchUser ? matchUser.employee : {}] }
+			}).then((task) => setActiveTask(task));
 		},
 		[updateTask, matchUser]
 	);

--- a/apps/web/core/hooks/users/use-user-selected-page.ts
+++ b/apps/web/core/hooks/users/use-user-selected-page.ts
@@ -1,15 +1,14 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
-import { useAuthTeamTasks, useTeamTasks } from '../organizations';
-import { useAuthenticateUser } from '../auth';
-import { useGetTasksStatsData } from '../tasks';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { activeTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
+import { useCallback, useMemo } from 'react';
+import { useAuthenticateUser } from '../auth';
+import { useAuthTeamTasks, useTeamTasks } from '../organizations';
+import { useCurrentTeam } from '../organizations/teams/use-current-team';
+import { useGetTasksStatsData } from '../tasks';
 
-export function useUserSelectedPage(memberId='') {
-	const activeTeam = useAtomValue(activeTeamState);
+export function useUserSelectedPage(memberId = '') {
+	const activeTeam = useCurrentTeam();
 	const { activeTeamTask, updateTask, tasks } = useTeamTasks();
 
 	const { user: auth } = useAuthenticateUser();

--- a/apps/web/core/services/client/api/tasks/task.service.ts
+++ b/apps/web/core/services/client/api/tasks/task.service.ts
@@ -5,7 +5,10 @@ import { GAUZY_API_BASE_SERVER_URL } from '@/core/constants/config/constants';
 import { DeleteResponse, PaginationResponse } from '@/core/types/interfaces/common/data-response';
 import { createTaskSchema, taskSchema, TCreateTask, TTask } from '@/core/types/schemas/task/task.schema';
 import { TEmployee, ZodValidationError } from '@/core/types/schemas';
-import { zodStrictApiResponseValidate, zodStrictPaginationResponseValidate } from '@/core/lib/validation/zod-validators';
+import {
+	zodStrictApiResponseValidate,
+	zodStrictPaginationResponseValidate
+} from '@/core/lib/validation/zod-validators';
 
 /**
  * Enhanced Task Service with Zod validation
@@ -81,12 +84,18 @@ class TaskService extends APIService {
 	 * @returns {Promise<PaginationResponse<TTask>>} - Validated paginated tasks data
 	 * @throws ValidationError if response data doesn't match schema
 	 */
-	getTasks = async ({ projectId }: { projectId: string }): Promise<PaginationResponse<TTask>> => {
+	getTasks = async ({
+		projectId,
+		activeTeamId
+	}: {
+		projectId?: string;
+		activeTeamId?: string;
+	}): Promise<PaginationResponse<TTask>> => {
 		try {
 			const query = qs.stringify({
 				...this.baseQueries,
-				'where[projectId]': projectId,
-				'where[teams][0]': this.activeTeamId
+				...(projectId && { 'where[projectId]': projectId }),
+				'where[teams][0]': activeTeamId ?? this.activeTeamId
 			});
 			const endpoint = `/tasks/team?${query}`;
 

--- a/apps/web/core/stores/auth/invitations.ts
+++ b/apps/web/core/stores/auth/invitations.ts
@@ -8,7 +8,7 @@ export const myInvitationsState = atom<TInvite[]>([]);
 
 /**
  * Keep for backward compatibility
- * @deprecated use `useTeamMemberInvitation()` hooks, that is partialy in sync with tanstack
+ * @deprecated use `useTeamMemberInvitation()` hooks, that is partially in sync with tanstack
  */
 export const getTeamInvitationsState = atom<TInvite[]>((get) => {
 	const invitations = get(teamInvitationsState);

--- a/apps/web/core/stores/auth/invitations.ts
+++ b/apps/web/core/stores/auth/invitations.ts
@@ -1,14 +1,18 @@
-import { atom } from 'jotai';
-import { activeTeamState } from '../teams/organization-team';
+import { useCurrentTeam } from '@/core/hooks/organizations/teams/use-current-team';
 import { TInvite } from '@/core/types/schemas';
+import { atom } from 'jotai';
 
 export const teamInvitationsState = atom<TInvite[]>([]);
 
 export const myInvitationsState = atom<TInvite[]>([]);
 
+/**
+ * Keep for backward compatibility
+ * @deprecated use `useTeamMemberInvitation()` hooks, that is partialy in sync with tanstack
+ */
 export const getTeamInvitationsState = atom<TInvite[]>((get) => {
 	const invitations = get(teamInvitationsState);
-	const activeTeam = get(activeTeamState);
+	const activeTeam = useCurrentTeam();
 	const members = activeTeam?.members || [];
 
 	return invitations.filter((invite) => {

--- a/apps/web/core/stores/teams/organization-team.ts
+++ b/apps/web/core/stores/teams/organization-team.ts
@@ -2,6 +2,10 @@ import { atom } from 'jotai';
 import { ERoleName } from '@/core/types/generics/enums/role';
 import { TOrganizationTeam, TOrganizationTeamEmployee } from '@/core/types/schemas';
 
+/**
+ * Keep for backward compatibility
+ * @deprecated use `useOrganisationTeams()` hook. That is in sync with tanstack-query !
+ */
 export const organizationTeamsState = atom<TOrganizationTeam[]>([]);
 
 export const activeTeamIdState = atom<string | null>(null);
@@ -17,6 +21,10 @@ export const isTeamJustDeletedState = atom<boolean>(false);
 export const isOTRefreshingState = atom<boolean>(false);
 export const OTRefreshIntervalState = atom<number>();
 
+/**
+ * Keep for backward compatibility
+ * @deprecated use `useCurrentTeam()` hook. That is in sync with tanstack-query !
+ */
 export const activeTeamState = atom<
 	TOrganizationTeam | null,
 	[((prev: TOrganizationTeam) => TOrganizationTeam) | TOrganizationTeam],
@@ -59,6 +67,10 @@ export const memberActiveTaskIdState = atom<string | null>(null);
 
 export const publicActiveTeamState = atom<TOrganizationTeam | undefined>(undefined);
 
+/**
+ * Keep for backward compatibility
+ * @deprecate use `useActiveTeamManagers()` hook. That is in sync with tanstack-query !
+ */
 export const activeTeamManagersState = atom<TOrganizationTeamEmployee[]>((get) => {
 	const activeTeam = get(activeTeamState);
 	const members = activeTeam?.members;

--- a/apps/web/core/stores/teams/team-tasks.ts
+++ b/apps/web/core/stores/teams/team-tasks.ts
@@ -4,21 +4,115 @@ import { atomWithStorage } from 'jotai/utils';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { TTaskStatistic } from '@/core/types/schemas/activities/statistics.schema';
 
+/**
+ * @deprecated Use `useCurrentTeamTasks()` hook instead.
+ * This atom is no longer in sync with TanStack Query cache.
+ *
+ * Migration:
+ * - Before: const tasks = useAtomValue(teamTasksState)
+ * - After:  const tasks = useCurrentTeamTasks()
+ *
+ * @see useCurrentTeamTasks
+ */
 export const teamTasksState = atom<TTask[]>([]);
 
+/**
+ * @deprecated Use `useCurrentActiveTask()` hook instead.
+ * This atom is no longer in sync with TanStack Query cache.
+ *
+ * Migration:
+ * - Before: const task = useAtomValue(activeTeamTaskState)
+ * - After:  const task = useCurrentActiveTask()
+ *
+ * @see useCurrentActiveTask
+ */
 export const activeTeamTaskState = atom<TTask | null>(null);
-export const activeTeamTaskId = atom<{ id: string }>({
+
+/**
+ * Stores the ID of the currently active task for the team.
+ *
+ * @warning DO NOT UPDATE THIS ATOM DIRECTLY!
+ * Always use the `useSetActiveTask()` hook to modify this value.
+ *
+ * The hook handles:
+ * - Optimistic UI updates with rollback
+ * - Server synchronization with retry logic
+ * - Cookie persistence for multi-device support
+ * - Proper state consistency across the app
+ *
+ * Direct updates will bypass these mechanisms and cause sync issues.
+ *
+ * @example
+ * // ❌ WRONG - Never do this
+ * const [taskId, setTaskId] = useAtom(activeTeamTaskId);
+ * setTaskId({ id: 'some-id' });
+ *
+ * // ✅ CORRECT - Use the hook
+ * const { setActiveTask } = useSetActiveTask();
+ * await setActiveTask(task);
+ */
+export const activeTeamTaskId = atom<{ id: string | null }>({
 	id: ''
 });
 export const tasksFetchingState = atom<boolean>(false);
 
+/**
+ * @deprecated Use `useDetailedTask()` hook instead.
+ * This atom is no longer in sync with TanStack Query cache.
+ *
+ * The hook now handles:
+ * - Data fetching via TanStack Query
+ * - Cache management with automatic garbage collection
+ * - Prefilling for hover optimization
+ *
+ * Migration:
+ * - Before: const task = useAtomValue(detailedTaskState)
+ * - After:  const { detailedTaskQuery } = useDetailedTask()
+ *           const task = detailedTaskQuery.data
+ *
+ * @see useDetailedTask
+ */
 export const detailedTaskState = atom<TTask | null>(null);
+
+/**
+ * Stores the ID of the task currently displayed in the detail panel.
+ *
+ * @warning For read/write operations, prefer using `useDetailedTask()` hook
+ * which provides additional features:
+ * - Automatic data fetching via TanStack Query
+ * - Cache prefilling for instant detail view
+ * - Proper loading/error states
+ *
+ * Direct atom access is acceptable for:
+ * - Simple ID checks (e.g., "is detail panel open?")
+ *
+ * @example
+ * // ✅ Recommended - Full featured hook
+ * const { detailedTaskId, setDetailedTaskId, detailedTaskQuery } = useDetailedTask();
+ *
+ * // ✅ Acceptable - Simple panel state check
+ * const detailedTaskId = useAtomValue(detailedTaskIdState);
+ * const isDetailPanelOpen = !!detailedTaskId;
+ *
+ * @see useDetailedTask
+ */
+export const detailedTaskIdState = atom<string | null>(null);
 
 // export const employeeTasksState = atom<TTask[] | null>({
 // 	key: 'employeeTasksState',
 // 	default: null
 // });
 
+/**
+ * @deprecated Use `useSortedTasksByCreation()` hook instead.
+ * This atom is no longer in sync with TanStack Query cache.
+ *
+ * Migration:
+ * - Before: const tasks = useAtomValue(tasksByTeamState)
+ * - After:  const tasks = useSortedTasksByCreation()
+ *
+ * @see useSortedTasksByCreation
+ */
 export const tasksByTeamState = atom<TTask[]>((get) => {
 	const tasks = get(teamTasksState);
 


### PR DESCRIPTION
# Refactor useDailyPlan hook - Separate Read Operations from CUD Operations

## Description

This PR refactors the monolithic `useDailyPlan` hook into a modern, modular architecture following React Query best practices.

**Problem addressed:**
- The original `useDailyPlan` hook was a 500+ lines monolith handling queries, mutations, derived states, and side effects
- Poor separation of concerns made testing and maintenance difficult
- Components using the hook were re-rendering unnecessarily due to subscribing to unrelated state changes
- Manual cache management was error-prone and duplicated across the codebase

**Why these changes are useful:**
- **Performance**: Components now subscribe only to the data they need, reducing unnecessary re-renders
- **Testability**: Isolated hooks are easier to mock and unit test
- **Maintainability**: Single responsibility per hook makes debugging straightforward
- **Tree-shaking**: Only imported hooks are bundled, reducing bundle size
- **Caching**: React Query handles cache invalidation automatically with proper query keys

## What Was Changed

### Major Changes

- **New Query Hooks** (`apps/web/core/hooks/daily-plans/queries/`):
  - `useAllDailyPlansQuery` - Fetches all team daily plans
  - `useMyDailyPlansQuery` - Fetches current user's plans
  - `useEmployeeDailyPlansQuery` - Fetches plans for a specific employee
  - `usePlansByTaskLazyQuery` - Lazily fetches plans containing a specific task

- **New Mutation Hooks** (`apps/web/core/hooks/daily-plans/mutations/`):
  - `useCreateDailyPlanMutation` - Creates new daily plans
  - `useUpdateDailyPlanMutation` - Updates existing plans
  - `useAddTaskToPlanMutation` - Adds tasks to plans
  - `useRemoveTaskFromPlanMutation` - Removes single task from plan
  - `useRemoveTaskFromManyPlansMutation` - Removes task from multiple plans
  - `useDeleteDailyPlanMutation` - Deletes daily plans

- **New derivered Hooks** (`apps/web/core/hooks/daily-plans/derived/`):
  - `useProfileDailyPlans` - Manages employee-specific daily plans
  - `useTodayPlan` - Returns today's plan for an employee
  - `useFuturePlans` - Returns future scheduled plans
  - `usePastPlans` - Returns past plans
  - `useOutstandingPlans` - Returns plans with incomplete tasks past due date
  - `useSortedPlan` - Returns plans sorted by date

### Minor Changes

- Added barrel exports (`index.ts`) for clean imports
- Improved error handling consistency across hooks
- Original `useDailyPlans` hook marked as `@deprecated` with full backward compatibility
- Comprehensive JSDoc on every returned property indicating the replacement hook

## How to Test This PR

1. Run the app with `yarn start:web:dev`
2. Open the browser at `http://localhost:3030`
3. Navigate to the Daily Plan feature
4. Test the following scenarios:

**Backward Compatibility:**
- Existing features using `useDailyPlan` should work without changes
- Check that plans load correctly on page load
- Verify CRUD operations (create, update, delete plans)

**Cache Invalidation:**
- Create a new plan → List should update automatically
- Update a plan → Changes should reflect immediately
- Delete a plan → Plan should disappear from lists

## Screenshots (if needed)

> No UI changes - This is a refactoring PR focused on code architecture.

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

## Related Issues

> - Related to [ETP-222 - Refactor useDailyPlan - Separate Read Operations from CUD Operations](https://evertech.atlassian.net/browse/ETP-222)

## Type of Change

- [ ] Bug fix (fixes a problem)
- [x] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [x] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

- **Backward Compatibility**: The original `useDailyPlan` hook is fully preserved and functional. It now uses the new hooks internally but returns the same API.

## ⚠️⚠️⚠️ Reviewers Suggested

- `@evereq` for architecture validation
- `@ndekocode` for integration review


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the monolithic useDailyPlan into atomic query, mutation, and derived hooks using React Query, and migrated affected components to reduce re-renders and simplify testing. Addresses ETP-222 by cleanly separating read operations from CUD, with backward-compatible deprecation of useDailyPlan.

- **Refactors**
  - Split useDailyPlan into queries (e.g., useAllDailyPlansQuery, useEmployeeDailyPlansQuery, usePlansByTaskLazy), mutations (e.g., useCreateDailyPlanMutation, useUpdateDailyPlanMutation, useRemoveTaskFromPlanMutation), and derived hooks (e.g., useFuturePlans, usePastPlans, useProfileDailyPlans).
  - Updated daily plan UI and related task/team flows to new hooks (e.g., useCurrentTeam, useGetTaskByIdQueryLazy, useUpdateTaskMutation); removed manual cache logic.
  - Marked useDailyPlan as deprecated with a backward-compatible wrapper and JSDoc; improved error handling and added barrel exports.

- **Migration**
  - No UI changes. Existing features continue to work.
  - Prefer the new hooks and drop manual cache invalidation; components should subscribe only to the data they use.
  - useDailyPlan remains temporarily for compatibility; follow JSDoc to migrate to the new hooks.

<sup>Written for commit 798270b3b358fa77da45dab6e052126f9f377d86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

