### PR TITLE
ETP-219 Fix Profile Page Filter Dropdowns Not Applying Selections 

### DIFF
--- a/apps/web/core/components/daily-plan/all-plans.tsx
+++ b/apps/web/core/components/daily-plan/all-plans.tsx
@@ -9,7 +9,11 @@ import { handleDragAndDrop } from '@/core/lib/helpers/drag-and-drop';
 import { FilterTabs } from '@/core/types/daily-plan-types';
 import { useEmployeeDailyPlans } from '@/core/hooks/daily-plans/use-employee-daily-plans';
 import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
-import { filterDailyPlan, filterDailyPlansByEmployee } from '@/core/hooks/daily-plans/use-filter-date-range';
+import {
+	filterDailyPlan,
+	filterDailyPlansByEmployee,
+	filterDailyPlansByTasks
+} from '@/core/hooks/daily-plans/use-filter-date-range';
 import { TDailyPlan, TUser } from '@/core/types/schemas';
 import { dailyPlanViewHeaderTabs } from '@/core/stores';
 import { clsxm } from '@/core/lib/utils';
@@ -32,13 +36,15 @@ export function AllPlans({
 	currentTab = 'All Tasks',
 	user,
 	employeeId,
-	filterByEmployee = false
+	filterByEmployee = false,
+	filteredTaskIds
 }: {
 	profile: any;
 	currentTab?: FilterTabs;
 	user?: TUser;
 	employeeId?: string; // Accept employeeId directly from parent
 	filterByEmployee?: boolean; // Filter tasks by employee (default: false = show all tasks)
+	filteredTaskIds?: string[]; // Filter plans by taskIds (default undefined = show all)
 }) {
 	// Filter plans
 	const filteredPlans = useRef<TDailyPlan[]>([]);
@@ -70,8 +76,12 @@ export function AllPlans({
 			filteredData = filterDailyPlansByEmployee(filteredData, user);
 		}
 
+		if (filteredTaskIds && filteredData) {
+			filteredData = filterDailyPlansByTasks(filteredData, filteredTaskIds);
+		}
+
 		return filteredData;
-	}, [date, employeeTodayPlan, employeeSortedPlans, user, filterByEmployee]);
+	}, [date, employeeTodayPlan, employeeSortedPlans, user, filterByEmployee, filteredTaskIds]);
 
 	// Local state for drag-and-drop functionality
 	const [dragPlans, setDragPlans] = useState(plans);

--- a/apps/web/core/components/pages/profile/user-profile-tasks.tsx
+++ b/apps/web/core/components/pages/profile/user-profile-tasks.tsx
@@ -176,7 +176,9 @@ export const UserProfileTask = memo(
 						<LazyActivityCalendar />
 					</Suspense>
 				)}
