### PR TITLE
Refactor: Separate useTeamTasks into more atomic Hooks

### DIFF
--- a/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
+++ b/apps/web/app/[locale]/(main)/(teams)/team/tasks/page.tsx
@@ -23,7 +23,8 @@ import { ETaskStatusName } from '@/core/types/generics/enums/task';
 import { ColumnDef } from '@tanstack/react-table';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { TeamTasksPageSkeleton } from '@/core/components/layouts/skeletons/team-tasks-page-skeleton';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState } from '@/core/stores';
+import { useSortedTasks } from '@/core/hooks';
 
 const TeamTask = () => {
 	const t = useTranslations();
@@ -41,7 +42,7 @@ const TeamTask = () => {
 		[activeTeam?.name, currentLocale, t]
 	);
 
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const [searchTaskTerm, setSearchTaskTerm] = useState('');
 	const filteredTasks = useMemo(
 		() => tasks.filter((el) => el.title.toLowerCase().includes(searchTaskTerm.toLowerCase())),

--- a/apps/web/core/components/features/daily-plan/add-task-estimation-hours-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/add-task-estimation-hours-modal.tsx
@@ -3,7 +3,7 @@ import { useMemo, useCallback, useState, useEffect, useRef, Dispatch, SetStateAc
 import { Modal, SpinnerLoader, Text } from '@/core/components';
 import { Button } from '@/core/components/duplicated-components/_button';
 import { useTranslations } from 'next-intl';
-import { useModal, useTeamTasks, useTimerView } from '@/core/hooks';
+import { useModal, useSortedTasks, useTeamTasks, useTimerView } from '@/core/hooks';
 import { useEmployeeDailyPlans } from '@/core/hooks/daily-plans/use-employee-daily-plans';
 import { useUpdateDailyPlan } from '@/core/hooks/daily-plans/use-update-daily-plan';
 import { useCreateDailyPlan } from '@/core/hooks/daily-plans/use-create-daily-plan';
@@ -31,7 +31,7 @@ import { ID } from '@/core/types/interfaces/common/base-interfaces';
 import { TDailyPlan } from '@/core/types/schemas/task/daily-plan.schema';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
-import { activeTeamTaskState, tasksByTeamState, taskStatusesState, timerStatusState } from '@/core/stores';
+import { activeTeamTaskState, taskStatusesState, timerStatusState } from '@/core/stores';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { EIssueType } from '@/core/types/generics/enums/task';
 
@@ -99,7 +99,7 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 		return plan?.tasks || propsTasks;
 	}, [plan?.tasks, propsTasks]);
 
-	const globalTasks = useAtomValue(tasksByTeamState);
+	const globalTasks = useSortedTasks();
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const timerStatus = useAtomValue(timerStatusState);
 	const { startTimer } = useTimerView();
@@ -672,7 +672,7 @@ export function SearchTaskInput(props: ISearchTaskInputProps) {
 		canEdit = true
 	} = props;
 
-	const teamTasks = useAtomValue(tasksByTeamState);
+	const teamTasks = useSortedTasks();
 	const { createTask } = useTeamTasks();
 	const taskStatuses = useAtomValue(taskStatusesState);
 	const [taskName, setTaskName] = useState('');

--- a/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
+++ b/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
@@ -19,7 +19,8 @@ import { TOrganizationTeam } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, activeTeamTaskState, organizationTeamsState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState, activeTeamTaskState, organizationTeamsState } from '@/core/stores';
+import { useSortedTasks } from '@/core/hooks';
 
 /**
  * Interface for the properties of the `AddManualTimeModal` component.
@@ -54,7 +55,7 @@ export function AddManualTimeModal(props: Readonly<IAddManualTimeModalProps>) {
 	const [timeDifference, setTimeDifference] = useState<string>('');
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const activeTeam = useAtomValue(activeTeamState);
 	const teams = useAtomValue(organizationTeamsState);
 	const { data: user } = useUserQuery();

--- a/apps/web/core/components/features/tasks/delete-status-confirmation-modal.tsx
+++ b/apps/web/core/components/features/tasks/delete-status-confirmation-modal.tsx
@@ -1,12 +1,10 @@
-import { useTaskStatus, useTeamTasks } from '@/core/hooks';
+import { useSortedTasks, useTaskStatus, useTeamTasks } from '@/core/hooks';
 import { Button, Modal, Text } from '@/core/components';
 import { useTranslations } from 'next-intl';
 import { useCallback, useMemo } from 'react';
 import { EverCard } from '../../common/ever-card';
 import { ETaskStatusName } from '@/core/types/generics/enums/task';
 import { TTaskStatus } from '@/core/types/schemas';
-import { useAtomValue } from 'jotai';
-import { tasksByTeamState } from '@/core/stores';
 
 interface DeleteTaskStatusModalProps {
 	open: boolean;
@@ -31,7 +29,7 @@ export function DeleteTaskStatusConfirmationModal(props: DeleteTaskStatusModalPr
 	const { deleteTaskStatus, deleteTaskStatusLoading, setTaskStatuses } = useTaskStatus();
 	const t = useTranslations();
 
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const { updateTask } = useTeamTasks();
 
 	// Filter tasks that are using the current status

--- a/apps/web/core/components/features/timesheet/add-mask-modal.tsx
+++ b/apps/web/core/components/features/timesheet/add-mask-modal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { TranslationHooks, useTranslations } from 'next-intl';
 import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components/teams/manage-member-component';
-import { useTimelogFilterOptions } from '@/core/hooks';
+import { useSortedTasks, useTimelogFilterOptions } from '@/core/hooks';
 import { clsxm } from '@/core/lib/utils';
 import { Modal } from '@/core/components';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/core/components/common/accordion';
@@ -22,7 +22,7 @@ import { ToggleButton } from '../tasks/edit-task-modal';
 import { DatePickerFilter } from '../../pages/timesheet/timesheet-filter-date';
 import { ETimeLogType, ETimeLogSource } from '@/core/types/generics/enums/timer';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState, organizationProjectsState } from '@/core/stores';
 
 export interface IAddTaskModalProps {
 	isOpen: boolean;
@@ -50,7 +50,7 @@ interface FormState {
 }
 
 export function AddTaskModal({ closeModal, isOpen }: IAddTaskModalProps) {
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const { generateTimeOptions } = useTimelogFilterOptions();
 	const organizationProjects = useAtomValue(organizationProjectsState);
 

--- a/apps/web/core/components/integration/calendar/time-sheet-filter-popover.tsx
+++ b/apps/web/core/components/integration/calendar/time-sheet-filter-popover.tsx
@@ -3,8 +3,9 @@ import { Modal } from '@/core/components';
 import { statusOptions } from '@/core/constants/config/constants';
 import { MultiSelect } from '@/core/components/common/multi-select';
 import { Input } from '@/core/components/common/input';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
+import { useSortedTasks } from '@/core/hooks';
 interface TimeSheetFilterProps {
 	isOpen: boolean;
 	closeModal: () => void;
@@ -13,7 +14,7 @@ interface TimeSheetFilterProps {
 export function TimeSheetFilter({ closeModal, isOpen }: TimeSheetFilterProps) {
 	const activeTeam = useAtomValue(activeTeamState);
 
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	// const [taskId, setTaskId] = useState<TTask | TTask[] | null>([]);
 	return (
 		<>

--- a/apps/web/core/components/layouts/app-sidebar.tsx
+++ b/apps/web/core/components/layouts/app-sidebar.tsx
@@ -25,7 +25,7 @@ import {
 import Link from 'next/link';
 import { cn } from '@/core/lib/helpers';
 import { isValidProjectForDisplay, projectBelongsToTeam, projectHasNoTeams } from '@/core/lib/helpers/type-guards';
-import { useFavorites, useModal } from '@/core/hooks';
+import { useFavorites, useModal, useSortedTasks } from '@/core/hooks';
 import { useTranslations } from 'next-intl';
 import { SidebarOptInForm } from './sidebar-opt-in-form';
 import { useMemo } from 'react';
@@ -43,7 +43,7 @@ import { EBaseEntityEnum } from '@/core/types/generics/enums/entity';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtomValue } from 'jotai';
 import { currentEmployeeFavoritesState } from '@/core/stores/common/favorites';
-import { activeTeamState, isTeamManagerState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState, isTeamManagerState, organizationProjectsState } from '@/core/stores';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { APP_NAME } from '@/core/constants/config/constants';
 import { GlobalAllPlansModal } from '../daily-plan';
@@ -57,7 +57,7 @@ export function AppSidebar({ publicTeam, ...props }: AppSidebarProps) {
 	const isTeamManager = useAtomValue(isTeamManagerState);
 	const { state } = useSidebar();
 	const currentEmployeeFavorites = useAtomValue(currentEmployeeFavoritesState);
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const { isOpen, closeModal } = useModal();
 	const t = useTranslations();
 	const organizationProjects = useAtomValue(organizationProjectsState);

--- a/apps/web/core/components/pages/task/child-issue-card.tsx
+++ b/apps/web/core/components/pages/task/child-issue-card.tsx
@@ -1,5 +1,5 @@
 import { Modal, SpinnerLoader, Text } from '@/core/components';
-import { IHookModal, useModal, useTeamTasks } from '@/core/hooks';
+import { IHookModal, useModal, useSortedTasks, useTeamTasks } from '@/core/hooks';
 import { useCallback, useState } from 'react';
 import { clsxm } from '@/core/lib/utils';
 import { ChevronDownIcon, ChevronUpIcon } from 'assets/svg';
@@ -11,8 +11,6 @@ import { EIssueType } from '@/core/types/generics/enums/task';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { FC } from 'react';
 import { useTranslations } from 'next-intl';
-import { tasksByTeamState } from '@/core/stores';
-import { useAtomValue } from 'jotai';
 
 export const ChildIssueCard: FC<{ task: TTask }> = ({ task }) => {
 	const t = useTranslations();
@@ -59,7 +57,7 @@ export const ChildIssueCard: FC<{ task: TTask }> = ({ task }) => {
 
 function CreateChildTask({ modal, task }: { modal: IHookModal; task: TTask }) {
 	const t = useTranslations();
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 
 	const { updateTask, loadTeamTasksData } = useTeamTasks();
 

--- a/apps/web/core/components/pages/task/issue-card.tsx
+++ b/apps/web/core/components/pages/task/issue-card.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { IHookModal, useModal, useQueryCall, useTeamTasks } from '@/core/hooks';
+import { IHookModal, useModal, useQueryCall, useSortedTasks, useTeamTasks } from '@/core/hooks';
 import { clsxm } from '@/core/lib/utils';
 import { Modal, SpinnerLoader, Text } from '@/core/components';
 import { ChevronDownIcon, ChevronUpIcon } from 'assets/svg';
@@ -15,7 +15,7 @@ import { TTask } from '@/core/types/schemas/task/task.schema';
 import { FC } from 'react';
 
 import { useAtomValue, useSetAtom } from 'jotai';
-import { detailedTaskState, tasksByTeamState } from '@/core/stores';
+import { detailedTaskState } from '@/core/stores';
 export const RelatedIssueCard: FC<{ task: TTask }> = ({ task }) => {
 	const t = useTranslations();
 	const modal = useModal();
@@ -97,7 +97,7 @@ export const RelatedIssueCard: FC<{ task: TTask }> = ({ task }) => {
 function CreateLinkedTask({ modal, task }: { modal: IHookModal; task: TTask }) {
 	const t = useTranslations();
 
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const detailedTask = useAtomValue(detailedTaskState);
 	const { loadTeamTasksData } = useTeamTasks();
 	const setDetailedTask = useSetAtom(detailedTaskState);

--- a/apps/web/core/components/pages/task/parent-task.tsx
+++ b/apps/web/core/components/pages/task/parent-task.tsx
@@ -1,4 +1,4 @@
-import { IHookModal, useTeamTasks } from '@/core/hooks';
+import { IHookModal, useSortedTasks, useTeamTasks } from '@/core/hooks';
 import { Modal, SpinnerLoader, Text } from '@/core/components';
 import cloneDeep from 'lodash/cloneDeep';
 import { useCallback, useState } from 'react';
@@ -7,12 +7,10 @@ import { EverCard } from '../../common/ever-card';
 import { TaskInput } from '../../tasks/task-input';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { toast } from 'sonner';
-import { useAtomValue } from 'jotai';
-import { tasksByTeamState } from '@/core/stores';
 function CreateParentTask({ modal, task }: { modal: IHookModal; task: TTask }) {
 	const t = useTranslations();
 
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const { loadTeamTasksData, updateTask } = useTeamTasks();
 
 	const [loading, setLoading] = useState(false);

--- a/apps/web/core/components/pages/time-and-activity/page-component.tsx
+++ b/apps/web/core/components/pages/time-and-activity/page-component.tsx
@@ -22,7 +22,8 @@ import {
 	LazyActivityTable,
 	LazyTimeActivityTable
 } from '@/core/components/optimized-components/reports';
-import { activeTeamState, isTrackingEnabledState, tasksByTeamState, organizationProjectsState } from '@/core/stores';
+import { activeTeamState, isTrackingEnabledState, organizationProjectsState } from '@/core/stores';
+import { useSortedTasks } from '@/core/hooks';
 
 const STORAGE_KEY = 'ever-teams-activity-view-options';
 
@@ -133,7 +134,7 @@ const TimeActivityComponents = () => {
 	const { userManagedTeams } = useOrganizationAndTeamManagers();
 	const organizationProjects = useAtomValue(organizationProjectsState);
 
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 	const activeTeam = useAtomValue(activeTeamState);
 

--- a/apps/web/core/components/pages/timesheet/timesheet-filter-popover.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-filter-popover.tsx
@@ -3,13 +3,13 @@ import { Button } from '@/core/components/duplicated-components/_button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/common/popover';
 import { SettingFilterIcon } from '@/assets/svg';
 import { useTranslations } from 'next-intl';
-import { useTimelogFilterOptions } from '@/core/hooks';
+import { useSortedTasks, useTimelogFilterOptions } from '@/core/hooks';
 import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
 import { cn } from '@/core/lib/helpers';
 import { statusTable } from '../../timesheet/timesheet-action';
 import { MultiSelect } from '../../common/multi-select';
 import { useAtomValue } from 'jotai';
-import { activeTeamState, organizationProjectsState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState, organizationProjectsState } from '@/core/stores';
 
 export const TimeSheetFilterPopover = React.memo(function TimeSheetFilterPopover() {
 	const [shouldRemoveItems, setShouldRemoveItems] = React.useState(false);
@@ -17,7 +17,7 @@ export const TimeSheetFilterPopover = React.memo(function TimeSheetFilterPopover
 	const activeTeam = useAtomValue(activeTeamState);
 
 	const organizationProjects = useAtomValue(organizationProjectsState);
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 
 	const t = useTranslations();
 	const { setEmployeeState, setProjectState, setStatusState, setTaskState, employee, project, statusState, task } =

--- a/apps/web/core/components/tasks/task-status.tsx
+++ b/apps/web/core/components/tasks/task-status.tsx
@@ -6,7 +6,7 @@ import { Nullable } from '@/core/types/generics/utils';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 // import { LoginIcon, RecordIcon } from 'lib/components/svgs';
 import { PropsWithChildren, useMemo } from 'react';
-import { useStatusValue, useTaskStatusValue } from '@/core/hooks';
+import { useSortedTasks, useStatusValue, useTaskStatusValue } from '@/core/hooks';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { readableColor } from 'polished';
 import { useTheme } from 'next-themes';
@@ -28,7 +28,7 @@ import { useMapToTaskStatusValues } from '@/core/hooks/tasks/use-map-to-task-sta
 import { useActiveTaskStatus } from '@/core/hooks/tasks/use-active-task-status';
 import { useTaskLabelsValue } from '@/core/hooks/tasks/use-task-labels-value';
 import { useAtomValue } from 'jotai';
-import { tasksByTeamState, taskSizesListState } from '@/core/stores';
+import { taskSizesListState } from '@/core/stores';
 
 /**
  * Task status dropwdown
@@ -237,7 +237,7 @@ export function EpicPropertiesDropdown({
 	children,
 	taskStatusClassName
 }: TTaskStatusesDropdown<'epic'>) {
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const status = useMemo(() => {
 		const temp: any = {};
 		tasks.forEach((task) => {

--- a/apps/web/core/components/tasks/task-statuses-form.tsx
+++ b/apps/web/core/components/tasks/task-statuses-form.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { useModal, useRefetchData, useTaskStatus } from '@/core/hooks';
-import { tasksByTeamState } from '@/core/stores';
+import { useModal, useRefetchData, useSortedTasks, useTaskStatus } from '@/core/hooks';
 import { clsxm } from '@/core/lib/utils';
 import { Spinner } from '@/core/components/common/spinner';
 import { PlusIcon } from '@heroicons/react/20/solid';
@@ -8,7 +7,6 @@ import { Button, ColorPicker, Modal, Text } from '@/core/components';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
-import { useAtomValue } from 'jotai';
 import { generateIconList, IIcon } from '../settings/icon-items';
 import IconPopover from '../settings/icon-popover';
 import { StatusesListCard } from '../settings/list-card';
@@ -140,7 +138,7 @@ export const TaskStatusesForm = ({ formOnly = false, onCreated }: StatusForm) =>
 		openModal: openDeleteConfirmationModal
 	} = useModal();
 	const [statusToDelete, setStatusToDelete] = useState<TTaskStatus | null>(null);
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 
 	/**
 	 * Get Icon by status name

--- a/apps/web/core/hooks/activities/use-timer.ts
+++ b/apps/web/core/hooks/activities/use-timer.ts
@@ -13,8 +13,7 @@ import {
 	activeTeamIdState,
 	activeTeamTaskState,
 	detailedTaskState,
-	activeTeamState,
-	teamTasksState
+	activeTeamState
 } from '@/core/stores';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
@@ -48,6 +47,7 @@ import {
 	STOP_TIMER_EFFECT_DEBOUNCE_MS,
 	SYNC_TIMER_INTERVAL
 } from '@/core/constants/config/constants';
+import { useCurrentTeamTasks } from '../tasks';
 
 /**
  * ! Don't modify this function unless you know what you're doing
@@ -195,7 +195,7 @@ export function useTimer() {
 	// Use useMyDailyPlans to get the logged-in user's plans (optimized for current user)
 	const { myDailyPlans } = useMyDailyPlans();
 
-	const teamTasks = useAtomValue(teamTasksState);
+	const { items: teamTasks } = useCurrentTeamTasks();
 
 	const [timerStatusFetching, setTimerStatusFetching] = useAtom(timerStatusFetchingState);
 

--- a/apps/web/core/hooks/daily-plans/use-employee-daily-plans.ts
+++ b/apps/web/core/hooks/daily-plans/use-employee-daily-plans.ts
@@ -2,13 +2,14 @@
 
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useState } from 'react';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState } from '@/core/stores';
 import { dailyPlanService } from '../../services/client/api';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/core/query/keys';
 import { useDailyPlanCalculations } from './use-daily-plan-calculations';
 import { toast } from 'sonner';
 import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { useSortedTasks } from '../tasks';
 
 export interface UseEmployeeDailyPlansOptions {
 	/**
@@ -50,7 +51,7 @@ export interface UseEmployeeDailyPlansOptions {
  */
 export function useEmployeeDailyPlans(employeeId: string | null, options?: UseEmployeeDailyPlansOptions) {
 	const activeTeam = useAtomValue(activeTeamState);
-	const allTeamTasks = useAtomValue(tasksByTeamState);
+	const allTeamTasks = useSortedTasks();
 	const queryClient = useQueryClient();
 	const [internalEmployeeId, setInternalEmployeeId] = useState(employeeId || '');
 

--- a/apps/web/core/hooks/daily-plans/use-my-daily-plans.ts
+++ b/apps/web/core/hooks/daily-plans/use-my-daily-plans.ts
@@ -2,12 +2,13 @@
 
 import { useAtomValue } from 'jotai';
 import { useCallback } from 'react';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState } from '@/core/stores';
 import { dailyPlanService } from '../../services/client/api';
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/core/query/keys';
 import { useUserQuery } from '../queries/user-user.query';
 import { useDailyPlanCalculations } from './use-daily-plan-calculations';
