### PR TITLE
[ETP-228] task web refactor use team invitations segregate admin vs user responsibilities

### DIFF
--- a/apps/web/app/[locale]/page-component.tsx
+++ b/apps/web/app/[locale]/page-component.tsx
@@ -1,7 +1,8 @@
 'use client';
 import React, { Suspense, useEffect } from 'react';
 
-import { useIsMemberManager, useTeamInvitations } from '@/core/hooks';
+import { useIsMemberManager } from '@/core/hooks';
+import { useMyInvitationsQuery } from '@/core/hooks/invitations/use-my-invitations-query';
 import { useEmployeeDailyPlans } from '@/core/hooks/daily-plans/use-employee-daily-plans';
 import { clsxm } from '@/core/lib/utils';
 import { withAuthentication } from '@/core/components/layouts/app/authenticator';
@@ -41,7 +42,7 @@ import {
 	LazyTeamMemberHeader
 } from '@/core/components/optimized-components/teams';
 import { LazyChatwootWidget, LazyUnverifiedEmail, LazyNoTeam } from '@/core/components/optimized-components/common';
-import { activeTeamState, isTeamMemberState, isTrackingEnabledState, myInvitationsState } from '@/core/stores';
+import { activeTeamState, isTeamMemberState, isTrackingEnabledState } from '@/core/stores';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
 function MainPage() {
@@ -59,8 +60,7 @@ function MainPage() {
 
 	const { isTeamManager } = useIsMemberManager(user);
 
-	const myInvitationsList = useAtomValue(myInvitationsState);
-	const { myInvitations } = useTeamInvitations();
+	const { myInvitations: myInvitationsList, refetchMyInvitations } = useMyInvitationsQuery();
 	const [fullWidth, setFullWidth] = useAtom(fullWidthState);
 	const [view, setView] = useAtom(headerTabs);
 	const path = usePathname();
@@ -127,7 +127,7 @@ function MainPage() {
 												<LazyTeamInvitations
 													className="!m-0"
 													myInvitationsList={myInvitationsList}
-													myInvitations={myInvitations}
+													myInvitations={refetchMyInvitations}
 												/>
 											</Suspense>
 										)}

--- a/apps/web/core/components/features/teams/invite-form-modal.tsx
+++ b/apps/web/core/components/features/teams/invite-form-modal.tsx
@@ -6,7 +6,7 @@ import { BackButton, Button, Modal, Text } from '@/core/components';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { InviteEmailDropdown } from '../../teams/invite/invite-email-dropdown';
-import { useTeamInvitations } from '@/core/hooks/organizations';
+import { useSendTeamInvitation } from '@/core/hooks/invitations/use-send-team-invitation';
 import { EverCard } from '@/core/components/common/ever-card';
 import { InputField } from '../../duplicated-components/_input';
 import { IInviteEmail } from '../../teams/invite/invite-email-item';
@@ -23,7 +23,7 @@ export function InviteFormModal({ open, closeModal }: { open: boolean; closeModa
 	const t = useTranslations();
 
 	const teamInvitations = useAtomValue(getTeamInvitationsState);
-	const { inviteUser, inviteLoading, resendTeamInvitation, resendInviteLoading } = useTeamInvitations();
+	const { inviteUser, inviteLoading, resendTeamInvitation, resendInviteLoading } = useSendTeamInvitation();
 
 	const [errors, setErrors] = useState<{ email?: string; name?: string; role?: string }>({});
 	const [selectedEmail, setSelectedEmail] = useState<IInviteEmail>();

--- a/apps/web/core/components/features/teams/invite-modal.tsx
+++ b/apps/web/core/components/features/teams/invite-modal.tsx
@@ -1,4 +1,5 @@
-import { useTeamInvitations } from '@/core/hooks/organizations/teams/use-team-invitations';
+import { useTeamInvitationsQuery } from '@/core/hooks/invitations/use-team-invitations-query';
+import { useSendTeamInvitation } from '@/core/hooks/invitations/use-send-team-invitation';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { Spinner } from '@/core/components/common/spinner';
 import { Dialog, DialogPanel, Transition, TransitionChild } from '@headlessui/react';
@@ -35,8 +36,8 @@ const InviteModal = ({ isOpen, closeModal }: IInviteProps) => {
 		...initialValues,
 		roleId: defaultSelectedRole?.id
 	});
-	const { inviteUser, inviteLoading, teamInvitations, resendTeamInvitation, resendInviteLoading } =
-		useTeamInvitations();
+	const { teamInvitations } = useTeamInvitationsQuery();
+	const { inviteUser, inviteLoading, resendTeamInvitation, resendInviteLoading } = useSendTeamInvitation();
 
 	const isAdmin = user?.role?.name && [ERoleName.ADMIN, ERoleName.SUPER_ADMIN].includes(user?.role.name as ERoleName);
 	const allowedRoles = new Set([ERoleName.ADMIN, ERoleName.EMPLOYEE, ERoleName.MANAGER]);

--- a/apps/web/core/components/layouts/app/init-state.tsx
+++ b/apps/web/core/components/layouts/app/init-state.tsx
@@ -13,10 +13,11 @@ import { useTeamDailyPlans } from '@/core/hooks/daily-plans/use-team-daily-plans
 import {
 	useOrganizationTeamsQuery,
 	useTeamTasksQuery,
-	useTeamInvitations,
 	useOrganizationProjects,
 	useEmployee
 } from '@/core/hooks/organizations';
+import { useTeamInvitationsQuery } from '@/core/hooks/invitations/use-team-invitations-query';
+import { useMyInvitationsQuery } from '@/core/hooks/invitations/use-my-invitations-query';
 import { useWorkspaces, useCurrentOrg, useAuthenticateUser } from '@/core/hooks/auth';
 import { useRolePermissions, useRoles } from '@/core/hooks/roles';
 import {
@@ -46,7 +47,8 @@ function InitState() {
 	const publicTeam = useAtomValue(publicState);
 	const { loadTeamsData, firstLoadTeamsData } = useOrganizationTeamsQuery();
 	const { firstLoadTasksData, loadTeamTasksData } = useTeamTasksQuery();
-	const { firstLoadTeamInvitationsData, myInvitations } = useTeamInvitations();
+	const { firstLoadTeamInvitationsData } = useTeamInvitationsQuery();
+	const { refetchMyInvitations } = useMyInvitationsQuery();
 	const { getTimerStatus, firstLoadTimerData } = useTimer();
 	const { firstLoadtasksStatisticsData } = useTaskStatistics();
 	const { loadLanguagesData, firstLoadLanguagesData } = useLanguageSettings();
@@ -186,7 +188,7 @@ function InitState() {
 			// 	true /* used as getTimerStatus deepCheck param */
 			// );
 
-			useRefreshIntervalV2(myInvitations, 60 * 1000, true /* used as loadTeamTasksData deepCheck param */);
+			useRefreshIntervalV2(refetchMyInvitations, 60 * 1000, true /* used as refetchMyInvitations deepCheck param */);
 
 			useRefreshIntervalV2(loadTaskStatusesData, five_minutes, true);
 			useRefreshIntervalV2(loadTaskPriorities, five_minutes, true);

--- a/apps/web/core/components/teams/invite/user-invite-card.tsx
+++ b/apps/web/core/components/teams/invite/user-invite-card.tsx
@@ -1,11 +1,11 @@
-import { useTeamInvitations } from '@/core/hooks';
+import { useSendTeamInvitation } from '@/core/hooks/invitations/use-send-team-invitation';
+import { useRemoveTeamInvitation } from '@/core/hooks/invitations/use-remove-team-invitation';
 import { IClassName } from '@/core/types/interfaces/common/class-name';
 import { clsxm } from '@/core/lib/utils';
 import { Popover, PopoverButton, PopoverPanel, Transition } from '@headlessui/react';
-import { SixSquareGridIcon, ThreeCircleOutlineVerticalIcon } from 'assets/svg';
+import { SixSquareGridIcon, ThreeCircleOutlineVerticalIcon, MailIcon } from 'assets/svg';
 import { Button, ConfirmDropdown, SpinnerLoader, Text } from '@/core/components';
 import { useTranslations } from 'next-intl';
-import { MailIcon } from 'assets/svg';
 import { toast } from 'sonner';
 import { TimerStatus } from '@/core/components/timer/timer-status';
 import { EverCard } from '@/core/components/common/ever-card';
@@ -61,7 +61,7 @@ export function InvitedCard({ invitation, className }: Props) {
 					</div>
 
 					<div className="w-1/2 lg:w-64">
-						<div className="flex items-center gap-2">
+						<div className="flex gap-2 items-center">
 							<Text.Heading
 								className="overflow-hidden text-ellipsis whitespace-nowrap lg:max-w-[15ch] xl:max-w-[17ch] 2xl:max-w-full"
 								as="h3"
@@ -170,8 +170,8 @@ export function InvitedCard({ invitation, className }: Props) {
 
 export function RemoveUserInviteMenu({ invitation }: Props) {
 	const t = useTranslations();
-	const { removeInviteLoading, removeTeamInvitation, resendTeamInvitation, resendInviteLoading } =
-		useTeamInvitations();
+	const { resendTeamInvitation, resendInviteLoading } = useSendTeamInvitation();
+	const { removeTeamInvitation, removeInviteLoading } = useRemoveTeamInvitation();
 
 	const loading = removeInviteLoading || resendInviteLoading;
 

--- a/apps/web/core/components/teams/team-invitations.tsx
+++ b/apps/web/core/components/teams/team-invitations.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useModal, useTeamInvitations } from '@/core/hooks';
+import { useModal } from '@/core/hooks';
+import { useRespondToInvitation } from '@/core/hooks/invitations/use-respond-to-invitation';
+import { useMyInvitationsQuery } from '@/core/hooks/invitations/use-my-invitations-query';
 import { clsxm } from '@/core/lib/utils';
 import { Button, Modal, Text } from '@/core/components';
 import { CrossCircleIcon as CloseCircleIcon } from 'assets/svg';
@@ -21,7 +23,8 @@ interface IProps {
 export function TeamInvitations(props: IProps) {
 	const { className, myInvitationsList, myInvitations } = props;
 	const t = useTranslations();
-	const { removeMyInvitation, acceptRejectMyInvitation, acceptRejectMyInvitationsLoading } = useTeamInvitations();
+	const { acceptOrRejectInvitation, acceptOrRejectLoading } = useRespondToInvitation();
+	const { removeMyInvitation } = useMyInvitationsQuery();
 	const { isOpen, closeModal, openModal } = useModal();
 	const [action, setAction] = useState<EInviteAction>();
 	const [actionInvitationId, setActionInvitationId] = useState<string>();
@@ -42,9 +45,9 @@ export function TeamInvitations(props: IProps) {
 
 	const handleAcceptReject = useCallback(async () => {
 		if (actionInvitationId && action) {
-			return acceptRejectMyInvitation(actionInvitationId, action);
+			return acceptOrRejectInvitation(actionInvitationId, action);
 		}
-	}, [action, actionInvitationId, acceptRejectMyInvitation]);
+	}, [action, actionInvitationId, acceptOrRejectInvitation]);
 	const handleOpenModal = (invitationid: string, action: EInviteAction) => {
 		setAction(action);
 		setActionInvitationId(invitationid);
@@ -118,7 +121,7 @@ export function TeamInvitations(props: IProps) {
 				open={isOpen}
 				close={closeModal}
 				onAction={handleAcceptReject}
-				loading={acceptRejectMyInvitationsLoading}
+				loading={acceptOrRejectLoading}
 				title={
 					action === EInviteAction.ACCEPTED
 						? t('pages.home.CONFIRM_ACCEPT_INVITATION')

--- a/apps/web/core/hooks/auth/use-accept-invite.ts
+++ b/apps/web/core/hooks/auth/use-accept-invite.ts
@@ -1,6 +1,6 @@
 import { EInvitationState, TInvitationState } from '@/core/types/schemas/user/invite.schema';
 import { useCallback, useState } from 'react';
-import { useTeamInvitations } from '../organizations';
+import { useInviteValidation } from '../invitations/use-invite-validation';
 import { userOrganizationService } from '@/core/services/client/api/users/user-organization.service';
 import { organizationTeamService } from '@/core/services/client/api/organizations/teams/team.service';
 import { CookiesDataType, setAuthCookies } from '@/core/lib/helpers/cookies';
@@ -11,7 +11,7 @@ export function useAcceptInvite() {
 		data: null,
 		error: null
 	});
-	const { acceptInvitationLoading, acceptInvitationMutation, validateInviteByCode } = useTeamInvitations();
+	const { acceptInvitationLoading, acceptInvitationMutation, validateInviteByCode } = useInviteValidation();
 
 	const handleAcceptInvitation = useCallback(
 		async ({

--- a/apps/web/core/hooks/index.ts
+++ b/apps/web/core/hooks/index.ts
@@ -4,6 +4,7 @@ export * from './auth';
 export * from './daily-plans';
 export * from './favorites';
 export * from './integrations';
+export * from './invitations';
 export * from './organizations';
 export * from './roles';
 export * from './tags';

--- a/apps/web/core/hooks/invitations/index.ts
+++ b/apps/web/core/hooks/invitations/index.ts
@@ -1,0 +1,15 @@
+// Shared
+export * from './use-invitation-invalidation';
+
+// Team invitations (Admin/Manager)
+export * from './use-team-invitations-query';
+export * from './use-send-team-invitation';
+export * from './use-remove-team-invitation';
+
+// My invitations (User)
+export * from './use-my-invitations-query';
+export * from './use-respond-to-invitation';
+
+// Validation (Public/Auth)
+export * from './use-invite-validation';
+

--- a/apps/web/core/hooks/invitations/use-invitation-invalidation.ts
+++ b/apps/web/core/hooks/invitations/use-invitation-invalidation.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { queryKeys } from '@/core/query/keys';
+import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
+import { useUserQuery } from '../queries/user-user.query';
+
+/**
+ * Shared cache invalidation logic for invitation mutations.
+ * Ensures consistent cache invalidation across all invitation operations.
+ *
+ * Following the same pattern as `useDailyPlanInvalidation`.
+ *
+ * @returns Object containing invalidation functions for team and user invitations
+ */
+export function useInvitationInvalidation() {
+	const queryClient = useQueryClient();
+	const { data: user } = useUserQuery();
+	const activeTeamId = getActiveTeamIdCookie();
+
+	const invalidateTeamInvitations = useCallback(() => {
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.users.invitations.team(
+				user?.tenantId || '',
+				user?.employee?.organizationId || '',
+				activeTeamId || ''
+			)
+		});
+	}, [queryClient, user?.tenantId, user?.employee?.organizationId, activeTeamId]);
+
+	const invalidateMyInvitations = useCallback(() => {
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.users.invitations.all
+		});
+	}, [queryClient]);
+
+	return { invalidateTeamInvitations, invalidateMyInvitations };
+}
+

--- a/apps/web/core/hooks/invitations/use-invite-validation.ts
+++ b/apps/web/core/hooks/invitations/use-invite-validation.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { inviteService } from '../../services/client/api/organizations/teams/invites';
+import { IInviteVerifyCode } from '@/core/types/interfaces/user/invite';
+import { TAcceptInvitationRequest, TValidateInviteRequest } from '@/core/types/schemas/user/invite.schema';
+import { useInvitationInvalidation } from './use-invitation-invalidation';
+
+/**
+ * Hook for invitation validation operations (Public/Auth pages).
+ * All operations use `useMutation` since they are imperative (triggered by user action).
+ *
+ * @returns Object containing validation and accept mutation functions with their loading states
+ */
+export function useInviteValidation() {
+	const { invalidateMyInvitations } = useInvitationInvalidation();
+
+	// ===== VALIDATE BY TOKEN =====
+
+	const validateByTokenMutation = useMutation({
+		mutationFn: async (params: TValidateInviteRequest) => {
+			return await inviteService.validateInviteByTokenAndEmail(params);
+		}
+	});
+
+	const validateInviteByTokenAndEmail = useCallback(
+		(params: TValidateInviteRequest) => {
+			return validateByTokenMutation.mutateAsync(params);
+		},
+		[validateByTokenMutation]
+	);
+
+	// ===== VALIDATE BY CODE =====
+
+	const validateByCodeMutation = useMutation({
+		mutationFn: async (params: IInviteVerifyCode) => {
+			return await inviteService.validateInvitationByCodeAndEmail(params);
+		}
+	});
+
+	const validateInviteByCode = useCallback(
+		(params: IInviteVerifyCode) => {
+			return validateByCodeMutation.mutateAsync(params);
+		},
+		[validateByCodeMutation]
+	);
+
+	// ===== ACCEPT INVITATION =====
+
+	const acceptInvitationMutation = useMutation({
+		mutationFn: async (data: TAcceptInvitationRequest) => {
+			return await inviteService.acceptInvite(data);
+		},
+		onSuccess: () => {
+			invalidateMyInvitations();
+		}
+	});
+
+	// ===== RETURN =====
+
+	return {
+		validateInviteByTokenAndEmail,
+		validateInviteByTokenAndEmailLoading: validateByTokenMutation.isPending,
+		validateInviteByCode,
+		validateInviteByCodeLoading: validateByCodeMutation.isPending,
+		acceptInvitationMutation,
+		acceptInvitationLoading: acceptInvitationMutation.isPending
+	};
+}
+

--- a/apps/web/core/hooks/invitations/use-my-invitations-query.ts
+++ b/apps/web/core/hooks/invitations/use-my-invitations-query.ts
@@ -3,10 +3,12 @@
 import { myInvitationsState } from '@/core/stores';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { inviteService } from '../../services/client/api/organizations/teams/invites';
 import { queryKeys } from '@/core/query/keys';
 import { useUserQuery } from '../queries/user-user.query';
+import { PaginationResponse } from '@/core/types/interfaces/common/data-response';
+import { TInvite } from '@/core/types/schemas';
 
 /**
  * Hook for reading the current user's invitations.
@@ -17,6 +19,7 @@ import { useUserQuery } from '../queries/user-user.query';
  * @returns Object containing user invitations data, loading states, and refetch callback
  */
 export function useMyInvitationsQuery() {
+	const queryClient = useQueryClient();
 	const setMyInvitations = useSetAtom(myInvitationsState);
 	const myInvitationsAtom = useAtomValue(myInvitationsState);
 
@@ -59,9 +62,23 @@ export function useMyInvitationsQuery() {
 
 	const removeMyInvitation = useCallback(
 		(id: string) => {
+			// Update Jotai atom (backward compat for legacy consumers)
 			setMyInvitations((prev) => prev.filter((invitation) => invitation.id !== id));
+
+			// Update React Query cache so hydrated `myInvitations` reflects the removal immediately
+			queryClient.setQueryData<PaginationResponse<TInvite>>(
+				queryKeys.users.invitations.my(user?.tenantId || ''),
+				(old) => {
+					if (!old) return old;
+					return {
+						...old,
+						items: old.items.filter((invitation) => invitation.id !== id),
+						total: old.total - 1
+					};
+				}
+			);
 		},
-		[setMyInvitations]
+		[setMyInvitations, queryClient, user?.tenantId]
 	);
 
 	// ===== REFETCH CALLBACK =====

--- a/apps/web/core/hooks/invitations/use-my-invitations-query.ts
+++ b/apps/web/core/hooks/invitations/use-my-invitations-query.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { myInvitationsState } from '@/core/stores';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useQuery } from '@tanstack/react-query';
+import { inviteService } from '../../services/client/api/organizations/teams/invites';
+import { queryKeys } from '@/core/query/keys';
+import { useUserQuery } from '../queries/user-user.query';
+
+/**
+ * Hook for reading the current user's invitations.
+ * READ only — no mutations. Following Single Responsibility Principle.
+ *
+ * Use `useRespondToInvitation` for accept/reject operations.
+ *
+ * @returns Object containing user invitations data, loading states, and refetch callback
+ */
+export function useMyInvitationsQuery() {
+	const setMyInvitations = useSetAtom(myInvitationsState);
+	const myInvitationsAtom = useAtomValue(myInvitationsState);
+
+	const { data: user } = useUserQuery();
+
+	// ===== QUERY =====
+
+	const {
+		data: myInvitationsData,
+		isLoading: myInvitationsLoading,
+		isSuccess: myInvitationsSuccess,
+		refetch: refetchMyInvitationsQuery
+	} = useQuery({
+		queryKey: queryKeys.users.invitations.my(user?.tenantId || ''),
+		queryFn: async () => {
+			return await inviteService.getMyInvitations();
+		},
+		enabled: !!user?.tenantId,
+		staleTime: 2 * 60 * 1000, // 2 minutes — prevents unnecessary refetch on re-mount
+		gcTime: 5 * 60 * 1000 // 5 minutes — keeps data in cache after unmount
+	});
+
+	// ===== JOTAI SYNCHRONIZATION =====
+
+	useEffect(() => {
+		if (myInvitationsSuccess && myInvitationsData?.items) {
+			setMyInvitations(myInvitationsData.items);
+		}
+	}, [myInvitationsSuccess, myInvitationsData?.items, setMyInvitations]);
+
+	// ===== HYDRATED DATA =====
+
+	const myInvitations = useMemo(() => {
+		return myInvitationsSuccess && myInvitationsData?.items
+			? (myInvitationsData?.items ?? myInvitationsAtom)
+			: [];
+	}, [myInvitationsData?.items, myInvitationsSuccess, myInvitationsAtom]);
+
+	// ===== LOCAL STATE OPERATIONS =====
+
+	const removeMyInvitation = useCallback(
+		(id: string) => {
+			setMyInvitations((prev) => prev.filter((invitation) => invitation.id !== id));
+		},
+		[setMyInvitations]
+	);
+
+	// ===== REFETCH CALLBACK =====
+
+	const refetchMyInvitations = useCallback(() => {
+		refetchMyInvitationsQuery();
+	}, [refetchMyInvitationsQuery]);
+
+	// ===== RETURN =====
+
+	return {
+		myInvitations,
+		myInvitationsLoading,
+		refetchMyInvitations,
+		removeMyInvitation
+	};
+}
+

--- a/apps/web/core/hooks/invitations/use-my-invitations-query.ts
+++ b/apps/web/core/hooks/invitations/use-my-invitations-query.ts
@@ -69,11 +69,12 @@ export function useMyInvitationsQuery() {
 			queryClient.setQueryData<PaginationResponse<TInvite>>(
 				queryKeys.users.invitations.my(user?.tenantId || ''),
 				(old) => {
-					if (!old) return old;
+					if (!old?.items) return old;
+					const filtered = old.items.filter((invitation) => invitation.id !== id);
 					return {
 						...old,
-						items: old.items.filter((invitation) => invitation.id !== id),
-						total: old.total - 1
+						items: filtered,
+						total: old.total - (old.items.length - filtered.length)
 					};
 				}
 			);

--- a/apps/web/core/hooks/invitations/use-remove-team-invitation.ts
+++ b/apps/web/core/hooks/invitations/use-remove-team-invitation.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { teamInvitationsState } from '@/core/stores';
+import { useCallback } from 'react';
+import { useSetAtom } from 'jotai';
+import { useMutation } from '@tanstack/react-query';
+import { inviteService } from '../../services/client/api/organizations/teams/invites';
+import { toast } from 'sonner';
+import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
+import { useIsMemberManager } from '../organizations/teams/use-team-member';
+import { useUserQuery } from '../queries/user-user.query';
+import { useInvitationInvalidation } from './use-invitation-invalidation';
+
+/**
+ * Hook for removing team invitations (Admin/Manager).
+ * WRITE only — single destructive operation. Following Single Responsibility Principle.
+ *
+ * @returns Object containing remove mutation function and its loading state
+ */
+export function useRemoveTeamInvitation() {
+	const setTeamInvitations = useSetAtom(teamInvitationsState);
+	const { invalidateTeamInvitations } = useInvitationInvalidation();
+
+	const activeTeamId = getActiveTeamIdCookie();
+	const { data: user } = useUserQuery();
+	const { isTeamManager } = useIsMemberManager(user);
+
+	// ===== REMOVE INVITATION =====
+
+	const removeInvitationMutation = useMutation({
+		mutationFn: async ({ invitationId }: { invitationId: string; email?: string }) => {
+			if (!activeTeamId) throw new Error('Missing team ID');
+			return await inviteService.removeTeamInvitations({
+				invitationId,
+				teamId: activeTeamId
+			});
+		},
+		onSuccess: (result, { email }) => {
+			if (email) {
+				toast.success('Invitation removed', {
+					description: `Invitation removed for ${email}`,
+					duration: 5000
+				});
+			}
+			setTeamInvitations(result.items || []);
+			invalidateTeamInvitations();
+		}
+	});
+
+	const removeTeamInvitation = useCallback(
+		(invitationId: string, email?: string) => {
+			if (!(activeTeamId && isTeamManager && user?.tenantId)) {
+				return Promise.resolve();
+			}
+			return removeInvitationMutation.mutateAsync({ invitationId, email });
+		},
+		[removeInvitationMutation, activeTeamId, isTeamManager, user]
+	);
+
+	// ===== RETURN =====
+
+	return {
+		removeTeamInvitation,
+		removeInviteLoading: removeInvitationMutation.isPending
+	};
+}
+

--- a/apps/web/core/hooks/invitations/use-respond-to-invitation.ts
+++ b/apps/web/core/hooks/invitations/use-respond-to-invitation.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { myInvitationsState } from '@/core/stores';
+import { useCallback } from 'react';
+import { useSetAtom } from 'jotai';
+import { useMutation } from '@tanstack/react-query';
+import { inviteService } from '../../services/client/api/organizations/teams/invites';
+import { useAuthenticateUser } from '../auth';
+import { EInviteAction } from '@/core/types/generics/enums/invite';
+import { useRouter } from 'next/navigation';
+import { useInvitationInvalidation } from './use-invitation-invalidation';
+
+/**
+ * Hook for responding to invitations (accept or reject).
+ * WRITE only — single mutation operation. Following Single Responsibility Principle.
+ *
+ * Side effects are centralized here:
+ * - On accept: refreshToken + router.refresh (session update)
+ * - On reject: optimistic Jotai update + cross-cache invalidation
+ *
+ * @returns Object containing respond mutation function and its loading state
+ */
+export function useRespondToInvitation() {
+	const router = useRouter();
+	const setMyInvitations = useSetAtom(myInvitationsState);
+	const { refreshToken } = useAuthenticateUser();
+	const { invalidateTeamInvitations, invalidateMyInvitations } = useInvitationInvalidation();
+
+	// ===== ACCEPT / REJECT =====
+
+	const acceptOrRejectMutation = useMutation({
+		mutationFn: async ({ id, action }: { id: string; action: EInviteAction }) => {
+			return await inviteService.acceptRejectMyInvitations(id, action);
+		},
+		onSuccess: async (res, { id, action }) => {
+			if (res.message) {
+				return res.message;
+			}
+
+			if (action === EInviteAction.ACCEPTED) {
+				await refreshToken();
+				router.refresh();
+				return res;
+			}
+
+			// Optimistic update for rejection
+			setMyInvitations((prev) => prev.filter((invitation) => invitation.id !== id));
+
+			// Cross-invalidate both caches
+			invalidateTeamInvitations();
+			invalidateMyInvitations();
+
+			return res;
+		}
+	});
+
+	const acceptOrRejectInvitation = useCallback(
+		(id: string, action: EInviteAction) => {
+			return acceptOrRejectMutation.mutateAsync({ id, action });
+		},
+		[acceptOrRejectMutation]
+	);
+
+	// ===== RETURN =====
+
+	return {
+		acceptOrRejectInvitation,
+		acceptOrRejectLoading: acceptOrRejectMutation.isPending
+	};
+}
+

--- a/apps/web/core/hooks/invitations/use-send-team-invitation.ts
+++ b/apps/web/core/hooks/invitations/use-send-team-invitation.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { inviteService } from '../../services/client/api/organizations/teams/invites';
+import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
+import { InviteUserParams } from '@/core/types/interfaces/user/invite';
+import { useUserQuery } from '../queries/user-user.query';
+import { useInvitationInvalidation } from './use-invitation-invalidation';
+
+/**
+ * Hook for sending team invitations (invite new user + resend existing invitation).
+ * WRITE only — send operations grouped by semantic cohesion.
+ *
+ * @returns Object containing invite/resend mutation functions and their loading states
+ */
+export function useSendTeamInvitation() {
+	const { invalidateTeamInvitations } = useInvitationInvalidation();
+	const activeTeamId = getActiveTeamIdCookie();
+	const { data: user } = useUserQuery();
+
+	// ===== INVITE USER =====
+
+	const inviteUserMutation = useMutation({
+		mutationFn: async (params: InviteUserParams) => {
+			return await inviteService.inviteByEmails({
+				email: params.email,
+				name: params.name,
+				organizationId: params.organizationId,
+				teamId: params.teamId,
+				roleId: params.roleId
+			});
+		},
+		onSuccess: () => {
+			invalidateTeamInvitations();
+		}
+	});
+
+	const inviteUser = useCallback(
+		(email: string, name: string, roleId?: string) => {
+			if (!user?.employee?.organizationId || !activeTeamId || !user?.tenantId) {
+				return Promise.reject(new Error('Missing required parameters'));
+			}
+
+			return inviteUserMutation.mutateAsync({
+				email,
+				name,
+				organizationId: user.employee.organizationId,
+				teamId: activeTeamId,
+				tenantId: user.tenantId,
+				roleId
+			});
+		},
+		[inviteUserMutation, user, activeTeamId]
+	);
+
+	// ===== RESEND INVITATION =====
+
+	const resendInvitationMutation = useMutation({
+		mutationFn: async (invitationId: string) => {
+			return await inviteService.resendTeamInvitations(invitationId);
+		},
+		onSuccess: () => {
+			invalidateTeamInvitations();
+		}
+	});
+
+	const resendTeamInvitation = useCallback(
+		(invitationId: string) => {
+			return resendInvitationMutation.mutateAsync(invitationId);
+		},
+		[resendInvitationMutation]
+	);
+
+	// ===== RETURN =====
+
+	return {
+		inviteUser,
+		inviteLoading: inviteUserMutation.isPending,
+		resendTeamInvitation,
+		resendInviteLoading: resendInvitationMutation.isPending
+	};
+}
+

--- a/apps/web/core/hooks/invitations/use-team-invitations-query.ts
+++ b/apps/web/core/hooks/invitations/use-team-invitations-query.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { fetchingTeamInvitationsState, getTeamInvitationsState, teamInvitationsState } from '@/core/stores';
+import { useEffect, useMemo } from 'react';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useQuery } from '@tanstack/react-query';
+import { useFirstLoad } from '../common/use-first-load';
+import { inviteService } from '../../services/client/api/organizations/teams/invites';
+import { queryKeys } from '@/core/query/keys';
+import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
+import { TeamInvitationsQueryParams } from '@/core/types/interfaces/user/invite';
+import { useIsMemberManager } from '../organizations/teams/use-team-member';
+import { useUserQuery } from '../queries/user-user.query';
+
+/**
+ * Hook for reading team invitations (Admin/Manager).
+ * READ only — no mutations. Following Single Responsibility Principle.
+ *
+ * Use `useSendTeamInvitation` for send operations (invite, resend).
+ * Use `useRemoveTeamInvitation` for removing invitations.
+ *
+ * @returns Object containing team invitations data, loading states, and firstLoad callback
+ */
+export function useTeamInvitationsQuery() {
+	const setTeamInvitations = useSetAtom(teamInvitationsState);
+	const teamInvitations = useAtomValue(getTeamInvitationsState);
+	const [fetchingInvitations, setFetchingInvitations] = useAtom(fetchingTeamInvitationsState);
+
+	const activeTeamId = getActiveTeamIdCookie();
+	const { firstLoad, firstLoadData: firstLoadTeamInvitationsData } = useFirstLoad();
+
+	const { data: user } = useUserQuery();
+	const { isTeamManager } = useIsMemberManager(user);
+
+	// Request params
+	const teamInvitationsParams: TeamInvitationsQueryParams | null =
+		activeTeamId && user?.tenantId && user?.employee?.organizationId
+			? {
+					tenantId: user.tenantId,
+					organizationId: user.employee.organizationId,
+					teamId: activeTeamId
+				}
+			: null;
+
+	// ===== QUERY =====
+
+	const {
+		data: teamInvitationsData,
+		isLoading: teamInvitationsLoading,
+		isSuccess: teamInvitationsSuccess
+	} = useQuery({
+		queryKey: queryKeys.users.invitations.team(
+			user?.tenantId || '',
+			user?.employee?.organizationId || '',
+			activeTeamId || ''
+		),
+		queryFn: async () => {
+			if (!teamInvitationsParams) return { items: [] };
+			return await inviteService.getTeamInvitations({
+				teamId: teamInvitationsParams.teamId
+			});
+		},
+		enabled: !!(activeTeamId && isTeamManager && user?.tenantId)
+	});
+
+	// ===== JOTAI SYNCHRONIZATION =====
+
+	useEffect(() => {
+		if (teamInvitationsSuccess && teamInvitationsData?.items) {
+			setTeamInvitations(teamInvitationsData.items);
+		}
+	}, [teamInvitationsSuccess, teamInvitationsData?.items, setTeamInvitations]);
+
+	useEffect(() => {
+		if (firstLoad) {
+			setFetchingInvitations(teamInvitationsLoading);
+		}
+	}, [teamInvitationsLoading, firstLoad, setFetchingInvitations]);
+
+	// ===== HYDRATED DATA =====
+
+	const hydratedInvitations = useMemo(() => {
+		return teamInvitationsSuccess && teamInvitationsData?.items
+			? (teamInvitationsData?.items ?? teamInvitations)
+			: [];
+	}, [teamInvitationsData?.items, teamInvitationsSuccess, teamInvitations]);
+
+	// ===== RETURN =====
+
+	return {
+		teamInvitations: hydratedInvitations,
+		firstLoadTeamInvitationsData,
+		fetchingInvitations,
+		isLoading: teamInvitationsLoading,
+		isSuccess: teamInvitationsSuccess
+	};
+}
+

--- a/apps/web/core/hooks/organizations/teams/use-team-invitations.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-invitations.ts
@@ -1,334 +1,88 @@
 'use client';
 
-import {
-	fetchingTeamInvitationsState,
-	getTeamInvitationsState,
-	myInvitationsState,
-	teamInvitationsState
-} from '@/core/stores';
-import { useCallback, useEffect, useMemo } from 'react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useFirstLoad } from '../../common/use-first-load';
-import { inviteService } from '../../../services/client/api/organizations/teams/invites';
-import { useAuthenticateUser } from '../../auth';
-import { EInviteAction } from '@/core/types/generics/enums/invite';
-import { toast } from 'sonner';
-import { queryKeys } from '@/core/query/keys';
-import { getActiveTeamIdCookie } from '@/core/lib/helpers/cookies';
-import { IInviteVerifyCode, InviteUserParams, TeamInvitationsQueryParams } from '@/core/types/interfaces/user/invite';
-import { useQueryCall } from '../../common';
-import { TAcceptInvitationRequest, TValidateInviteRequest } from '@/core/types/schemas/user/invite.schema';
-import { useIsMemberManager } from './use-team-member';
-import { useUserQuery } from '../../queries/user-user.query';
-import { useRouter } from 'next/navigation';
+/**
+ * @deprecated This hook re-exports from specialized hooks for backward compatibility.
+ * For new code, prefer using the specific hooks directly:
+ *
+ * READ:
+ * - `useTeamInvitationsQuery` for team invitations data (admin/manager)
+ * - `useMyInvitationsQuery` for user's own invitations data (+ removeMyInvitation local state)
+ *
+ * WRITE:
+ * - `useSendTeamInvitation` for invite + resend operations (admin/manager)
+ * - `useRemoveTeamInvitation` for removing invitations (admin/manager)
+ * - `useRespondToInvitation` for accept/reject operations (user)
+ * - `useInviteValidation` for token/code validation and accept (public/auth)
+ */
 
+import { useTeamInvitationsQuery } from '../../invitations/use-team-invitations-query';
+import { useSendTeamInvitation } from '../../invitations/use-send-team-invitation';
+import { useRemoveTeamInvitation } from '../../invitations/use-remove-team-invitation';
+import { useMyInvitationsQuery } from '../../invitations/use-my-invitations-query';
+import { useRespondToInvitation } from '../../invitations/use-respond-to-invitation';
+import { useInviteValidation } from '../../invitations/use-invite-validation';
+
+/**
+ * @deprecated Use specialized hooks instead (see file header).
+ */
 export function useTeamInvitations() {
-	const queryClient = useQueryClient();
-	const router = useRouter();
+	// ==================== SPECIALIZED HOOKS ====================
 
-	const setTeamInvitations = useSetAtom(teamInvitationsState);
-	const [myInvitationsList, setMyInvitationsList] = useAtom(myInvitationsState);
-	const teamInvitations = useAtomValue(getTeamInvitationsState);
-	const [fetchingInvitations, setFetchingInvitations] = useAtom(fetchingTeamInvitationsState);
+	const { teamInvitations, firstLoadTeamInvitationsData, fetchingInvitations } = useTeamInvitationsQuery();
 
-	const activeTeamId = getActiveTeamIdCookie();
-	const { firstLoad, firstLoadData: firstLoadTeamInvitationsData } = useFirstLoad();
+	const { inviteUser, inviteLoading, resendTeamInvitation, resendInviteLoading } = useSendTeamInvitation();
 
-	const { data: user } = useUserQuery();
-	const { isTeamManager } = useIsMemberManager(user);
-	const { refreshToken } = useAuthenticateUser();
+	const { removeTeamInvitation, removeInviteLoading } = useRemoveTeamInvitation();
 
-	// Request params memoized
-	const teamInvitationsParams: TeamInvitationsQueryParams | null =
-		activeTeamId && user?.tenantId && user?.employee?.organizationId
-			? {
-					tenantId: user.tenantId,
-					organizationId: user.employee.organizationId,
-					// No role specified = get all invitations (EMPLOYEE, MANAGER, etc.)
-					teamId: activeTeamId
-				}
-			: null;
+	const { myInvitations: myInvitationsList, refetchMyInvitations, myInvitationsLoading, removeMyInvitation } =
+		useMyInvitationsQuery();
 
-	// ===== QUERIES =====
+	const { acceptOrRejectInvitation, acceptOrRejectLoading } = useRespondToInvitation();
 
-	// Query for team invitations
 	const {
-		data: teamInvitationsData,
-		isLoading: teamInvitationsLoading,
-		isSuccess: teamInvitationsSuccess,
-		dataUpdatedAt: teamInvitationsUpdatedAt
-	} = useQuery({
-		queryKey: queryKeys.users.invitations.team(
-			user?.tenantId || '',
-			user?.employee?.organizationId || '',
-			activeTeamId || ''
-		),
-		queryFn: async () => {
-			if (!teamInvitationsParams) return { items: [] };
+		validateInviteByTokenAndEmail,
+		validateInviteByTokenAndEmailLoading,
+		validateInviteByCode,
+		validateInviteByCodeLoading,
+		acceptInvitationMutation,
+		acceptInvitationLoading
+	} = useInviteValidation();
 
-			// WORKAROUND: getTeamInvitations now automatically fetches all roles (EMPLOYEE + non-EMPLOYEE)
-			return await inviteService.getTeamInvitations({
-				teamId: teamInvitationsParams.teamId
-			});
-		},
-		enabled: !!(activeTeamId && isTeamManager && user?.tenantId)
-	});
+	// ==================== RETURN ALL PROPERTIES (BACKWARD COMPATIBILITY) ====================
 
-	const invalidateTeamInvitationData = () => {
-		queryClient.invalidateQueries({
-			queryKey: queryKeys.users.invitations.team(
-				user?.tenantId || '',
-				user?.employee?.organizationId || '',
-				activeTeamId || ''
-			)
-		});
-	};
-
-	// Query for my invitations
-	const {
-		data: myInvitationsData,
-		isLoading: myInvitationsLoadingQuery,
-		refetch: refetchMyInvitations
-	} = useQuery({
-		queryKey: queryKeys.users.invitations.all,
-
-		queryFn: async () => {
-			if (!user?.tenantId) return { items: [] };
-			return await inviteService.getMyInvitations();
-		},
-		enabled: !!user?.tenantId, // Disabled by default, enabled manually via refetch
-		staleTime: 2 * 60 * 1000, // 2 minutes
-		gcTime: 5 * 60 * 1000 // 5 minutes
-	});
-
-	const { queryCall: validateInviteByTokenAndEmailQueryCall, loading: validateInviteByTokenAndEmailLoading } =
-		useQueryCall(async (params: TValidateInviteRequest) => {
-			return queryClient.fetchQuery({
-				queryKey: queryKeys.users.invitations.operations.validateByToken(params.token, params.email),
-				queryFn: () => inviteService.validateInviteByTokenAndEmail(params),
-				staleTime: 0,
-				gcTime: 0
-			});
-		});
-
-	const { queryCall: validateInviteByCodeQueryCall, loading: validateInviteByCodeLoading } = useQueryCall(
-		async (params: IInviteVerifyCode) => {
-			return queryClient.fetchQuery({
-				queryKey: queryKeys.users.invitations.operations.validateByCode(params.code, params.email),
-				queryFn: () => inviteService.validateInvitationByCodeAndEmail(params),
-				staleTime: 0,
-				gcTime: 0
-			});
-		}
-	);
-
-	// ===== MUTATIONS =====
-
-	// Mutation to invite a user
-	const inviteUserMutation = useMutation({
-		mutationFn: async (params: InviteUserParams) => {
-			return await inviteService.inviteByEmails({
-				email: params.email,
-				name: params.name,
-				organizationId: params.organizationId,
-				teamId: params.teamId,
-				roleId: params.roleId
-			});
-		},
-		onSuccess: () => {
-			// Just invalidate - let the query refetch handle the state update
-			invalidateTeamInvitationData();
-		}
-	});
-
-	// Mutation to remove an invitation
-	const removeInvitationMutation = useMutation({
-		mutationFn: async ({ invitationId, email }: { invitationId: string; email?: string }) => {
-			if (!teamInvitationsParams) throw new Error('Missing parameters');
-
-			const result = await inviteService.removeTeamInvitations({
-				invitationId,
-				teamId: teamInvitationsParams.teamId
-			});
-
-			return { result, email };
-		},
-		onSuccess: ({ result, email }) => {
-			if (email) {
-				toast.success('Invitation removed', {
-					description: `Invitation removed for ${email}`,
-					duration: 5000
-				});
-			}
-
-			setTeamInvitations(result.items || []);
-
-			// Invalidation of the cache
-			invalidateTeamInvitationData();
-		}
-	});
-
-	// Mutation to resend an invitation
-	const resendInvitationMutation = useMutation({
-		mutationFn: async (invitationId: string) => {
-			return await inviteService.resendTeamInvitations(invitationId);
-		},
-		onSuccess: () => {
-			// Invalidation of the cache for refetch
-			invalidateTeamInvitationData();
-		}
-	});
-
-	// Mutation to accept/reject an invitation
-	const acceptOrRejectInvitationMutation = useMutation({
-		mutationFn: async ({ id, action }: { id: string; action: EInviteAction }) => {
-			return await inviteService.acceptRejectMyInvitations(id, action);
-		},
-		onSuccess: async (res, { id, action }) => {
-			if (res.message) {
-				return res.message;
-			}
-
-			if (action === EInviteAction.ACCEPTED) {
-				await refreshToken();
-				router.refresh();
-				return res;
-			}
-
-			// Optimistic update of the cache
-			setMyInvitationsList((prev) => prev.filter((invitation) => invitation.id !== id));
-
-			// Invalidation of the cache
-			invalidateTeamInvitationData();
-
-			return res;
-		}
-	});
-
-	const acceptInvitationMutation = useMutation({
-		mutationFn: async (data: TAcceptInvitationRequest) => {
-			return await inviteService.acceptInvite(data);
-		},
-		onSuccess: () => {
-			queryClient.invalidateQueries({
-				queryKey: queryKeys.users.invitations.all
-			});
-		}
-	});
-
-	// ===== EFFECTS =====
-
-	// Synchronization with the Jotai stores for compatibility
-
-	useEffect(() => {
-		if (teamInvitationsSuccess && teamInvitationsData?.items) {
-			setTeamInvitations(teamInvitationsData.items);
-		}
-	}, [teamInvitationsSuccess, teamInvitationsUpdatedAt]);
-
-	useEffect(() => {
-		if (myInvitationsData?.items) {
-			setMyInvitationsList(myInvitationsData.items);
-		}
-	}, [myInvitationsData, setMyInvitationsList]);
-
-	useEffect(() => {
-		if (firstLoad) {
-			setFetchingInvitations(teamInvitationsLoading);
-		}
-	}, [teamInvitationsLoading, firstLoad, setFetchingInvitations]);
-
-	// ===== INTERFACE FUNCTIONS =====
-
-	const inviteUser = useCallback(
-		(email: string, name: string, roleId?: string) => {
-			if (!user?.employee?.organizationId || !activeTeamId || !user?.tenantId) {
-				return Promise.reject(new Error('Missing required parameters'));
-			}
-
-			return inviteUserMutation.mutateAsync({
-				email,
-				name,
-				organizationId: user.employee.organizationId,
-				teamId: activeTeamId,
-				tenantId: user.tenantId,
-				roleId
-			});
-		},
-		[inviteUserMutation, user, activeTeamId]
-	);
-
-	const removeTeamInvitation = useCallback(
-		(invitationId: string, email?: string) => {
-			if (!(activeTeamId && isTeamManager && user?.tenantId)) {
-				return;
-			}
-
-			removeInvitationMutation.mutate({ invitationId, email });
-		},
-		[removeInvitationMutation, activeTeamId, isTeamManager, user]
-	);
-
-	const resendTeamInvitation = useCallback(
-		(invitationId: string) => {
-			return resendInvitationMutation.mutateAsync(invitationId);
-		},
-		[resendInvitationMutation]
-	);
-
-	const myInvitations = useCallback(() => {
-		if (myInvitationsLoadingQuery || !user?.tenantId) {
-			return;
-		}
-
-		refetchMyInvitations();
-	}, [refetchMyInvitations, user?.tenantId, myInvitationsLoadingQuery]);
-
-	const removeMyInvitation = useCallback(
-		(id: string) => {
-			setMyInvitationsList((prev) => prev.filter((invitation) => invitation.id !== id));
-		},
-		[setMyInvitationsList]
-	);
-
-	const acceptRejectMyInvitation = useCallback(
-		(id: string, action: EInviteAction) => {
-			return acceptOrRejectInvitationMutation.mutateAsync({ id, action });
-		},
-		[acceptOrRejectInvitationMutation]
-	);
-	const hydratedInvitations = useMemo(() => {
-		return teamInvitationsSuccess && teamInvitationsData?.items
-			? (teamInvitationsData?.items ?? teamInvitations)
-			: [];
-	}, [teamInvitationsData?.items, teamInvitationsSuccess, teamInvitations]);
-	const hydratedMyInvitations = useMemo(() => {
-		return myInvitationsData?.items ?? myInvitationsList;
-	}, [myInvitationsData?.items, myInvitationsList]);
-	// ===== RETURN =====
 	return {
-		teamInvitations: hydratedInvitations,
-		myInvitationsList: hydratedMyInvitations,
+		// From useTeamInvitationsQuery (READ Admin)
+		teamInvitations,
 		firstLoadTeamInvitationsData,
 		fetchingInvitations,
-		inviteLoading: inviteUserMutation.isPending,
+
+		// From useSendTeamInvitation (WRITE Admin — send)
 		inviteUser,
-		removeTeamInvitation,
+		inviteLoading,
 		resendTeamInvitation,
-		removeInviteLoading: removeInvitationMutation.isPending,
-		resendInviteLoading: resendInvitationMutation.isPending,
+		resendInviteLoading,
+
+		// From useRemoveTeamInvitation (WRITE Admin — delete)
+		removeTeamInvitation,
+		removeInviteLoading,
+
+		// From useMyInvitationsQuery (READ User + local state)
+		myInvitationsList,
+		myInvitations: refetchMyInvitations,
 		myInvitationsQueryCall: refetchMyInvitations,
-		myInvitationsLoading: myInvitationsLoadingQuery,
-		myInvitations,
+		myInvitationsLoading,
 		removeMyInvitation,
-		acceptRejectMyInvitation,
-		acceptRejectMyInvitationsLoading: acceptOrRejectInvitationMutation.isPending,
-		validateInviteByTokenAndEmail: validateInviteByTokenAndEmailQueryCall,
+
+		// From useRespondToInvitation (WRITE User)
+		acceptRejectMyInvitation: acceptOrRejectInvitation,
+		acceptRejectMyInvitationsLoading: acceptOrRejectLoading,
+
+		// From useInviteValidation (Public/Auth)
+		validateInviteByTokenAndEmail,
 		validateInviteByTokenAndEmailLoading,
+		validateInviteByCode,
+		validateInviteByCodeLoading,
 		acceptInvitationMutation,
-		acceptInvitationLoading: acceptInvitationMutation.isPending,
-		validateInviteByCode: validateInviteByCodeQueryCall,
-		validateInviteByCodeLoading
+		acceptInvitationLoading
 	};
 }


### PR DESCRIPTION
# [ETP-228](https://evertech.atlassian.net/browse/ETP-228) task web refactor use team invitations segregate admin vs user responsibilities

This PR refactors the monolithic `useTeamInvitations` hook (334 lines) into **8 focused, CRUD-split hooks** following the Single Responsibility Principle.

The original hook violated SRP by combining three distinct domains in a single file:
- **Admin/Manager operations** (invite, remove, resend)
- **User operations** (accept, reject, list my invitations)
- **Public/Auth operations** (validate token/code, accept invitation)

This created unnecessary coupling, security concerns (user components loading admin logic), and made the code harder to maintain and test.

### What was done:
- Split the monolith into 8 semantically cohesive hooks under `core/hooks/invitations/`
- Migrated all 7 consumer files to import directly from the new hooks
- Replaced legacy `useQueryCall` patterns with native React Query `useMutation`
- Optimized `useEffect` dependencies (removed `dataUpdatedAt`, kept `data?.items` + `isSuccess`) leveraging React Query's structural sharing
- Preserved the original hook as a thin deprecated wrapper for backward compatibility

## What Was Changed

### Major Changes

- **New `core/hooks/invitations/` module** with CRUD-split architecture:

| File | Responsibility | Lines |
|------|---------------|-------|
| `use-invitation-invalidation.ts` | Shared cache invalidation (React Query) | 40 |
| `use-team-invitations-query.ts` | READ — Team invitations + Jotai sync + firstLoad | 98 |
| `use-send-team-invitation.ts` | WRITE — Invite user + Resend invitation | 84 |
| `use-remove-team-invitation.ts` | WRITE — Remove invitation (destructive) | 67 |
| `use-my-invitations-query.ts` | READ — My invitations + Jotai sync + local remove | 82 |
| `use-respond-to-invitation.ts` | WRITE — Accept / Reject invitation | 71 |
| `use-invite-validation.ts` | WRITE — Validate token/code + accept (auth pages) | 71 |
| `index.ts` | Barrel exports | 15 |

- **Deprecated `use-team-invitations.ts`**: reduced from **334 → 88 lines** (thin wrapper composing the 6 new hooks, full backward-compatible return interface preserved)

- **All 7 consumers migrated** to import directly from the new specific hooks:

| Consumer | Before | After |
|----------|--------|-------|
| `invite-form-modal.tsx` | `useTeamInvitations` | `useSendTeamInvitation` |
| `invite-modal.tsx` | `useTeamInvitations` | `useTeamInvitationsQuery` + `useSendTeamInvitation` |
| `user-invite-card.tsx` | `useTeamInvitations` | `useSendTeamInvitation` + `useRemoveTeamInvitation` |
| `team-invitations.tsx` | `useTeamInvitations` | `useRespondToInvitation` + `useMyInvitationsQuery` |
| `init-state.tsx` | `useTeamInvitations` | `useTeamInvitationsQuery` + `useMyInvitationsQuery` |
| `page-component.tsx` | `useTeamInvitations` | `useMyInvitationsQuery` |
| `use-accept-invite.ts` | `useTeamInvitations` | `useInviteValidation` |

### Minor Changes

- Replaced `useQueryCall` (imperative wrapper with `useState`) with native React Query `useMutation` in `use-invite-validation.ts`
- Optimized `useEffect` dependencies in query hooks: removed `dataUpdatedAt` (triggers on every refetch even with identical data) in favor of `data?.items` + `isSuccess` (leverages React Query structural sharing)
- Preserved `staleTime: 2min` / `gcTime: 5min` on my invitations query to prevent unnecessary API calls
- Added barrel export in `core/hooks/index.ts`

## How to Test This PR

1. Run the app with `yarn web:dev`
2. Open the browser at `http://localhost:3030`

### Scenario 1 — Invite a member (Manager)
3. Open the invite modal (team settings or invite button)
4. Enter an email and send the invitation
5. Verify the invitation appears in the team invitations list
6. Try resending the invitation from the invite card

### Scenario 2 — Remove an invitation (Manager)
7. Click remove on an existing invitation
8. Verify the toast notification appears
9. Verify the invitation is removed from the list

### Scenario 3 — Accept/Reject an invitation (User)
10. Log in as a user who has pending invitations
11. Accept or reject an invitation from the home page
12. Verify accepted invitations redirect and refresh auth token
13. Verify rejected invitations are removed from the list

### Scenario 4 — Accept invite flow (Auth page)
14. Use an invitation link with a code/token
15. Verify the validation flow works (token → code → accept)
16. Verify the user is properly onboarded after accepting

### Build verification
- `tsc --noEmit` passes with **0 errors** ✅
- No `useQueryCall` left in invitation hooks ✅
- No references to deleted files ✅

## Screenshots (if needed)

> No UI changes — this is a pure refactoring PR. The user experience remains identical.

### Previous screenshots

N/A — No visual changes.

### Current screenshots

N/A — No visual changes.

## Related Issues

- Closes [ETP-228](https://evertech.atlassian.net/browse/ETP-228)

## Type of Change

- [ ] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [x] Refactoring (improves code quality without changing behavior)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced
- [x] `tsc --noEmit` passes with 0 errors
- [x] Backward compatibility maintained via deprecated wrapper

## Notes for the Reviewer (Optional)

- The deprecated wrapper (`use-team-invitations.ts`) can be removed once all external references are updated. It currently composes the 6 new hooks and maps to the original return interface.
- The `removeMyInvitation` function is a **local Jotai state operation** (not an API call), which is why it lives in the query hook rather than a separate mutation hook.
- `removeTeamInvitation` now uses `mutateAsync` instead of `mutate` — the consumer was already doing `await removeTeamInvitation(...)`, so this is a correctness fix (the `await` now actually waits for completion).
- The new hooks follow the same pattern as `core/hooks/daily-plans/` (invalidation hook + query hook + mutation hooks).

[ETP-228]: https://evertech.atlassian.net/browse/ETP-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ETP-228]: https://evertech.atlassian.net/browse/ETP-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the monolithic useTeamInvitations into focused hooks that clearly separate admin and user responsibilities, improving maintainability and safer imports. Aligns with ETP-228; behavior is unchanged and the old hook remains as a thin, backward-compatible wrapper. Latest: removeMyInvitation now updates Jotai and React Query caches and correctly adjusts the total count for immediate UI consistency.

- **Refactors**
  - Split into dedicated hooks: useTeamInvitationsQuery, useMyInvitationsQuery, useSendTeamInvitation, useRemoveTeamInvitation, useRespondToInvitation, useInviteValidation.
  - Added shared cache invalidation via useInvitationInvalidation.
  - Replaced legacy useQueryCall with React Query useMutation; simplified effects using structural sharing.
  - Updated consumers to import the new hooks directly; kept the deprecated wrapper for compatibility.
  - Enhanced removeMyInvitation to sync caches and properly update totals.

- **Migration**
  - Prefer the new hooks: query (team/my), send, remove, respond, and validation.
  - No UI changes or breaking changes; the old hook can be removed once external references are updated.

<sup>Written for commit b9255b267665898a121893aa10d06ac1d4a3ad19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Invitation handling reorganized into specialized modules (send, remove, respond, validate, query) for clearer behavior.
  * Auto-refresh and accept/resend/remove flows now use query-driven refreshes for more reliable, timely invitation state updates.
  * No change to user-facing workflows: inviting, resending, accepting/rejecting, and removing invitations continue to work as before with improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->