-				{tabFiltered.tab === 'dailyplan' && <UserProfilePlans user={user} employeeId={employeeId} />}
+				{tabFiltered.tab === 'dailyplan' && (
+					<UserProfilePlans filteredTasks={otherTasks} user={user} employeeId={employeeId} />
+				)}
 
 				{tabFiltered.tab === 'worked' && otherTasks.length > 0 && (
 					<div className="flex items-center my-6 space-x-2">

--- a/apps/web/core/components/tasks/custom-dropdown.tsx
+++ b/apps/web/core/components/tasks/custom-dropdown.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/core/lib/helpers';
-import { useState, ReactNode } from 'react';
+import { useState, ReactNode, useCallback } from 'react';
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -40,28 +40,31 @@ export function CustomListboxDropdown<T>({
 }) {
 	const [open, setOpen] = useState(false);
 
-	const handleSelect = (itemValue: T) => {
-		if (!onChange) return;
-		if (isMultiple && multiple) {
-			const stringItemValue = String(itemValue);
-			const isAlreadySelected = values.some((v) => String(v) === stringItemValue);
-			if (isAlreadySelected) {
-				const newValues = values.filter((v) => String(v) !== stringItemValue);
-				onChange(newValues);
-			} else {
-				const stringValues = values.map((v) => String(v));
-
-				if (!stringValues.includes(stringItemValue)) {
-					onChange([...values, itemValue]);
+	const handleSelect = useCallback(
+		(itemValue: T) => {
+			if (!onChange) return;
+			if (isMultiple && multiple) {
+				const stringItemValue = String(itemValue);
+				const isAlreadySelected = values.some((v) => String(v) === stringItemValue);
+				if (isAlreadySelected) {
+					const newValues = values.filter((v) => String(v) !== stringItemValue);
+					onChange(newValues);
 				} else {
-					console.log('Value already selected, ignored:', stringItemValue);
+					const stringValues = values.map((v) => String(v));
+
+					if (!stringValues.includes(stringItemValue)) {
+						onChange([...values, itemValue]);
+					} else {
+						console.log('Value already selected, ignored:', stringItemValue);
+					}
 				}
+			} else {
+				onChange(itemValue);
+				setOpen(false);
 			}
-		} else {
-			onChange(itemValue);
-			setOpen(false);
-		}
-	};
+		},
+		[isMultiple, multiple, values, onChange, setOpen]
+	);
 
 	return (
 		<div className={cn('relative', className)}>

--- a/apps/web/core/components/tasks/daily-plan/future-tasks.tsx
+++ b/apps/web/core/components/tasks/daily-plan/future-tasks.tsx
@@ -8,7 +8,11 @@ import { dailyPlanViewHeaderTabs } from '@/core/stores/common/header-tabs';
 import TaskBlockCard from '../task-block-card';
 import { clsxm } from '@/core/lib/utils';
 import { useMemo } from 'react';
-import { filterDailyPlan, filterDailyPlansByEmployee } from '@/core/hooks/daily-plans/use-filter-date-range';
+import {
+	filterDailyPlan,
+	filterDailyPlansByEmployee,
+	filterDailyPlansByTasks
+} from '@/core/hooks/daily-plans/use-filter-date-range';
 import { TUser } from '@/core/types/schemas';
 import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
 import { useDateRange } from '@/core/hooks/daily-plans/use-date-range';
@@ -20,12 +24,14 @@ export function FutureTasks({
 	profile,
 	user,
 	employeeId,
-	filterByEmployee = false
+	filterByEmployee = false,
+	filteredTaskIds
 }: {
 	profile: any;
 	user?: TUser;
 	employeeId?: string; // Accept employeeId directly from parent
 	filterByEmployee?: boolean; // Filter tasks by employee (default: false = show all tasks)
+	filteredTaskIds?: string[]; // Filter plans by taskIds (default undefined = show all)
 }) {
 	// Use employeeId from props if provided, otherwise calculate from user
 	const targetEmployeeId = employeeId ?? user?.employee?.id ?? user?.employeeId ?? '';
@@ -46,8 +52,12 @@ export function FutureTasks({
 			filteredData = filterDailyPlansByEmployee(filteredData, user);
 		}
 
+		if (filteredTaskIds && filteredData) {
+			filteredData = filterDailyPlansByTasks(filteredData, filteredTaskIds);
+		}
+
 		return filteredData;
-	}, [date, employeeFuturePlans, user, filterByEmployee]);
+	}, [date, employeeFuturePlans, user, filterByEmployee, filteredTaskIds]);
 
 	if (!futureDailyPlanTasks) return null;
 	return (

--- a/apps/web/core/components/tasks/daily-plan/outstanding-all.tsx
+++ b/apps/web/core/components/tasks/daily-plan/outstanding-all.tsx
@@ -34,41 +34,9 @@ export function OutstandingAll({ profile, user, outstandingPlans, filteredTaskId
 		[user?.id]
 	);
 
-	// Memoized task deduplication to prevent unnecessary recalculations
-	// This fixes the bug where duplicate tasks caused count/display mismatch
-	const uniqueTasks = useMemo(() => {
-		// Early return for empty data to avoid unnecessary processing
-		if (!outstandingPlans.length) return [];
-
-		// ALWAYS filter by user if user exists (original behavior before filterByEmployee flag)
-		// This is intentional for privacy/security in the Outstanding view
-		const allTasks = outstandingPlans.flatMap((plan) => {
-			const tasks = plan.tasks ?? [];
-			return user ? filterTasksByUser(tasks) : tasks;
-		});
-
-		// Use Map for deduplication by task ID to handle large datasets efficiently
-		const taskMap = new Map<string, TTask>();
-		allTasks.forEach((task) => {
-			if (task?.id && !taskMap.has(task.id)) {
-				taskMap.set(task.id, task);
-			}
-		});
-
-		return Array.from(taskMap.values());
-	}, [outstandingPlans, filterTasksByUser]);
-
-	// State for drag & drop functionality only
-	const [dragTasks, setDragTasks] = useState<TTask[]>(uniqueTasks);
-
-	// Sync drag state only when source data changes
-	useEffect(() => {
-		setDragTasks(uniqueTasks);
-	}, [uniqueTasks]);
-
 	// Create filtered plans for TaskEstimatedCount to match the displayed tasks
 	// ALWAYS filter by user if user exists (same logic as uniqueTasks)
-	const filteredPlansForCount = useMemo(() => {
+	const filteredPlans = useMemo(() => {
 		let filteredData = outstandingPlans;
 
 		if (filteredTaskIds && filteredData) {
@@ -81,11 +49,40 @@ export function OutstandingAll({ profile, user, outstandingPlans, filteredTaskId
 				tasks: user ? filterTasksByUser(plan.tasks ?? []) : plan.tasks
 			}))
 			.filter((plan) => plan.tasks && plan.tasks.length > 0);
-	}, [outstandingPlans, filterTasksByUser, user]);
+	}, [outstandingPlans, filterTasksByUser, user, filteredTaskIds]);
+
+	// Memoized task deduplication to prevent unnecessary recalculations
+	// This fixes the bug where duplicate tasks caused count/display mismatch
+	const uniqueTasks = useMemo(() => {
+		// Early return for empty data to avoid unnecessary processing
+		if (!filteredPlans.length) return [];
+
+		const allTasks = filteredPlans.flatMap((plan) => {
+			return plan.tasks ?? [];
+		});
+
+		// Use Map for deduplication by task ID to handle large datasets efficiently
+		const taskMap = new Map<string, TTask>();
+		allTasks.forEach((task) => {
+			if (task?.id && !taskMap.has(task.id)) {
+				taskMap.set(task.id, task);
+			}
+		});
+
+		return Array.from(taskMap.values());
+	}, [filteredPlans, filterTasksByUser]);
+
+	// State for drag & drop functionality only
+	const [dragTasks, setDragTasks] = useState<TTask[]>(uniqueTasks);
+
+	// Sync drag state only when source data changes
+	useEffect(() => {
+		setDragTasks(uniqueTasks);
+	}, [uniqueTasks]);
 
 	return (
 		<div className="flex flex-col gap-6">
-			<TaskEstimatedCount outstandingPlans={filteredPlansForCount} />
+			<TaskEstimatedCount outstandingPlans={filteredPlans} />
 
 			{uniqueTasks.length > 0 ? (
 				<>

--- a/apps/web/core/components/tasks/daily-plan/outstanding-all.tsx
+++ b/apps/web/core/components/tasks/daily-plan/outstanding-all.tsx
@@ -11,13 +11,15 @@ import { useState, useMemo, useEffect, useCallback } from 'react';
 import { TDailyPlan, TUser } from '@/core/types/schemas';
 import { handleDragAndDropDailyOutstandingAll } from '@/core/lib/helpers/index';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { filterDailyPlansByTasks } from '@/core/hooks';
 
 interface OutstandingAllProps {
 	profile: any;
 	user?: TUser;
 	outstandingPlans: TDailyPlan[];
+	filteredTaskIds?: string[]; // Filter plans by taskIds (default undefined = show all)
 }
-export function OutstandingAll({ profile, user, outstandingPlans }: OutstandingAllProps) {
+export function OutstandingAll({ profile, user, outstandingPlans, filteredTaskIds }: OutstandingAllProps) {
 	const view = useAtomValue(dailyPlanViewHeaderTabs);
 
 	// Memoized user filter function for performance
@@ -67,7 +69,13 @@ export function OutstandingAll({ profile, user, outstandingPlans }: OutstandingA
 	// Create filtered plans for TaskEstimatedCount to match the displayed tasks
 	// ALWAYS filter by user if user exists (same logic as uniqueTasks)
 	const filteredPlansForCount = useMemo(() => {
-		return outstandingPlans
+		let filteredData = outstandingPlans;
+
+		if (filteredTaskIds && filteredData) {
+			filteredData = filterDailyPlansByTasks(filteredData, filteredTaskIds);
+		}
+
+		return filteredData
 			.map((plan) => ({
 				...plan,
 				tasks: user ? filterTasksByUser(plan.tasks ?? []) : plan.tasks

--- a/apps/web/core/components/tasks/daily-plan/outstanding-date.tsx
+++ b/apps/web/core/components/tasks/daily-plan/outstanding-date.tsx
@@ -13,25 +13,39 @@ import { TDailyPlan, TUser } from '@/core/types/schemas';
 import { HorizontalSeparator } from '../../duplicated-components/separator';
 import DailyPlanTasksTableView from './table-view';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { filterDailyPlansByEmployee } from '@/core/hooks/daily-plans/use-filter-date-range';
+import { filterDailyPlansByEmployee, filterDailyPlansByTasks } from '@/core/hooks/daily-plans/use-filter-date-range';
 
 interface IOutstandingFilterDate {
 	profile: any;
 	user?: TUser;
 	outstandingPlans: TDailyPlan[];
 	filterByEmployee?: boolean; // Filter tasks by employee (default: false = show all tasks)
+	filteredTaskIds?: string[]; // Filter plans by taskIds (default undefined = show all)
 }
-export function OutstandingFilterDate({ profile, user, outstandingPlans, filterByEmployee = false }: IOutstandingFilterDate) {
+export function OutstandingFilterDate({
+	profile,
+	user,
+	outstandingPlans,
+	filterByEmployee = false,
+	filteredTaskIds
+}: IOutstandingFilterDate) {
 	const view = useAtomValue(dailyPlanViewHeaderTabs);
 
 	// Performance: useMemo prevents recalculating filtered plans on every render
 	const filteredPlans = useMemo(() => {
-		// If filterByEmployee flag is disabled, show all tasks
-		if (!filterByEmployee) return outstandingPlans;
+		let filteredData = outstandingPlans;
 
-		// Filter tasks by employee if flag is enabled
-		return filterDailyPlansByEmployee(outstandingPlans, user);
-	}, [outstandingPlans, user, filterByEmployee]);
+		if (filterByEmployee) {
+			// Filter tasks by employee if flag is enabled
+			filteredData = filterDailyPlansByEmployee(outstandingPlans, user);
+		}
+
+		if (filteredTaskIds && filteredData) {
+			filteredData = filterDailyPlansByTasks(filteredData, filteredTaskIds);
+		}
+
+		return filteredData;
+	}, [outstandingPlans, user, filterByEmployee, filteredTaskIds]);
 
 	// Local state for drag-and-drop functionality (minimal approach)
 	const [plans, setPlans] = useState(filteredPlans);

--- a/apps/web/core/components/tasks/daily-plan/past-tasks.tsx
+++ b/apps/web/core/components/tasks/daily-plan/past-tasks.tsx
@@ -7,7 +7,11 @@ import { useAtomValue } from 'jotai';
 import { dailyPlanViewHeaderTabs } from '@/core/stores/common/header-tabs';
 import { clsxm } from '@/core/lib/utils';
 import TaskBlockCard from '../task-block-card';
-import { filterDailyPlan, filterDailyPlansByEmployee } from '@/core/hooks/daily-plans/use-filter-date-range';
+import {
+	filterDailyPlan,
+	filterDailyPlansByEmployee,
+	filterDailyPlansByTasks
+} from '@/core/hooks/daily-plans/use-filter-date-range';
 import { useMemo } from 'react';
 import { TUser } from '@/core/types/schemas';
 import { DragDropContext, Draggable, Droppable, DroppableProvided, DroppableStateSnapshot } from '@hello-pangea/dnd';
@@ -22,13 +26,15 @@ export function PastTasks({
 	profile,
 	currentTab = 'Past Tasks',
 	employeeId: propsEmployeeId,
-	filterByEmployee = false
+	filterByEmployee = false,
+	filteredTaskIds
 }: {
 	profile: any;
 	currentTab?: FilterTabs;
 	user?: TUser;
 	employeeId?: string; // Accept employeeId directly from parent
 	filterByEmployee?: boolean; // Filter tasks by employee (default: false = show all tasks)
+	filteredTaskIds?: string[]; // Filter plans by taskIds (default undefined = show all)
 }) {
 	// Use employeeId from props if provided, otherwise calculate from user
 	const employeeId = propsEmployeeId ?? user?.employee?.id ?? user?.employeeId ?? '';
@@ -50,9 +56,12 @@ export function PastTasks({
 		if (filterByEmployee && filteredData) {
 			filteredData = filterDailyPlansByEmployee(filteredData, user);
 		}
+		if (filteredTaskIds && filteredData) {
+			filteredData = filterDailyPlansByTasks(filteredData, filteredTaskIds);
+		}
 
 		return filteredData;
-	}, [date, employeePastPlans, user, filterByEmployee]);
+	}, [date, employeePastPlans, user, filterByEmployee, filteredTaskIds]);
 	if (!filteredPastPlans) return null;
 	return (
 		<div className="flex flex-col gap-6">

--- a/apps/web/core/components/tasks/task-status.tsx
+++ b/apps/web/core/components/tasks/task-status.tsx
@@ -5,7 +5,7 @@ import { ITaskStatusField } from '@/core/types/interfaces/task/task-status/task-
 import { Nullable } from '@/core/types/generics/utils';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 // import { LoginIcon, RecordIcon } from 'lib/components/svgs';
-import { PropsWithChildren, useMemo } from 'react';
+import { PropsWithChildren, useCallback, useMemo } from 'react';
 import { useStatusValue, useTaskStatusValue } from '@/core/hooks';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { readableColor } from 'polished';
@@ -632,24 +632,29 @@ export function StatusDropdown<T extends TStatusItem>({
 	isLoading?: boolean;
 	titleClassName?: string;
 }>) {
-	const processedValues = [...new Set(values)];
-	if (multiple && value) {
-		const valueToAdd = value.value || value.name;
-		if (valueToAdd && !processedValues.some((v) => v === valueToAdd)) {
-			processedValues.push(valueToAdd);
+	const processedValues = useMemo(() => {
+		const processedValues = [...new Set(values)];
+		if (multiple && value) {
+			const valueToAdd = value.value || value.name;
+			if (valueToAdd && !processedValues.some((v) => v === valueToAdd)) {
+				processedValues.push(valueToAdd);
+			}
 		}
-	}
+		return processedValues;
+	}, [values, multiple, value]);
 
-	values = processedValues;
-	const defaultValue: TStatusItem = {
-		bgColor: undefined,
-		icon: (
-			<span>
-				<CircleIcon className="w-4 h-4" />
-			</span>
-		),
-		name: defaultItem
-	};
+	const defaultValue: TStatusItem = useMemo(
+		() => ({
+			bgColor: undefined,
+			icon: (
+				<span>
+					<CircleIcon className="w-4 h-4" />
+				</span>
+			),
+			name: defaultItem
+		}),
+		[defaultItem]
+	);
 
 	const currentValue = value || defaultValue;
 	const hasBtnIcon = issueType === 'status' && !showButtonOnly;
@@ -708,97 +713,131 @@ export function StatusDropdown<T extends TStatusItem>({
 		</TaskStatus>
 	);
 
+	const triggerContent = !multiple ? (
+		<Tooltip
+			enabled={hasBtnIcon && (value?.name || '').length > 10}
+			label={capitalize(value?.name) || ''}
+			className="h-full"
+		>
+			{button}
+		</Tooltip>
+	) : (
+		<TaskStatus
+			{...defaultValue}
+			active={true}
+			forDetails={forDetails}
+			sidebarUI={sidebarUI}
+			className={cn(
+				'justify-between w-full capitalize h-full',
+				sidebarUI && ['text-xs'],
+				'text-dark dark:text-white bg-[#F2F2F2] dark:bg-dark--theme-light',
+				forDetails && 'bg-transparent border dark:border-[#FFFFFF33] dark:bg-[#1B1D22]',
+				taskStatusClassName
+			)}
+			name={
+				processedValues.length > 0
+					? `Item${processedValues.length === 1 ? '' : 's'} (${processedValues.length})`
+					: defaultValue.name
+			}
+			isEpic={isEpic}
+		>
+			<ChevronDownIcon className={cn('w-5 h-5 text-default dark:text-white')} />
+		</TaskStatus>
+	);
+
+	const renderItem = useCallback(
+		(item: T, isSelected: boolean) => {
+			const itemValue = item.value || item.name;
+			const handleRemove = (e: React.MouseEvent) => {
+				e.stopPropagation();
+				if (onChange && multiple && itemValue) {
+					const newValues = processedValues.filter((v) => v !== itemValue);
+					onChange(newValues.join(','));
+				}
+				onRemoveSelected?.();
+			};
+
+			return (
+				<div className="relative w-full outline-none cursor-pointer">
+					<TaskStatus
+						showIcon={showIcon}
+						{...item}
+						checked={isSelected}
+						className={cn(
+							'!w-full',
+							issueType === 'issue' && ['rounded-md px-2 text-white'],
+							sidebarUI && 'rounded-[8px]',
+							bordered && 'input-border',
+							(isVersion || isEpic) && 'dark:text-white',
+							item.className
+						)}
+					/>
+					{isSelected && issueType !== 'issue' && (
+						<button
+							onClick={handleRemove}
+							className="absolute w-4 h-4 -translate-y-1/2 bg-transparent bg-white rounded right-1 top-1/2 dark:bg-black"
+						>
+							<XMarkIcon
+								className="text-dark dark:text-white"
+								height={16}
+								width={16}
+								aria-hidden="true"
+							/>
+						</button>
+					)}
+				</div>
+			);
+		},
+		[
+			showIcon,
+			issueType,
+			sidebarUI,
+			bordered,
+			isVersion,
+			isEpic,
+			onChange,
+			multiple,
+			processedValues,
+			onRemoveSelected
+		]
+	);
+	const handleChange = useCallback(
+		(selectedValue: any) => {
+			if (!onChange) return;
+
+			if (multiple) {
+				const valueArray = Array.isArray(selectedValue) ? selectedValue : [selectedValue];
+				const uniqueValues = [...new Set(valueArray)];
+				onChange(uniqueValues.join(','));
+			} else {
+				onChange(selectedValue);
+			}
+		},
+		[onChange, multiple]
+	);
+
 	const dropdown = (
 		<div className={cn('relative', className)}>
 			<Tooltip className="h-full" label={disabledReason} enabled={!enabled} placement="auto">
-				{(() => {
-					const triggerContent = !multiple ? (
-						<Tooltip
-							enabled={hasBtnIcon && (value?.name || '').length > 10}
-							label={capitalize(value?.name) || ''}
-							className="h-full"
-						>
-							{button}
-						</Tooltip>
-					) : (
-						<TaskStatus
-							{...defaultValue}
-							active={true}
-							forDetails={forDetails}
-							sidebarUI={sidebarUI}
-							className={cn(
-								'justify-between w-full capitalize h-full',
-								sidebarUI && ['text-xs'],
-								'text-dark dark:text-white bg-[#F2F2F2] dark:bg-dark--theme-light',
-								forDetails && 'bg-transparent border dark:border-[#FFFFFF33] dark:bg-[#1B1D22]',
-								taskStatusClassName
-							)}
-							name={
-								values.length > 0
-									? `Item${values.length === 1 ? '' : 's'} (${values.length})`
-									: defaultValue.name
-							}
-							isEpic={isEpic}
-						>
-							<ChevronDownIcon className={cn('w-5 h-5 text-default dark:text-white')} />
-						</TaskStatus>
-					);
-
-					const renderItem = (item: T, isSelected: boolean) => {
-						const item_value = item.value || item.name;
-						return (
-							<div className="relative w-full outline-none cursor-pointer">
-								<TaskStatus
-									showIcon={showIcon}
-									{...item}
-									checked={isSelected}
-									className={cn(
-										'!w-full',
-										issueType === 'issue' && ['rounded-md px-2 text-white'],
-										sidebarUI && 'rounded-[8px]',
-										bordered && 'input-border',
-										(isVersion || isEpic) && 'dark:text-white',
-										item.className
-									)}
-								/>
-								{isSelected && issueType !== 'issue' && (
-									<button
-										onClick={(e) => {
-											e.stopPropagation();
-											if (onChange && multiple && item_value) {
-												const newValues = values.filter((v) => v !== item_value);
-												onChange(newValues.join(','));
-											}
-											onRemoveSelected?.();
-										}}
-										className="absolute w-4 h-4 -translate-y-1/2 bg-transparent bg-white rounded right-1 top-1/2 dark:bg-black"
-									>
-										<XMarkIcon
-											className="text-dark dark:text-white"
-											height={16}
-											width={16}
-											aria-hidden="true"
-										/>
-									</button>
-								)}
-							</div>
-						);
-					};
-
-					const handleChange = (selectedValue: any) => {
-						if (!onChange) return;
-
-						if (multiple) {
-							const valueArray = Array.isArray(selectedValue) ? selectedValue : [selectedValue];
-							const uniqueValues = [...new Set(valueArray)];
-							onChange(uniqueValues.join(','));
-						} else {
-							onChange(selectedValue);
-						}
-					};
-
-					if (showButtonOnly) {
-						return (
+				{showButtonOnly ? (
+					<div
+						className={cn(!forDetails && 'w-full max-w-[170px]', 'cursor-pointer outline-none')}
+						style={{
+							width: largerWidth ? '160px' : ''
+						}}
+					>
+						{triggerContent}
+					</div>
+				) : (
+					<CustomListboxDropdown
+						children={children}
+						isMultiple={isMultiple}
+						value={value?.value || value?.name}
+						values={processedValues}
+						onChange={handleChange}
+						disabled={disabled}
+						enabled={enabled}
+						trigger={
 							<div
 								className={cn(!forDetails && 'w-full max-w-[170px]', 'cursor-pointer outline-none')}
 								style={{
@@ -807,35 +846,13 @@ export function StatusDropdown<T extends TStatusItem>({
 							>
 								{triggerContent}
 							</div>
-						);
-					}
-
-					return (
-						<CustomListboxDropdown
-							children={children}
-							isMultiple={isMultiple}
-							value={value?.value || value?.name}
-							values={values}
-							onChange={handleChange}
-							disabled={disabled}
-							enabled={enabled}
-							trigger={
-								<div
-									className={cn(!forDetails && 'w-full max-w-[170px]', 'cursor-pointer outline-none')}
-									style={{
-										width: largerWidth ? '160px' : ''
-									}}
-								>
-									{triggerContent}
-								</div>
-							}
-							items={items}
-							renderItem={renderItem as any}
-							multiple={multiple}
-							dropdownClassName="max-h-[320px] overflow-auto scrollbar-hide !border-b-0 dark:bg-[#1B1D22]"
-						/>
-					);
-				})()}
+						}
+						items={items}
+						renderItem={renderItem as any}
+						multiple={multiple}
+						dropdownClassName="max-h-[320px] overflow-auto scrollbar-hide !border-b-0 dark:bg-[#1B1D22]"
+					/>
+				)}
 			</Tooltip>
 		</div>
 	);

--- a/apps/web/core/components/tasks/task-status.tsx
+++ b/apps/web/core/components/tasks/task-status.tsx
@@ -487,7 +487,7 @@ export function TaskStatus({
 	showIssueLabels,
 	bordered,
 	titleClassName,
-	cheched = false,
+	checked = false,
 	showIcon = true,
 	sidebarUI = false,
 	realName,
@@ -501,7 +501,7 @@ export function TaskStatus({
 			showIssueLabels?: boolean;
 			forDetails?: boolean;
 			titleClassName?: string;
-			cheched?: boolean;
+			checked?: boolean;
 			sidebarUI?: boolean;
 			value?: string;
 			isVersion?: boolean;
@@ -540,7 +540,7 @@ export function TaskStatus({
 					titleClassName
 				)}
 			>
-				{cheched ? (
+				{checked ? (
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
 						viewBox="0 0 24 24"

--- a/apps/web/core/components/users/user-profile-plans.tsx
+++ b/apps/web/core/components/users/user-profile-plans.tsx
@@ -2,7 +2,7 @@
 import { useAtomValue } from 'jotai';
 import { AlertPopup, Container } from '@/core/components';
 import { DottedLanguageObjectStringPaths, useTranslations } from 'next-intl';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useCanSeeActivityScreen, useTimer, useUserProfilePage } from '@/core/hooks';
 import { useEmployeeDailyPlans } from '@/core/hooks/daily-plans/use-employee-daily-plans';
 import { useDeleteDailyPlan } from '@/core/hooks/daily-plans/use-delete-daily-plan';
@@ -15,7 +15,7 @@ import {
 	HAS_SEEN_DAILY_PLAN_SUGGESTION_MODAL,
 	HAS_VISITED_OUTSTANDING_TASKS
 } from '@/core/constants/config/constants';
-import { TUser } from '@/core/types/schemas';
+import { TDailyPlan, TUser } from '@/core/types/schemas';
 import { activeTeamState } from '@/core/stores';
 import { fullWidthState } from '@/core/stores/common/full-width';
 import { clsxm } from '@/core/lib/utils';
@@ -38,6 +38,8 @@ import { usePathname } from 'next/navigation';
 import { IconsCalendarMonthOutline } from '@/core/components/icons';
 import { VerticalSeparator } from '../duplicated-components/separator';
 import { AllPlans, EmptyPlans } from '@/core/components/daily-plan';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { filterDailyPlansByTasks } from '@/core/hooks';
 
 export type FilterTabs = 'Today Tasks' | 'Future Tasks' | 'Past Tasks' | 'All Tasks' | 'Outstanding';
 type FilterOutstanding = 'ALL' | 'DATE';
@@ -45,12 +47,15 @@ type FilterOutstanding = 'ALL' | 'DATE';
 interface IUserProfilePlansProps {
 	user?: TUser;
 	employeeId?: string; // Accept employeeId directly from parent
+	filteredTasks?: TTask[];
 }
 
 export function UserProfilePlans(props: IUserProfilePlansProps) {
 	const t = useTranslations();
 
-	const { user, employeeId: propsEmployeeId } = props;
+	const { user, employeeId: propsEmployeeId, filteredTasks } = props;
+
+	const filteredTaskIds = useMemo(() => filteredTasks?.map((task) => task.id), [filteredTasks]);
 
 	const profile = useUserProfilePage();
 	const { data: authUser } = useUserQuery();
@@ -87,22 +92,54 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 	const [currentTab, setCurrentTab] = useLocalStorageState<FilterTabs>('daily-plan-tab', 'Today Tasks');
 	const { setDate, date } = useDateRange(currentTab);
 
+	const filterPlanAndTask = useCallback(
+		(plans: TDailyPlan[]) => (filteredTaskIds ? filterDailyPlansByTasks(plans, filteredTaskIds) : plans),
+		[filteredTaskIds]
+	);
+
 	const screenOutstanding = {
-		ALL: <OutstandingAll profile={profile} user={user} outstandingPlans={employeeOutstandingPlans} />,
+		ALL: (
+			<OutstandingAll
+				profile={profile}
+				user={user}
+				outstandingPlans={employeeOutstandingPlans}
+				filteredTaskIds={filteredTaskIds}
+			/>
+		),
 		DATE: (
 			<OutstandingFilterDate
 				profile={profile}
 				user={user}
 				outstandingPlans={employeeOutstandingPlans}
 				filterByEmployee
+				filteredTaskIds={filteredTaskIds}
 			/>
 		)
 	};
 	const tabsScreens = {
-		'Today Tasks': <AllPlans profile={profile} currentTab={currentTab} user={user} employeeId={targetEmployeeId} />,
-		'Future Tasks': <FutureTasks profile={profile} user={user} employeeId={targetEmployeeId} />,
-		'Past Tasks': <PastTasks profile={profile} user={user} employeeId={targetEmployeeId} />,
-		'All Tasks': <AllPlans profile={profile} user={user} employeeId={targetEmployeeId} />,
+		'Today Tasks': (
+			<AllPlans
+				profile={profile}
+				currentTab={currentTab}
+				user={user}
+				filteredTaskIds={filteredTaskIds}
+				employeeId={targetEmployeeId}
+			/>
+		),
+		'Future Tasks': (
+			<FutureTasks
+				profile={profile}
+				user={user}
+				filteredTaskIds={filteredTaskIds}
+				employeeId={targetEmployeeId}
+			/>
+		),
+		'Past Tasks': (
+			<PastTasks profile={profile} user={user} filteredTaskIds={filteredTaskIds} employeeId={targetEmployeeId} />
+		),
+		'All Tasks': (
+			<AllPlans profile={profile} user={user} filteredTaskIds={filteredTaskIds} employeeId={targetEmployeeId} />
+		),
 		Outstanding: <Outstanding filter={screenOutstanding[currentOutstanding]} />
 	};
 	const dailyPlanSuggestionModalDate = window && window?.localStorage.getItem(DAILY_PLAN_SUGGESTION_MODAL_DATE);
@@ -152,9 +189,9 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 	// when targetEmployeeId changes (e.g., when viewing different user profiles)
 	const totalTasksDailyPlansMap = useMemo(() => {
 		// Apply date filtering to get the correct counts
-		const filteredFuturePlans = filterDailyPlan(date, employeeFuturePlans);
-		const filteredPastPlans = filterDailyPlan(date, employeePastPlans);
-		const filteredAllPlans = filterDailyPlan(date, employeeSortedPlans);
+		const filteredFuturePlans = filterDailyPlan(date, filterPlanAndTask(employeeFuturePlans));
+		const filteredPastPlans = filterDailyPlan(date, filterPlanAndTask(employeePastPlans));
+		const filteredAllPlans = filterDailyPlan(date, filterPlanAndTask(employeeSortedPlans));
 
 		return {
 			// filterByEmployee = false: show ALL tasks in daily plans (not just assigned to user)
@@ -165,7 +202,7 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 			// For Outstanding, ALWAYS filter by user (same logic as OutstandingAll component)
 			// This ensures the count matches what's actually displayed
 			Outstanding: estimatedTotalTime(
-				employeeOutstandingPlans.map((plan) => {
+				filterPlanAndTask(employeeOutstandingPlans).map((plan) => {
 					const tasks = plan.tasks ?? [];
 					// Filter by user if user exists (privacy/security - same as OutstandingAll)
 					return user
@@ -178,6 +215,7 @@ export function UserProfilePlans(props: IUserProfilePlansProps) {
 		employeeTodayPlan,
 		employeeFuturePlans,
 		employeePastPlans,
+		filterPlanAndTask,
 		employeeSortedPlans,
 		employeeOutstandingPlans,
 		user,

--- a/apps/web/core/hooks/daily-plans/use-filter-date-range.ts
+++ b/apps/web/core/hooks/daily-plans/use-filter-date-range.ts
@@ -58,3 +58,32 @@ export const filterDailyPlansByEmployee = (plans: TDailyPlan[], user: TUser | un
 		}))
 		.filter((plan) => plan.tasks && plan.tasks.length > 0);
 };
+
+/**
+ * Filters daily plans to retain only tasks matching the provided task IDs.
+ *
+ * Performs two-level filtering:
+ * 1. Removes non-matching tasks from each plan
+ * 2. Excludes plans with no remaining tasks
+ *
+ * Uses a Set for O(1) lookup performance.
+ *
+ * @param plans - The daily plans to filter
+ * @param taskIds - Task IDs to retain
+ * @returns Filtered plans containing only matching tasks
+ *
+ * @example
+ * filterDailyPlansByTasks(
+ *   [{ id: 'plan-1', tasks: [{ id: 'task-1' }, { id: 'task-2' }] }],
+ *   ['task-1']
+ * );
+ * // Returns: [{ id: 'plan-1', tasks: [{ id: 'task-1' }] }]
+ */
+export const filterDailyPlansByTasks = (plans: TDailyPlan[], taskIds: string[]): TDailyPlan[] => {
+	// Create a Set for efficient O(1) lookup performance
+	const taskIdSet = new Set(taskIds);
+
+	return plans
+		.map((plan) => ({ ...plan, tasks: plan.tasks?.filter((task) => taskIdSet.has(task?.id)) }))
+		.filter((plan) => plan?.tasks?.length);
+};

--- a/apps/web/core/hooks/tasks/use-task-status.ts
+++ b/apps/web/core/hooks/tasks/use-task-status.ts
@@ -193,6 +193,7 @@ export function useStatusValue<T extends ITaskStatusField>({
 
 	const [value, setValue] = useState<ITaskStatusStack[T] | undefined>($value);
 	const [values, setValues] = useState<ITaskStatusStack[T][]>(defaultValues);
+	const valuesRef = useSyncRef(values);
 	// Use external value ($value) for immediate UI updates, fallback to internal state (value)
 	const effectiveValue = $value !== undefined ? $value : value;
 	const item: TStatusItem | undefined = useMemo(
@@ -215,22 +216,20 @@ export function useStatusValue<T extends ITaskStatusField>({
 	const onChange = useCallback(
 		(value: ITaskStatusStack[T]) => {
 			if (multipleRef.current) {
-				setValues((prevValues) => {
-					const newValues =
-						typeof value === 'string'
-							? prevValues.includes(value)
-								? prevValues.filter((v) => v !== value)
-								: [...prevValues, value]
-							: Array.isArray(value)
-								? value
-								: [value];
-
-					onValueChangeRef.current?.(value, newValues);
-					return newValues;
-				});
+				const prevValues = valuesRef.current;
+				const newValues =
+					typeof value === 'string'
+						? prevValues.includes(value)
+							? prevValues.filter((v) => v !== value)
+							: [...prevValues, value]
+						: Array.isArray(value)
+							? value
+							: [value];
+				setValues(newValues);
+				onValueChangeRef?.current?.(value, newValues);
 			} else {
 				setValue(value);
-				onValueChangeRef.current?.(value, [value]);
+				onValueChangeRef?.current?.(value, [value]);
 			}
 		},
 		[onValueChangeRef, multipleRef]


### PR DESCRIPTION
# ETP-219 Fix Profile Page Filter Dropdowns Not Applying Selections

## Description

**Problem:** On the Profile page, when selecting an item from any filter dropdown (priority, size, status, etc.), the filter panel closes immediately without applying the selected filter. The user's selection is not validated or applied to the task list.

**Solution:**
- Fixed dropdown behavior to properly apply filters before closing
- Added `DailyPlans` filtering based on filtered tasks
- Properly propagated `filteredTaskIds` to child components

## What Was Changed

### Major Changes

- New `filterDailyPlansByTasks` utility function to filter plans by task IDs
- Added `filteredTaskIds` prop to `UserProfilePlans` and its children
- Integrated filtering logic in `outstanding-date.tsx` and `past-date.tsx`

## How to Test This PR

1. Run `yarn start:web:dev` → `http://localhost:3030`
2. Navigate to the **Member Profile** page
3. Test each filter dropdown (Priority, Size, Status, Labels)
4. Verify:
   - ✅ Selection is applied to the task list,when click on Apply Button
   - ✅ Active filters are visually indicated
   - ✅ Reset button works correctly
   - ✅ DailyPlans display only filtered tasks

## Screenshots

### Before

https://github.com/user-attachments/assets/7aaaa1aa-c0a6-4ac8-921e-c1889b8f52ba 

### After

https://github.com/user-attachments/assets/563a62dd-b309-43a9-9738-b5a075e73071

## Related Issues

- Closes [ETP-219](https://evertech.atlassian.net/browse/ETP-219)

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Reviewers Suggested

- `@evereq` for architecture validation
- `@ndekocode` for integration review


[ETP-219]: https://evertech.atlassian.net/browse/ETP-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Profile page filter dropdowns so selections apply without closing early, and makes Daily Plans respect selected task filters across Today/Future/Past/All and Outstanding with matching counts (ETP-219).

- **Bug Fixes**
  - Apply selection before closing in CustomListboxDropdown/StatusDropdown for single and multi-select.
  - Pass filteredTaskIds from Profile filters into UserProfilePlans and into All/Future/Past/Outstanding views.
  - Add filterDailyPlansByTasks to drop non-matching tasks and empty plans; used for lists and counters.
  - Fix use-task-status multi-select handler to avoid render errors and ensure onValueChange fires reliably.
  - Filter and dedupe Outstanding (All/By Date) so TaskEstimatedCount matches the visible tasks.
  - Rename TaskStatus prop cheched -> checked to avoid prop mismatch.

<sup>Written for commit ba3156b80f42f12362d81fdcc59de24a88c81d16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added task-based filtering across daily plans and user profile views so lists and counts can be limited to specific tasks.
  * New utility to filter plans by task IDs for consistent cross-view filtering.

* **Improvements**
  * Dropdown and status controls optimized with memoization and callbacks for smoother, more reliable selection behavior.
  * Selection handling guarded to avoid duplicate entries and improve performance.

* **Bug Fixes**
  * Plan counts and totals now correctly reflect applied task filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->