+import { useSortedTasks } from '../tasks';
 
 export interface UseMyDailyPlansOptions {
 	/**
@@ -46,7 +47,7 @@ export interface UseMyDailyPlansOptions {
 export function useMyDailyPlans(options?: UseMyDailyPlansOptions) {
 	const { data: user } = useUserQuery();
 	const activeTeam = useAtomValue(activeTeamState);
-	const allTeamTasks = useAtomValue(tasksByTeamState);
+	const allTeamTasks = useSortedTasks();
 
 	// Extract options with defaults
 	const { enabled = true } = options || {};

--- a/apps/web/core/hooks/organizations/teams/use-auth-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-auth-team-tasks.ts
@@ -1,14 +1,15 @@
 import { useEmployeeDailyPlans } from '@/core/hooks/daily-plans/use-employee-daily-plans';
-import { activeTeamState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState } from '@/core/stores';
 import { useMemo } from 'react';
 import { useAtomValue } from 'jotai';
 import { getTotalTasks } from '@/core/components/tasks/daily-plan';
 import { TUser } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
+import { useSortedTasks } from '../../tasks';
 
 export function useAuthTeamTasks(user: TUser | undefined) {
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const { data: authenticatedUser } = useUserQuery();
 
 	const activeTeam = useAtomValue(activeTeamState);

--- a/apps/web/core/hooks/organizations/teams/use-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-tasks.ts
@@ -6,34 +6,37 @@ import {
 	setActiveTaskIdCookie,
 	setActiveUserTaskCookie
 } from '@/core/lib/helpers/index';
-import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
-import { taskService } from '@/core/services/client/api';
+import { logErrorInDev } from '@/core/lib/helpers/error-message';
 import {
 	activeTeamState,
 	activeTeamTaskId,
 	detailedTaskState,
-	memberActiveTaskIdState,
 	activeTeamTaskState,
 	teamTasksState,
 	taskStatusesState
 } from '@/core/stores';
 import isEqual from 'lodash/isEqual';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useOrganizationEmployeeTeams } from './use-organization-teams-employee';
 import { useAuthenticateUser } from '../../auth';
-import { useFirstLoad, useConditionalUpdateEffect, useSyncRef, useQueryCall } from '../../common';
+import { useFirstLoad, useConditionalUpdateEffect, useSyncRef } from '../../common';
 import { ITaskStatusField } from '@/core/types/interfaces/task/task-status/task-status-field';
 import { ITaskStatusStack } from '@/core/types/interfaces/task/task-status/task-status-stack';
-import { ETaskStatusName, TEmployee, TOrganizationTeamEmployee, TTag } from '@/core/types/schemas';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '@/core/query/keys';
+import { ETaskStatusName, TEmployee, TTag } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { PaginationResponse } from '@/core/types/interfaces/common/data-response';
 import { useUserQuery } from '../../queries/user-user.query';
 import { EIssueType, ETaskPriority, ETaskSize } from '@/core/types/generics/enums/task';
-import { toast } from 'sonner';
-import { useSortedTasks } from '../../tasks';
+import {
+	useCreateTaskMutation,
+	useDeleteEmployeeFromTaskMutation,
+	useDeleteTaskMutation,
+	useGetCurrentTeamTasksQuery,
+	useGetTaskByEmployeeQuery,
+	useGetTaskByIdLazyQuery,
+	useSortedTasks,
+	useUpdateTaskMutation
+} from '../../tasks';
+import { useSetActiveTask } from '../../tasks/utils/use-set-active-task';
 
 /**
  * A React hook that provides functionality for managing team tasks, including creating, updating, deleting, and fetching tasks.
@@ -69,9 +72,7 @@ import { useSortedTasks } from '../../tasks';
  */
 
 export function useTeamTasks() {
-	const { updateOrganizationTeamEmployeeActiveTask } = useOrganizationEmployeeTeams();
-	const { user, $user } = useAuthenticateUser();
-	const queryClient = useQueryClient();
+	const { user } = useAuthenticateUser();
 
 	const setAllTasks = useSetAtom(teamTasksState);
 	const tasks = useSortedTasks();
@@ -80,125 +81,30 @@ export function useTeamTasks() {
 	const { data: userData } = useUserQuery();
 	const authUser = useSyncRef(userData);
 	const setActive = useSetAtom(activeTeamTaskId);
-	const memberActiveTaskId = useAtomValue(memberActiveTaskIdState);
-	const $memberActiveTaskId = useSyncRef(memberActiveTaskId);
 	const taskStatuses = useAtomValue(taskStatusesState);
 	const activeTeam = useAtomValue(activeTeamState);
 	const activeTeamRef = useSyncRef(activeTeam);
 	const [selectedEmployeeId, setSelectedEmployeeId] = useState(user?.employee?.id);
-	const [selectedOrganizationTeamId, setSelectedOrganizationTeamId] = useState(activeTeam?.id);
+	const [, setSelectedOrganizationTeamId] = useState(activeTeam?.id);
 	const [activeTeamTask, setActiveTeamTask] = useAtom(activeTeamTaskState);
-	const [isUpdatingActiveTask, setIsUpdatingActiveTask] = useState(false);
 
-	// Keep activeTeamTask in sync with a ref to avoid stale closures in setActiveTask
-	const activeTeamTaskRef = useSyncRef(activeTeamTask);
-
-	// Track expected task ID to prevent stale server data from overwriting local selection.
-	// When user selects a task, we store its ID here. The sync effect will skip updates
-	// until server data matches this expected ID (confirming our selection was persisted).
-	const expectedActiveTaskIdRef = useRef<string | null>(null);
 	const { firstLoad, firstLoadData: firstLoadTasksData } = useFirstLoad();
 
 	// React Query for team tasks
-	const teamTasksQuery = useQuery({
-		queryKey: queryKeys.tasks.byTeam(activeTeam?.id),
-		queryFn: async () => {
-			if (!activeTeam?.id) {
-				throw new Error('Required parameters missing');
-			}
-			const projectId = activeTeam?.projects && activeTeam?.projects.length > 0 ? activeTeam.projects[0].id : '';
-			return await taskService.getTasks({ projectId });
-		},
-		enabled: !!activeTeam?.id,
-		gcTime: 1000 * 60 * 60
-	});
+	const teamTasksQuery = useGetCurrentTeamTasksQuery();
 
-	const { queryCall: getTaskByIdQuery, loading: getTasksByIdLoading } = useQueryCall(async (taskId: string) =>
-		queryClient.fetchQuery({
-			queryKey: queryKeys.tasks.detail(taskId),
-			queryFn: async () => {
-				if (!taskId) {
-					throw new Error('Task ID is required');
-				}
-				return await taskService.getTaskById(taskId);
-			}
-		})
-	);
+	const { getTaskById: getTaskByIdQuery, isPending: getTasksByIdLoading } = useGetTaskByIdLazyQuery();
 
-	const getTasksByEmployeeIdQuery = useQuery({
-		queryKey: queryKeys.tasks.byEmployee(selectedEmployeeId, selectedOrganizationTeamId),
-		queryFn: async () => {
-			if (!activeTeam?.id) {
-				throw new Error('Required parameters missing');
-			}
-			return await taskService.getTasksByEmployeeId({ employeeId: selectedEmployeeId! });
-		},
-		enabled: !!selectedEmployeeId && !!activeTeam?.id && !!selectedOrganizationTeamId,
-		gcTime: 1000 * 60 * 60
-	});
+	const getTasksByEmployeeIdQuery = useGetTaskByEmployeeQuery(selectedEmployeeId);
 
 	// Mutations
-	const createTaskMutation = useMutation({
-		mutationFn: async (taskData: Parameters<typeof taskService.createTask>[0]) => {
-			return await taskService.createTask(taskData);
-		},
-		onSuccess: () => {
-			invalidateTeamTasksData();
-		}
-	});
+	const createTaskMutation = useCreateTaskMutation();
 
-	const updateTaskMutation = useMutation({
-		mutationFn: async ({ taskId, taskData }: { taskId: string; taskData: Partial<TTask> }) => {
-			return await taskService.updateTask({ taskId, data: taskData });
-		},
-		onSuccess: (updatedTask, { taskId }) => {
-			queryClient.setQueryData(queryKeys.tasks.byTeam(activeTeam?.id), (oldTasks: PaginationResponse<TTask>) => {
-				if (!oldTasks) return oldTasks;
+	const updateTaskMutation = useUpdateTaskMutation();
 
-				const updatedItems = oldTasks?.items?.map((task) =>
-					task.id === taskId ? { ...task, ...updatedTask } : task
-				);
+	const deleteTaskMutation = useDeleteTaskMutation();
 
-				// Sync the tasks store
-				setAllTasks(updatedItems);
-
-				return updatedItems ? { items: updatedItems, total: updatedItems.length } : oldTasks;
-			});
-			// Invalidate both tasks and daily plans to ensure UI synchronization
-			invalidateTeamTasksData();
-		}
-	});
-
-	const deleteTaskMutation = useMutation({
-		mutationFn: async (taskId: string) => {
-			return await taskService.deleteTask(taskId);
-		},
-		onSuccess: () => {
-			invalidateTeamTasksData();
-		}
-	});
-
-	const deleteEmployeeFromTasksMutation = useMutation({
-		mutationFn: async (employeeId: string) => {
-			return await taskService.deleteEmployeeFromTasks(employeeId);
-		},
-		onSuccess: () => {
-			invalidateTeamTasksData();
-		}
-	});
-
-	// Invalidation function
-	const invalidateTeamTasksData = useCallback(() => {
-		queryClient.invalidateQueries({
-			queryKey: queryKeys.tasks.all
-		});
-		queryClient.invalidateQueries({
-			queryKey: queryKeys.tasks.byTeam(activeTeam?.id)
-		});
-		queryClient.invalidateQueries({
-			queryKey: queryKeys.dailyPlans.all
-		});
-	}, [activeTeam?.id, queryClient]);
+	const deleteEmployeeFromTasksMutation = useDeleteEmployeeFromTaskMutation();
 
 	// Deep update function
 	const deepCheckAndUpdateTasks = useCallback(
@@ -294,23 +200,6 @@ export function useTeamTasks() {
 			}
 		},
 		[teamTasksQuery, deepCheckAndUpdateTasks, user, activeTeamRef]
-	);
-
-	const setActiveUserTaskCookieCb = useCallback(
-		(task: TTask | null) => {
-			if (task?.id && authUser.current?.id) {
-				setActiveUserTaskCookie({
-					taskId: task?.id,
-					userId: authUser.current?.id
-				});
-			} else {
-				setActiveUserTaskCookie({
-					taskId: '',
-					userId: ''
-				});
-			}
-		},
-		[authUser]
 	);
 
 	const deleteTask = useCallback(
@@ -517,125 +406,7 @@ export function useTeamTasks() {
 	/**
 	 * Change active task
 	 */
-	const setActiveTask = useCallback(
-		async (task: TTask | null) => {
-			// Set flag to prevent race conditions with server sync
-			setIsUpdatingActiveTask(true);
-
-			try {
-				/**
-				 * Unassign previous active task
-				 */
-				if ($memberActiveTaskId.current && $user.current) {
-					const _task = tasksRef.current.find((t) => t.id === $memberActiveTaskId.current);
-
-					if (_task) {
-						await updateTask({
-							..._task,
-							members: _task.members?.filter((m) => m.id !== $user.current?.employee?.id)
-						});
-					}
-				}
-
-				// Use ref to get current activeTeamTask to avoid stale closure
-				const previousTask = activeTeamTaskRef.current;
-				const previousTaskId = getActiveTaskIdCookie();
-
-				// Set expected task ID BEFORE updating state/cookies.
-				// This prevents the sync effect from overwriting with stale server data.
-				expectedActiveTaskIdRef.current = task?.id || null;
-
-				setActiveTaskIdCookie(task?.id || '');
-				setActiveTeamTask(task);
-				setActiveUserTaskCookieCb(task);
-
-				if (task) {
-					/**
-					 * Sync active task to server for multi-device support.
-					 * Cookies are already set above, so local persistence works even if API fails.
-					 * Retry up to 3 times because activeTeam.members may not be loaded yet on first render.
-					 */
-					const MAX_RETRIES = 3;
-					const RETRY_DELAY_MS = 500;
-
-					try {
-						let success = false;
-
-						// Use activeTeamRef.current to get fresh values on each retry attempt.
-						// Using activeTeam directly would capture the stale closure value.
-						for (let attempt = 1; attempt <= MAX_RETRIES && !success; attempt++) {
-							const currentEmployeeDetails = activeTeamRef.current?.members?.find(
-								(member: TOrganizationTeamEmployee) =>
-									member.employeeId === authUser.current?.employee?.id
-							);
-
-							if (currentEmployeeDetails?.id) {
-								await updateOrganizationTeamEmployeeActiveTask(currentEmployeeDetails.id, {
-									organizationId: task.organizationId,
-									activeTaskId: task.id,
-									organizationTeamId: activeTeamRef.current?.id,
-									tenantId: activeTeamRef.current?.tenantId ?? ''
-								});
-								success = true;
-							} else if (attempt < MAX_RETRIES) {
-								await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-							}
-						}
-
-						if (!success) {
-							// All retries exhausted - members may not be loaded yet.
-							// Local state (cookies + Jotai) is already persisted, only server sync failed.
-							logErrorInDev(
-								'[setActiveTask] Failed to sync after retries - members may not be loaded',
-								null
-							);
-							// Clear expected ID to allow server sync to resume
-							expectedActiveTaskIdRef.current = null;
-						}
-
-						if (success) {
-							toast.success('Active task updated', {
-								description: `"${task.title}" is now your active task`
-							});
-
-							// Short delay to let React Query stabilize before clearing isUpdatingActiveTask.
-							// The expectedActiveTaskIdRef provides the main protection against stale data,
-							// this delay is just an extra safety buffer for edge cases.
-							// NOTE: Do NOT invalidate queries here - updateActiveTaskMutation already handles it.
-							await new Promise((resolve) => setTimeout(resolve, 600));
-							// Clear expectation on success - server will confirm via sync effect
-							expectedActiveTaskIdRef.current = null;
-						}
-					} catch (error) {
-						logErrorInDev('[setActiveTask] API call failed:', error);
-						toast.error('Failed to update active task', {
-							description: getErrorMessage(error)
-						});
-						// Rollback: restore previous state and clear expected ID
-						expectedActiveTaskIdRef.current = previousTaskId || null;
-						setActiveTaskIdCookie(previousTaskId || '');
-						setActiveTeamTask(previousTask);
-						setActiveUserTaskCookieCb(previousTask);
-					}
-				}
-			} finally {
-				// Always clear the flag, even if an error occurred
-				setIsUpdatingActiveTask(false);
-			}
-		},
-		[
-			setActiveTeamTask,
-			setActiveUserTaskCookieCb,
-			updateOrganizationTeamEmployeeActiveTask,
-			activeTeam,
-			authUser,
-			$memberActiveTaskId,
-			$user,
-			tasksRef,
-			updateTask,
-			setIsUpdatingActiveTask
-		]
-	);
+	const { setActiveTask, isUpdatingActiveTask } = useSetActiveTask();
 
 	const deleteEmployeeFromTasks = useCallback(
 		async (employeeId: string) => {
@@ -653,35 +424,6 @@ export function useTeamTasks() {
 		setActiveTaskIdCookie('');
 		setActiveTeamTask(null);
 	}, [setActiveTeamTask]);
-
-	useConditionalUpdateEffect(
-		() => {
-			// Skip if we're currently updating the active task
-			if (isUpdatingActiveTask) {
-				return;
-			}
-
-			// If we have an expected task ID (user just selected a task locally):
-			// - If server data matches → clear expectation, no need to update (already correct)
-			// - If server data differs → skip update (server has stale data, wait for it to sync)
-			if (expectedActiveTaskIdRef.current) {
-				if (memberActiveTaskId === expectedActiveTaskIdRef.current) {
-					// Server confirmed our selection
-					expectedActiveTaskIdRef.current = null;
-				}
-				// Either way, skip - local state is already correct
-				return;
-			}
-
-			// No local expectation - sync from server (multi-device sync or initial load)
-			const memberActiveTask = tasks.find((item) => item.id === memberActiveTaskId);
-			if (memberActiveTask) {
-				setActiveTeamTask(memberActiveTask);
-			}
-		},
-		[activeTeam, tasks, memberActiveTaskId, isUpdatingActiveTask],
-		Boolean(activeTeamTask)
-	);
 
 	// Reload tasks after active team changed
 	useConditionalUpdateEffect(
@@ -712,15 +454,6 @@ export function useTeamTasks() {
 	);
 
 	// Sync React Query data with Jotai state
-	useConditionalUpdateEffect(
-		() => {
-			if (teamTasksQuery.data?.items) {
-				deepCheckAndUpdateTasks(teamTasksQuery.data.items, true);
-			}
-		},
-		[teamTasksQuery.data?.items],
-		Boolean(tasks?.length)
-	);
 
 	return {
 		tasks,

--- a/apps/web/core/hooks/organizations/teams/use-team-tasks.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-tasks.ts
@@ -14,7 +14,6 @@ import {
 	detailedTaskState,
 	memberActiveTaskIdState,
 	activeTeamTaskState,
-	tasksByTeamState,
 	teamTasksState,
 	taskStatusesState
 } from '@/core/stores';
@@ -34,6 +33,7 @@ import { PaginationResponse } from '@/core/types/interfaces/common/data-response
 import { useUserQuery } from '../../queries/user-user.query';
 import { EIssueType, ETaskPriority, ETaskSize } from '@/core/types/generics/enums/task';
 import { toast } from 'sonner';
+import { useSortedTasks } from '../../tasks';
 
 /**
  * A React hook that provides functionality for managing team tasks, including creating, updating, deleting, and fetching tasks.
@@ -74,7 +74,7 @@ export function useTeamTasks() {
 	const queryClient = useQueryClient();
 
 	const setAllTasks = useSetAtom(teamTasksState);
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const [detailedTask, setDetailedTask] = useAtom(detailedTaskState);
 	const tasksRef = useSyncRef(tasks);
 	const { data: userData } = useUserQuery();

--- a/apps/web/core/hooks/tasks/constants/TASK_QUERY_GC_TIME.ts
+++ b/apps/web/core/hooks/tasks/constants/TASK_QUERY_GC_TIME.ts
@@ -1,0 +1,4 @@
+/**
+ * 1 hours
+ */
+export const TASK_QUERY_GC_TIME_HOUR = 3_600_000 as const;

--- a/apps/web/core/hooks/tasks/derived/use-current-team-tasks.ts
+++ b/apps/web/core/hooks/tasks/derived/use-current-team-tasks.ts
@@ -3,6 +3,11 @@ import { useGetCurrentTeamTasksQuery } from '../queries/use-get-tasks-by-team.qu
 import moment from 'moment';
 
 const defaultValue = { items: [], total: 0 };
+/**
+ * Returns current team tasks from global Jotai store.
+ *
+ * @returns {{ tasks: TTask[] }}
+ */
 export const useCurrentTeamTasks = () => {
 	const { data: tasksResponse = defaultValue } = useGetCurrentTeamTasksQuery();
 
@@ -12,7 +17,11 @@ export const useCurrentTeamTasks = () => {
 type SortableTaskField = 'createdAt' | 'updatedAt' | 'dueDate';
 type SortOrder = 'asc' | 'desc';
 
-// tasksByTeamState
+/**
+ * Returns tasks sorted alphabetically by title.
+ *
+ * @returns {{ sortedTasks: TTask[] }}
+ */
 export const useSortedTasks = (field: SortableTaskField = 'createdAt', order: SortOrder = 'desc') => {
 	const { items: tasks } = useCurrentTeamTasks();
 

--- a/apps/web/core/hooks/tasks/derived/use-current-team-tasks.ts
+++ b/apps/web/core/hooks/tasks/derived/use-current-team-tasks.ts
@@ -12,6 +12,7 @@ export const useCurrentTeamTasks = () => {
 type SortableTaskField = 'createdAt' | 'updatedAt' | 'dueDate';
 type SortOrder = 'asc' | 'desc';
 
+// tasksByTeamState
 export const useSortedTasks = (field: SortableTaskField = 'createdAt', order: SortOrder = 'desc') => {
 	const { items: tasks } = useCurrentTeamTasks();
 

--- a/apps/web/core/hooks/tasks/derived/use-current-team-tasks.ts
+++ b/apps/web/core/hooks/tasks/derived/use-current-team-tasks.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { useGetCurrentTeamTasksQuery } from '../queries/use-get-tasks-by-team.query';
+import moment from 'moment';
+
+const defaultValue = { items: [], total: 0 };
+export const useCurrentTeamTasks = () => {
+	const { data: tasksResponse = defaultValue } = useGetCurrentTeamTasksQuery();
+
+	return { ...tasksResponse };
+};
+
+type SortableTaskField = 'createdAt' | 'updatedAt' | 'dueDate';
+type SortOrder = 'asc' | 'desc';
+
+export const useSortedTasks = (field: SortableTaskField = 'createdAt', order: SortOrder = 'desc') => {
+	const { items: tasks } = useCurrentTeamTasks();
+
+	const sortedTasks = useMemo(() => {
+		const multiplier = order === 'desc' ? 1 : -1;
+
+		return [...(tasks ?? [])].sort((a, b) => {
+			const dateA = a[field];
+			const dateB = b[field];
+
+			// Handle null/undefined dates (push them to the end)
+			if (!dateA && !dateB) return 0;
+			if (!dateA) return 1;
+			if (!dateB) return -1;
+
+			return multiplier * moment(dateB).diff(moment(dateA));
+		});
+	}, [tasks, field, order]);
+
+	return sortedTasks;
+};

--- a/apps/web/core/hooks/tasks/index.ts
+++ b/apps/web/core/hooks/tasks/index.ts
@@ -13,3 +13,14 @@ export * from './use-task-sizes';
 export * from './use-task-statistics';
 export * from './use-task-status';
 export * from './use-task-version';
+
+export * from './derived/use-current-team-tasks';
+
+export * from './mutations/use-create-task.mutation';
+export * from './mutations/use-delete-employee-from-task.mutation';
+export * from './mutations/use-delete-task.mutation';
+export * from './mutations/use-update-task.mutation';
+
+export * from './queries/use-get-tasks-by-employee.query';
+export * from './queries/use-get-tasks-by-id.query';
+export * from './queries/use-get-tasks-by-team.query';

--- a/apps/web/core/hooks/tasks/mutations/use-create-task.mutation.ts
+++ b/apps/web/core/hooks/tasks/mutations/use-create-task.mutation.ts
@@ -2,6 +2,12 @@ import { taskService } from '@/core/services/client/api';
 import { useMutation } from '@tanstack/react-query';
 import { useInvalidateTeamTasksData } from '../utils/use-invalidate-task-data';
 
+/**
+ * Creates a new task for the current active team.
+ * Automatically invalidates team tasks cache on success.
+ *
+ * @returns Mutation object with mutateAsync({ title, issueType, status, ... })
+ */
 export const useCreateTaskMutation = () => {
 	const invalidateTeamTasksData = useInvalidateTeamTasksData();
 

--- a/apps/web/core/hooks/tasks/mutations/use-create-task.mutation.ts
+++ b/apps/web/core/hooks/tasks/mutations/use-create-task.mutation.ts
@@ -1,0 +1,18 @@
+import { taskService } from '@/core/services/client/api';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateTeamTasksData } from '../utils/use-invalidate-task-data';
+
+export const useCreateTaskMutation = () => {
+	const invalidateTeamTasksData = useInvalidateTeamTasksData();
+
+	const createTaskMutation = useMutation({
+		mutationFn: async (taskData: Parameters<typeof taskService.createTask>[0]) => {
+			return await taskService.createTask(taskData);
+		},
+		onSuccess: () => {
+			invalidateTeamTasksData();
+		}
+	});
+
+	return createTaskMutation;
+};

--- a/apps/web/core/hooks/tasks/mutations/use-delete-employee-from-task.mutation.ts
+++ b/apps/web/core/hooks/tasks/mutations/use-delete-employee-from-task.mutation.ts
@@ -2,6 +2,12 @@ import { taskService } from '@/core/services/client/api';
 import { useMutation } from '@tanstack/react-query';
 import { useInvalidateTeamTasksData } from '../utils/use-invalidate-task-data';
 
+/**
+ * Removes an employee from all their assigned tasks.
+ * Useful when removing a team member.
+ *
+ * @returns Mutation object with mutateAsync(employeeId)
+ */
 export const useDeleteEmployeeFromTaskMutation = () => {
 	const invalidateTeamTasksData = useInvalidateTeamTasksData();
 

--- a/apps/web/core/hooks/tasks/mutations/use-delete-employee-from-task.mutation.ts
+++ b/apps/web/core/hooks/tasks/mutations/use-delete-employee-from-task.mutation.ts
@@ -1,0 +1,18 @@
+import { taskService } from '@/core/services/client/api';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateTeamTasksData } from '../utils/use-invalidate-task-data';
+
+export const useDeleteEmployeeFromTaskMutation = () => {
+	const invalidateTeamTasksData = useInvalidateTeamTasksData();
+
+	const deleteEmployeeFromTasksMutation = useMutation({
+		mutationFn: async (employeeId: string) => {
+			return await taskService.deleteEmployeeFromTasks(employeeId);
+		},
+		onSuccess: () => {
+			invalidateTeamTasksData();
+		}
+	});
+
+	return deleteEmployeeFromTasksMutation;
+};

--- a/apps/web/core/hooks/tasks/mutations/use-delete-task.mutation.ts
+++ b/apps/web/core/hooks/tasks/mutations/use-delete-task.mutation.ts
@@ -1,0 +1,18 @@
+import { taskService } from '@/core/services/client/api';
+import { useMutation } from '@tanstack/react-query';
+import { useInvalidateTeamTasksData } from '../utils/use-invalidate-task-data';
+
+export const useDeleteTaskMutation = () => {
+	const invalidateTeamTasksData = useInvalidateTeamTasksData();
+
+	const deleteTaskMutation = useMutation({
+		mutationFn: async (taskId: string) => {
+			return await taskService.deleteTask(taskId);
+		},
+		onSuccess: () => {
+			invalidateTeamTasksData();
+		}
+	});
+
+	return deleteTaskMutation;
+};

--- a/apps/web/core/hooks/tasks/mutations/use-delete-task.mutation.ts
+++ b/apps/web/core/hooks/tasks/mutations/use-delete-task.mutation.ts
@@ -2,6 +2,12 @@ import { taskService } from '@/core/services/client/api';
 import { useMutation } from '@tanstack/react-query';
 import { useInvalidateTeamTasksData } from '../utils/use-invalidate-task-data';
 
+/**
+ * Deletes a task by ID.
+ * Invalidates team tasks cache on success.
+ *
+ * @returns Mutation object with mutateAsync(taskId)
+ */
 export const useDeleteTaskMutation = () => {
 	const invalidateTeamTasksData = useInvalidateTeamTasksData();
 

--- a/apps/web/core/hooks/tasks/mutations/use-update-task.mutation.ts
+++ b/apps/web/core/hooks/tasks/mutations/use-update-task.mutation.ts
@@ -7,6 +7,12 @@ import { activeTeamState, teamTasksState } from '@/core/stores';
 import { PaginationResponse } from '@/core/types/interfaces/common/data-response';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 
+/**
+ * Updates an existing task by ID.
+ * Invalidates team tasks cache on success.
+ *
+ * @returns Mutation object with mutateAsync({ taskId, taskData })
+ */
 export const useUpdateTaskMutation = () => {
 	const invalidateTeamTasksData = useInvalidateTeamTasksData();
 	const queryClient = useQueryClient();

--- a/apps/web/core/hooks/tasks/mutations/use-update-task.mutation.ts
+++ b/apps/web/core/hooks/tasks/mutations/use-update-task.mutation.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useInvalidateTeamTasksData } from '../utils/use-invalidate-task-data';
+import { taskService } from '@/core/services/client/api';
+import { queryKeys } from '@/core/query/keys';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { activeTeamState, teamTasksState } from '@/core/stores';
+import { PaginationResponse } from '@/core/types/interfaces/common/data-response';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+
+export const useUpdateTaskMutation = () => {
+	const invalidateTeamTasksData = useInvalidateTeamTasksData();
+	const queryClient = useQueryClient();
+
+	const activeTeam = useAtomValue(activeTeamState);
+	const setAllTasks = useSetAtom(teamTasksState);
+
+	const updateTaskMutation = useMutation({
+		mutationFn: async ({ taskId, taskData }: { taskId: string; taskData: Partial<TTask> }) => {
+			return await taskService.updateTask({ taskId, data: taskData });
+		},
+		onSuccess: (updatedTask, { taskId }) => {
+			queryClient.setQueryData(queryKeys.tasks.byTeam(activeTeam?.id), (oldTasks: PaginationResponse<TTask>) => {
+				if (!oldTasks) return oldTasks;
+
+				const updatedItems = oldTasks?.items?.map((task) =>
+					task.id === taskId ? { ...task, ...updatedTask } : task
+				);
+
+				// Sync the tasks store
+				setAllTasks(updatedItems);
+
+				return updatedItems ? { items: updatedItems, total: updatedItems.length } : oldTasks;
+			});
+			// Invalidate both tasks and daily plans to ensure UI synchronization
+			invalidateTeamTasksData();
+		}
+	});
+
+	return updateTaskMutation;
+};

--- a/apps/web/core/hooks/tasks/queries/use-get-tasks-by-employee.query.ts
+++ b/apps/web/core/hooks/tasks/queries/use-get-tasks-by-employee.query.ts
@@ -7,6 +7,13 @@ import { TASK_QUERY_GC_TIME_HOUR } from '../constants/TASK_QUERY_GC_TIME';
 import { taskService } from '@/core/services/client/api';
 import { useLazyQueryState } from '../utils/use-lazy-query';
 
+/**
+ * Fetches all tasks assigned to a specific employee within a team.
+ *
+ * @param employeeId - Employee ID (optional, disables query if undefined)
+ * @param organizationTeamId - Team ID (optional, falls back to active team)
+ * @returns Query result with employee's tasks
+ */
 export const useGetTaskByEmployeeQuery = (employeeId: string) => {
 	const activeTeam = useAtomValue(activeTeamState);
 	const _teamId = useMemo(() => activeTeam?.id, [activeTeam?.id]);
@@ -24,6 +31,13 @@ export const useGetTaskByEmployeeQuery = (employeeId: string) => {
 	return query;
 };
 
+/**
+ * Lazy version - fetches employee tasks only when triggered.
+ *
+ * @param employeeId - Employee ID
+ * @param organizationTeamId - Team ID
+ * @returns Query result with manual refetch control
+ */
 export const useGetTaskByEmployeeLazyQuery = () => {
 	const activeTeam = useAtomValue(activeTeamState);
 

--- a/apps/web/core/hooks/tasks/queries/use-get-tasks-by-employee.query.ts
+++ b/apps/web/core/hooks/tasks/queries/use-get-tasks-by-employee.query.ts
@@ -1,0 +1,50 @@
+import { queryKeys } from '@/core/query/keys';
+import { activeTeamState } from '@/core/stores';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
+import { useMemo } from 'react';
+import { TASK_QUERY_GC_TIME_HOUR } from '../constants/TASK_QUERY_GC_TIME';
+import { taskService } from '@/core/services/client/api';
+import { useLazyQueryState } from '../utils/use-lazy-query';
+
+export const useGetTaskByEmployeeQuery = (employeeId: string) => {
+	const activeTeam = useAtomValue(activeTeamState);
+	const _teamId = useMemo(() => activeTeam?.id, [activeTeam?.id]);
+
+	const query = useQuery({
+		queryKey: queryKeys.tasks.byEmployee(employeeId, _teamId),
+		queryFn: async () => {
+			if (!_teamId) throw new Error('Team ID is Required');
+			if (!employeeId) throw new Error('Employee ID is Required');
+
+			return await taskService.getTasksByEmployeeId({ employeeId });
+		},
+		gcTime: TASK_QUERY_GC_TIME_HOUR
+	});
+	return query;
+};
+
+export const useGetTaskByEmployeeLazyQuery = () => {
+	const activeTeam = useAtomValue(activeTeamState);
+
+	const queryClient = useQueryClient();
+	const { setQueryKey, ...state } = useLazyQueryState();
+
+	const getTasksByEmployeeId = async (employeeId: string) => {
+		const teamId = activeTeam?.id;
+
+		return queryClient.fetchQuery({
+			queryKey: queryKeys.tasks.byEmployee(employeeId, teamId),
+			queryFn: async () => {
+				setQueryKey(queryKeys.tasks.byEmployee(employeeId, teamId));
+				if (!teamId) throw new Error('Team ID is Required');
+				if (!employeeId) throw new Error('Employee ID is Required');
+
+				return await taskService.getTasksByEmployeeId({ employeeId });
+			},
+			gcTime: TASK_QUERY_GC_TIME_HOUR
+		});
+	};
+
+	return { getTasksByEmployeeId, ...state };
+};

--- a/apps/web/core/hooks/tasks/queries/use-get-tasks-by-id.query.ts
+++ b/apps/web/core/hooks/tasks/queries/use-get-tasks-by-id.query.ts
@@ -1,0 +1,38 @@
+import { queryKeys } from '@/core/query/keys';
+import { taskService } from '@/core/services/client/api';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { TASK_QUERY_GC_TIME_HOUR } from '../constants/TASK_QUERY_GC_TIME';
+import { useLazyQueryState } from '../utils/use-lazy-query';
+
+export const useGetTaskByIdQuery = (taskId: string) => {
+	const query = useQuery({
+		queryKey: queryKeys.tasks.detail(taskId),
+		queryFn: async () => {
+			if (!taskId) throw new Error('Task ID is required');
+			return await taskService.getTaskById(taskId);
+		},
+		gcTime: TASK_QUERY_GC_TIME_HOUR
+	});
+
+	return query;
+};
+
+export const useGetTaskByIdLazyQuery = () => {
+	// utility for lazy query
+	const { setQueryKey, ...status } = useLazyQueryState<ReturnType<typeof queryKeys.tasks.detail>>();
+	const queryClient = useQueryClient();
+
+	const getTaskById = (taskId: string) => {
+		setQueryKey(queryKeys.tasks.detail(taskId));
+		return queryClient.fetchQuery({
+			queryKey: queryKeys.tasks.detail(taskId),
+			queryFn: async () => {
+				setQueryKey(queryKeys.tasks.detail(taskId));
+				if (!taskId) throw new Error('Task ID is required');
+				return await taskService.getTaskById(taskId);
+			}
+		});
+	};
+
+	return { getTaskById, ...status };
+};

--- a/apps/web/core/hooks/tasks/queries/use-get-tasks-by-id.query.ts
+++ b/apps/web/core/hooks/tasks/queries/use-get-tasks-by-id.query.ts
@@ -4,6 +4,12 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { TASK_QUERY_GC_TIME_HOUR } from '../constants/TASK_QUERY_GC_TIME';
 import { useLazyQueryState } from '../utils/use-lazy-query';
 
+/**
+ * Fetches a single task by its ID.
+ *
+ * @param taskId - The task ID to fetch
+ * @returns Query result with task data
+ */
 export const useGetTaskByIdQuery = (taskId: string) => {
 	const query = useQuery({
 		queryKey: queryKeys.tasks.detail(taskId),
@@ -17,6 +23,10 @@ export const useGetTaskByIdQuery = (taskId: string) => {
 	return query;
 };
 
+/**
+ * Lazy version - provides getTaskById() function for imperative fetching.
+ * Ideal for fetching task details on user interaction.
+ */
 export const useGetTaskByIdLazyQuery = () => {
 	// utility for lazy query
 	const { setQueryKey, ...status } = useLazyQueryState<ReturnType<typeof queryKeys.tasks.detail>>();

--- a/apps/web/core/hooks/tasks/queries/use-get-tasks-by-team.query.ts
+++ b/apps/web/core/hooks/tasks/queries/use-get-tasks-by-team.query.ts
@@ -7,6 +7,12 @@ import { useMemo } from 'react';
 import { TASK_QUERY_GC_TIME_HOUR } from '../constants/TASK_QUERY_GC_TIME';
 import { useLazyQueryState } from '../utils/use-lazy-query';
 
+/**
+ * Fetches all tasks for the current active team.
+ * Automatically refetches when team changes.
+ *
+ * @returns Query result with team tasks array
+ */
 export const useGetCurrentTeamTasksQuery = () => {
 	const activeTeam = useAtomValue(activeTeamState);
 	const _projectId = useMemo(
@@ -30,6 +36,12 @@ export const useGetCurrentTeamTasksQuery = () => {
 	return getTaskByTeamIdQuery;
 };
 
+/**
+ * Lazy version - only fetches when manually triggered via refetch().
+ * Useful for on-demand data loading.
+ *
+ * @returns Query result with manual refetch control
+ */
 export const useGetCurrentTeamTasksLazyQuery = () => {
 	const activeTeam = useAtomValue(activeTeamState);
 	const projectId = useMemo(

--- a/apps/web/core/hooks/tasks/queries/use-get-tasks-by-team.query.ts
+++ b/apps/web/core/hooks/tasks/queries/use-get-tasks-by-team.query.ts
@@ -1,0 +1,60 @@
+import { queryKeys } from '@/core/query/keys';
+import { taskService } from '@/core/services/client/api';
+import { activeTeamState } from '@/core/stores';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
+import { useMemo } from 'react';
+import { TASK_QUERY_GC_TIME_HOUR } from '../constants/TASK_QUERY_GC_TIME';
+import { useLazyQueryState } from '../utils/use-lazy-query';
+
+export const useGetCurrentTeamTasksQuery = () => {
+	const activeTeam = useAtomValue(activeTeamState);
+	const _projectId = useMemo(
+		() => (activeTeam?.projects && activeTeam?.projects.length > 0 ? activeTeam.projects[0].id : ''),
+		[activeTeam?.projects]
+	);
+	const teamId = useMemo(() => activeTeam?.id, [activeTeam?.id]);
+
+	const getTaskByTeamIdQuery = useQuery({
+		queryKey: queryKeys.tasks.byTeam(teamId),
+		queryFn: async () => {
+			if (!teamId) {
+				throw new Error('Required parameters missing');
+			}
+			return await taskService.getTasks({ projectId: _projectId });
+		},
+		enabled: !!teamId,
+		gcTime: TASK_QUERY_GC_TIME_HOUR
+	});
+
+	return getTaskByTeamIdQuery;
+};
+
+export const useGetCurrentTeamTasksLazyQuery = () => {
+	const activeTeam = useAtomValue(activeTeamState);
+	const projectId = useMemo(
+		() => (activeTeam?.projects && activeTeam?.projects.length > 0 ? activeTeam.projects[0].id : ''),
+		[activeTeam?.projects]
+	);
+	const teamId = useMemo(() => activeTeam?.id, [activeTeam?.id]);
+
+	// utility for lazy query
+	const queryClient = useQueryClient();
+	const { setQueryKey, ...state } = useLazyQueryState<ReturnType<typeof queryKeys.tasks.byTeam>>();
+
+	const getCurrentTeamTasks = () => {
+		return queryClient.fetchQuery({
+			queryKey: queryKeys.tasks.byTeam(teamId),
+			queryFn: async ({ queryKey }) => {
+				setQueryKey(queryKey);
+				if (!teamId) {
+					throw new Error('Required parameters missing');
+				}
+				return await taskService.getTasks({ projectId });
+			},
+			gcTime: TASK_QUERY_GC_TIME_HOUR
+		});
+	};
+
+	return { getCurrentTeamTasks, ...state };
+};

--- a/apps/web/core/hooks/tasks/use-active-team-task.ts
+++ b/apps/web/core/hooks/tasks/use-active-team-task.ts
@@ -3,11 +3,12 @@
 import { useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { activeTeamState, activeTeamTaskState, getPublicState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState, activeTeamTaskState, getPublicState } from '@/core/stores';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { taskService } from '@/core/services/client/api';
 import { queryKeys } from '@/core/query/keys';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useSortedTasks } from './derived/use-current-team-tasks';
 
 /**
  * Result interface for the useActiveTeamTask hook
@@ -40,7 +41,7 @@ export const useActiveTeamTask = (): UseActiveTeamTaskResult => {
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const setActiveTeamTask = useSetAtom(activeTeamTaskState);
 	const activeTeam = useAtomValue(activeTeamState);
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const publicTeam = useAtomValue(getPublicState);
 
 	// User data

--- a/apps/web/core/hooks/tasks/utils/use-invalidate-task-data.ts
+++ b/apps/web/core/hooks/tasks/utils/use-invalidate-task-data.ts
@@ -1,0 +1,24 @@
+import { queryKeys } from '@/core/query/keys';
+import { activeTeamState } from '@/core/stores';
+import { useQueryClient } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
+import { useCallback } from 'react';
+
+export const useInvalidateTeamTasksData = () => {
+	const activeTeam = useAtomValue(activeTeamState);
+	const queryClient = useQueryClient();
+
+	const invalidateTeamTasksData = useCallback(() => {
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.tasks.all
+		});
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.tasks.byTeam(activeTeam?.id)
+		});
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.dailyPlans.all
+		});
+	}, [activeTeam?.id, queryClient]);
+
+	return invalidateTeamTasksData;
+};

--- a/apps/web/core/hooks/tasks/utils/use-invalidate-task-data.ts
+++ b/apps/web/core/hooks/tasks/utils/use-invalidate-task-data.ts
@@ -4,6 +4,12 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 import { useCallback } from 'react';
 
+/**
+ * Provides cache invalidation for team tasks queries.
+ * Call after any task mutation to refresh data.
+ *
+ * @returns {{ invalidateTeamTasks: () => Promise<void> }}
+ */
 export const useInvalidateTeamTasksData = () => {
 	const activeTeam = useAtomValue(activeTeamState);
 	const queryClient = useQueryClient();

--- a/apps/web/core/hooks/tasks/utils/use-lazy-query.ts
+++ b/apps/web/core/hooks/tasks/utils/use-lazy-query.ts
@@ -1,0 +1,20 @@
+import { QueryKey, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+
+export const useLazyQueryState = <T extends QueryKey = QueryKey>() => {
+	const queryClient = useQueryClient();
+	const [queryKey, setQueryKey] = useState<T | null>(null);
+	const state = queryKey ? queryClient.getQueryState(queryKey) : null;
+	const status = useMemo(
+		() => ({
+			isIdle: state === null, // No query key set yet
+			isError: state?.status == 'error',
+			isPending: state?.status == 'pending',
+			isSuccess: state?.status == 'success',
+			isLoading: state?.status == 'pending' && state?.fetchStatus == 'fetching'
+		}),
+		[state?.status, state?.fetchStatus, state]
+	);
+
+	return { setQueryKey, ...status, ...(state && { ...state }) };
+};

--- a/apps/web/core/hooks/tasks/utils/use-lazy-query.ts
+++ b/apps/web/core/hooks/tasks/utils/use-lazy-query.ts
@@ -1,6 +1,14 @@
 import { QueryKey, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 
+/**
+ * Generic utility for creating lazy/imperative query patterns.
+ * Manages loading state and provides fetch function wrapper.
+ *
+ * @template T - Return type of the fetch function
+ * @param fetchFn - Async function to execute
+ * @returns {{ execute: () => Promise<T>, isPending: boolean, data: T | null }}
+ */
 export const useLazyQueryState = <T extends QueryKey = QueryKey>() => {
 	const queryClient = useQueryClient();
 	const [queryKey, setQueryKey] = useState<T | null>(null);

--- a/apps/web/core/hooks/tasks/utils/use-set-active-task.ts
+++ b/apps/web/core/hooks/tasks/utils/use-set-active-task.ts
@@ -12,6 +12,15 @@ import { useOrganizationEmployeeTeams } from '../../organizations';
 import { useUpdateTaskMutation } from '../mutations/use-update-task.mutation';
 import { useSortedTasks } from '../derived/use-current-team-tasks';
 
+/**
+ * Manages active task selection with cookie persistence.
+ * Handles optimistic updates and race condition protection.
+ *
+ * @returns {{
+ *   setActiveTask: (task: TTask) => Promise<TTask>,
+ *   isUpdatingActiveTask: boolean
+ * }}
+ */
 export const useSetActiveTask = () => {
 	const { mutateAsync: updateTask } = useUpdateTaskMutation();
 	const tasks = useSortedTasks();

--- a/apps/web/core/hooks/tasks/utils/use-set-active-task.ts
+++ b/apps/web/core/hooks/tasks/utils/use-set-active-task.ts
@@ -1,0 +1,208 @@
+import { getActiveTaskIdCookie, setActiveTaskIdCookie, setActiveUserTaskCookie } from '@/core/lib/helpers/cookies';
+import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
+import { activeTeamState, activeTeamTaskState, memberActiveTaskIdState, tasksByTeamState } from '@/core/stores';
+import { TOrganizationTeamEmployee } from '@/core/types/schemas';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useAtom, useAtomValue } from 'jotai';
+import { useCallback, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { useAuthenticateUser } from '../../auth';
+import { useConditionalUpdateEffect, useSyncRef } from '../../common';
+import { useOrganizationEmployeeTeams } from '../../organizations';
+import { useUpdateTaskMutation } from '../mutations/use-update-task.mutation';
+
+export const useSetActiveTask = () => {
+	const { mutateAsync: updateTask } = useUpdateTaskMutation();
+	const tasks = useAtomValue(tasksByTeamState);
+	const tasksRef = useSyncRef(tasks);
+
+	const { updateOrganizationTeamEmployeeActiveTask } = useOrganizationEmployeeTeams();
+
+	const activeTeam = useAtomValue(activeTeamState);
+	const activeTeamRef = useSyncRef(activeTeam);
+
+	const memberActiveTaskId = useAtomValue(memberActiveTaskIdState);
+	const $memberActiveTaskId = useSyncRef(memberActiveTaskId);
+
+	const { $user } = useAuthenticateUser();
+
+	const [activeTeamTask, setActiveTeamTask] = useAtom(activeTeamTaskState);
+	// Keep activeTeamTask in sync with a ref to avoid stale closures in setActiveTask
+	const activeTeamTaskRef = useSyncRef(activeTeamTask);
+
+	// Track expected task ID to prevent stale server data from overwriting local selection.
+	// When user selects a task, we store its ID here. The sync effect will skip updates
+	// until server data matches this expected ID (confirming our selection was persisted).
+	const expectedActiveTaskIdRef = useRef<string | null>(null);
+
+	const [isUpdatingActiveTask, setIsUpdatingActiveTask] = useState(false);
+
+	const setActiveUserTaskCookieCb = useCallback(
+		(task: TTask | null) => {
+			if (task?.id && $user?.current?.id) {
+				setActiveUserTaskCookie({
+					taskId: task?.id,
+					userId: $user?.current?.id
+				});
+			} else {
+				setActiveUserTaskCookie({
+					taskId: '',
+					userId: ''
+				});
+			}
+		},
+		[$user?.current?.id]
+	);
+
+	const setActiveTask = useCallback(
+		async (task: TTask | null) => {
+			// Set flag to prevent race conditions with server sync
+			setIsUpdatingActiveTask(true);
+
+			try {
+				/**
+				 * Unassign previous active task
+				 */
+				if ($memberActiveTaskId.current && $user.current) {
+					const _task = (tasks ?? []).find((t) => t.id === $memberActiveTaskId.current);
+
+					if (_task) {
+						await updateTask({
+							taskId: _task.id,
+							taskData: {
+								..._task,
+								members: _task.members?.filter((m) => m.id !== $user.current?.employee?.id)
+							}
+						});
+					}
+				}
+
+				// Use ref to get current activeTeamTask to avoid stale closure
+				const previousTask = activeTeamTaskRef?.current;
+				const previousTaskId = activeTeamTaskRef?.current?.id ?? getActiveTaskIdCookie();
+
+				// Set expected task ID BEFORE updating state/cookies.
+				// This prevents the sync effect from overwriting with stale server data.
+				expectedActiveTaskIdRef.current = task?.id || null;
+
+				setActiveTaskIdCookie(task?.id || '');
+				setActiveTeamTask(task);
+				setActiveUserTaskCookieCb(task);
+
+				if (task) {
+					/**
+					 * Sync active task to server for multi-device support.
+					 * Cookies are already set above, so local persistence works even if API fails.
+					 * Retry up to 3 times because activeTeam.members may not be loaded yet on first render.
+					 */
+					const MAX_RETRIES = 3;
+					const RETRY_DELAY_MS = 500;
+
+					try {
+						let success = false;
+
+						// Use activeTeamRef.current to get fresh values on each retry attempt.
+						// Using activeTeam directly would capture the stale closure value.
+						for (let attempt = 1; attempt <= MAX_RETRIES && !success; attempt++) {
+							const currentEmployeeDetails = activeTeamRef.current?.members?.find(
+								(member: TOrganizationTeamEmployee) => member.employeeId === $user.current?.employee?.id
+							);
+
+							if (currentEmployeeDetails?.id) {
+								await updateOrganizationTeamEmployeeActiveTask(currentEmployeeDetails.id, {
+									organizationId: task.organizationId,
+									activeTaskId: task.id,
+									organizationTeamId: activeTeamRef.current?.id,
+									tenantId: activeTeamRef.current?.tenantId ?? ''
+								});
+								success = true;
+							} else if (attempt < MAX_RETRIES) {
+								await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+							}
+						}
+
+						if (!success) {
+							// All retries exhausted - members may not be loaded yet.
+							// Local state (cookies + Jotai) is already persisted, only server sync failed.
+							logErrorInDev(
+								'[setActiveTask] Failed to sync after retries - members may not be loaded',
+								null
+							);
+							// Clear expected ID to allow server sync to resume
+							expectedActiveTaskIdRef.current = null;
+						}
+
+						if (success) {
+							toast.success('Active task updated', {
+								description: `"${task.title}" is now your active task`
+							});
+
+							// Short delay to let React Query stabilize before clearing isUpdatingActiveTask.
+							// The expectedActiveTaskIdRef provides the main protection against stale data,
+							// this delay is just an extra safety buffer for edge cases.
+							// NOTE: Do NOT invalidate queries here - updateActiveTaskMutation already handles it.
+							await new Promise((resolve) => setTimeout(resolve, 600));
+							// Clear expectation on success - server will confirm via sync effect
+							expectedActiveTaskIdRef.current = null;
+						}
+					} catch (error) {
+						logErrorInDev('[setActiveTask] API call failed:', error);
+						toast.error('Failed to update active task', {
+							description: getErrorMessage(error)
+						});
+						// Rollback: restore previous state and clear expected ID
+						expectedActiveTaskIdRef.current = previousTaskId || null;
+						setActiveTaskIdCookie(previousTaskId || '');
+						setActiveTeamTask(previousTask);
+						setActiveUserTaskCookieCb(previousTask);
+					}
+				}
+			} finally {
+				// Always clear the flag, even if an error occurred
+				setIsUpdatingActiveTask(false);
+			}
+		},
+		[
+			setActiveTeamTask,
+			setActiveUserTaskCookieCb,
+			updateOrganizationTeamEmployeeActiveTask,
+			activeTeam,
+			$memberActiveTaskId,
+			$user,
+			tasksRef,
+			updateTask,
+			setIsUpdatingActiveTask
+		]
+	);
+
+	useConditionalUpdateEffect(
+		() => {
+			// Skip if we're currently updating the active task
+			if (isUpdatingActiveTask) {
+				return;
+			}
+
+			// If we have an expected task ID (user just selected a task locally):
+			// - If server data matches → clear expectation, no need to update (already correct)
+			// - If server data differs → skip update (server has stale data, wait for it to sync)
+			if (expectedActiveTaskIdRef.current) {
+				if (memberActiveTaskId === expectedActiveTaskIdRef.current) {
+					// Server confirmed our selection
+					expectedActiveTaskIdRef.current = null;
+				}
+				// Either way, skip - local state is already correct
+				return;
+			}
+
+			// No local expectation - sync from server (multi-device sync or initial load)
+			const memberActiveTask = tasks.find((item) => item.id === memberActiveTaskId);
+			if (memberActiveTask) {
+				setActiveTeamTask(memberActiveTask);
+			}
+		},
+		[activeTeam, tasks, memberActiveTaskId, isUpdatingActiveTask],
+		Boolean(activeTeamTask)
+	);
+
+	return { setActiveTask };
+};

--- a/apps/web/core/hooks/tasks/utils/use-set-active-task.ts
+++ b/apps/web/core/hooks/tasks/utils/use-set-active-task.ts
@@ -1,6 +1,6 @@
 import { getActiveTaskIdCookie, setActiveTaskIdCookie, setActiveUserTaskCookie } from '@/core/lib/helpers/cookies';
 import { getErrorMessage, logErrorInDev } from '@/core/lib/helpers/error-message';
-import { activeTeamState, activeTeamTaskState, memberActiveTaskIdState, tasksByTeamState } from '@/core/stores';
+import { activeTeamState, activeTeamTaskState, memberActiveTaskIdState } from '@/core/stores';
 import { TOrganizationTeamEmployee } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useAtom, useAtomValue } from 'jotai';
@@ -10,10 +10,11 @@ import { useAuthenticateUser } from '../../auth';
 import { useConditionalUpdateEffect, useSyncRef } from '../../common';
 import { useOrganizationEmployeeTeams } from '../../organizations';
 import { useUpdateTaskMutation } from '../mutations/use-update-task.mutation';
+import { useSortedTasks } from '../derived/use-current-team-tasks';
 
 export const useSetActiveTask = () => {
 	const { mutateAsync: updateTask } = useUpdateTaskMutation();
-	const tasks = useAtomValue(tasksByTeamState);
+	const tasks = useSortedTasks();
 	const tasksRef = useSyncRef(tasks);
 
 	const { updateOrganizationTeamEmployeeActiveTask } = useOrganizationEmployeeTeams();

--- a/apps/web/core/hooks/tasks/utils/use-set-active-task.ts
+++ b/apps/web/core/hooks/tasks/utils/use-set-active-task.ts
@@ -205,5 +205,5 @@ export const useSetActiveTask = () => {
 		Boolean(activeTeamTask)
 	);
 
-	return { setActiveTask };
+	return { setActiveTask, isUpdatingActiveTask };
 };


### PR DESCRIPTION
# Refactor: separate useTeamTasks into more atomic Hooks

## Description

This PR refactors the monolithic `useTeamTasks` hook (~600+ lines) into smaller, focused, and reusable hooks following the **Single Responsibility Principle**.

- **Problem:** The original hook was doing too much (queries, mutations, state management, cookie handling, sorting, etc.), making it hard to maintain, test, and reuse individual pieces.
- **Solution:** Split into 12 specialized hooks organized by concern (queries, mutations, derived state, utils).
- **Benefits:**
  - ~42% code reduction in the main hook
  - Better separation of concerns
  - Improved testability and reusability
  - Easier onboarding for new developers
  - Consistent patterns with React Query best practices

## What Was Changed

### Major Changes

> **New hook architecture:**
>
> **Queries (3 files):**
> - `useGetCurrentTeamTasksQuery` / `useGetCurrentTeamTasksLazyQuery` - Fetch tasks for active team
> - `useGetTaskByIdQuery` / `useGetTaskByIdLazyQuery` - Fetch single task by ID
> - `useGetTaskByEmployeeQuery` / `useGetTaskByEmployeeLazyQuery` - Fetch tasks by employee
>
> **Mutations (4 files):**
> - `useCreateTaskMutation` - Create new tasks with cache invalidation
> - `useUpdateTaskMutation` - Update tasks with optimistic updates
> - `useDeleteTaskMutation` - Delete tasks with cache sync
> - `useDeleteEmployeeFromTasksMutation` - Remove employee from all tasks
>
> **Derived State (2 files):**
> - `useCurrentTeamTasks` / `useSortedTasks` - Access and sort team tasks from store
> - `useSetActiveTask` - Manage active task with cookie persistence and race condition protection
>
> **Utils (2 files):**
> - `useInvalidateTeamTasksData` - Cache invalidation helper
> - `useLazyQueryState` - Generic lazy query pattern utility

### Minor Changes

> - Added JSDoc documentation to all new hooks
> - Cleaned up unused dependencies in useCallback arrays
> - Organized hooks into logical folder structure:
> ```
> hooks/tasks/
> ├── queries/
> ├── mutations/
> ├── derived/
> ├── utils/
> └── index.ts
> ```


## How to Test This PR

> 1. Run the app with `yarn start:web:dev`
> 2. Open the browser at `http://localhost:3030`
> 3. **Test the following scenarios:**
>
> | Action | Expected Result |
> |--------|-----------------|
> | Load team tasks | Tasks list displays correctly |
> | Create a new task | Task appears in list, no console errors |
> | Update a task (title, status, etc.) | Changes persist, UI updates |
> | Delete a task | Task removed from list |
> | Switch active task | Cookie updated, UI reflects selection |
> | Change team | Tasks reload for new team |
> | Assign/unassign employee | Task membership updates correctly |
>
> 4. **Verify React Query DevTools** shows proper cache invalidation

## Screenshots (if needed)

| Before | After |
| ------ | ----- |
| N/A - No UI changes | N/A - Internal refactor only |

## Related Issues

> - Related to [ETP-171](https://evertech.atlassian.net/browse/ETP-171)

## Type of Change

- [ ] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [x] Documentation update
- [x] **Refactoring** (code improvement without behavior change)

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

- **Backward compatibility:** The main `useTeamTasks` hook returns the exact same API, so no changes needed in consuming components.
- **Intentional scope limitation:** To keep this PR focused and reviewable, I did not update some components that consume `useTeamTasks` to use the new atomic hooks directly. This migration will be done in a follow-up PR.

## Reviewers Suggested

- `@evereq` for architecture validation
- `@ndekocode` for integration review


[ETP-171]: https://evertech.atlassian.net/browse/ETP-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the large useTeamTasks hook into small, focused hooks for queries, mutations, derived state, and utils to simplify maintenance and testing. Updated call sites to use useSortedTasks for reading team tasks; aligns with ETP-171.

- **Refactors**
  - Added queries: useGetCurrentTeamTasksQuery, useGetTaskById(Lazy), useGetTaskByEmployee(Query/Lazy) with 1‑hour GC.
  - Added mutations: useCreateTaskMutation, useUpdateTaskMutation (optimistic cache sync), useDeleteTaskMutation, useDeleteEmployeeFromTaskMutation; shared invalidation via useInvalidateTeamTasksData.
  - Introduced derived hooks: useCurrentTeamTasks and useSortedTasks; replaced tasksByTeamState/teamTasksState across the app.
  - Moved active task logic to useSetActiveTask with cookie persistence and race‑condition protection.
  - Slimmed useTeamTasks by ~300 LOC; added JSDoc and organized hooks by concern.

- **Migration**
  - Continue using useTeamTasks where needed; no changes required in consumers.
  - For reads, prefer useSortedTasks() or useCurrentTeamTasks(); for writes, use the new mutation hooks (cache invalidation is handled).

<sup>Written for commit 408e02f7482d3e7e90e25ebcecf3d4be1fd7e829. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Task management system restructured for improved performance and reliability across the application.
  * Enhanced task data caching and retrieval mechanisms for better efficiency.
  * Task operations (creation, updates, deletion) now feature improved state synchronization.
  * Consistent task sorting applied throughout all task-related features for a unified experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->