### PR TITLE
[ETP-224] task web refactor use timesheet separate transformation from data fetching

### DIFF
--- a/apps/web/core/components/features/tasks/edit-task-modal.tsx
+++ b/apps/web/core/components/features/tasks/edit-task-modal.tsx
@@ -7,7 +7,7 @@ import { Item, ManageOrMemberComponent, getNestedValue } from '@/core/components
 import { statusTable } from '../../timesheet/timesheet-action';
 import { ITimeLog } from '@/core/types/interfaces/timer/time-log/time-log';
 import { differenceBetweenHours, formatTimeFromDate, secondsToTime, toDate } from '@/core/lib/helpers/index';
-import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useUpdateTimesheet } from '@/core/hooks/timesheet/use-update-timesheet';
 import { ToastAction } from '@/core/components/common/toast';
 import { ReloadIcon } from '@radix-ui/react-icons';
 import { addMinutes, format, parseISO } from 'date-fns';
@@ -28,7 +28,7 @@ export function EditTaskModal({ isOpen, closeModal, dataTimesheet }: IEditTaskMo
 
 	const activeTeam = useAtomValue(activeTeamState);
 	const t = useTranslations();
-	const { updateTimesheet, loadingUpdateTimesheet } = useTimesheet({});
+	const { updateTimesheet, loadingUpdateTimesheet } = useUpdateTimesheet();
 	const initialTimeRange = {
 		startTime: formatTimeFromDate(dataTimesheet.startedAt),
 		endTime: formatTimeFromDate(dataTimesheet.stoppedAt)

--- a/apps/web/core/components/features/timesheet/add-mask-modal.tsx
+++ b/apps/web/core/components/features/timesheet/add-mask-modal.tsx
@@ -13,7 +13,7 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@/core/components/common/select';
-import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useCreateTimesheet } from '@/core/hooks/timesheet/use-create-timesheet';
 import { toUTC } from '@/core/lib/helpers/index';
 import { PlusIcon, ReloadIcon } from '@radix-ui/react-icons';
 import { CustomSelect } from '../../common/multiple-select';
@@ -55,7 +55,7 @@ export function AddTaskModal({ closeModal, isOpen }: IAddTaskModalProps) {
 	const organizationProjects = useAtomValue(organizationProjectsState);
 
 	const activeTeam = useAtomValue(activeTeamState);
-	const { createTimesheet, loadingCreateTimesheet } = useTimesheet({});
+	const { createTimesheet, loadingCreateTimesheet } = useCreateTimesheet();
 
 	const timeOptions = generateTimeOptions(5);
 	const t = useTranslations();

--- a/apps/web/core/components/features/timesheet/reject-selected-modal.tsx
+++ b/apps/web/core/components/features/timesheet/reject-selected-modal.tsx
@@ -1,4 +1,4 @@
-import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useUpdateTimesheet } from '@/core/hooks/timesheet/use-update-timesheet';
 import { clsxm } from '@/core/lib/utils';
 import { Modal } from '@/core/components';
 import { ReloadIcon } from '@radix-ui/react-icons';
@@ -35,7 +35,7 @@ export function RejectSelectedModal({
 }: IRejectSelectedModalProps) {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [reason, setReason] = useState('');
-	const { updateTimesheetStatus, loadingUpdateTimesheetStatus, setSelectTimesheetId } = useTimesheet({});
+	const { updateTimesheetStatus, loadingUpdateTimesheetStatus } = useUpdateTimesheet();
 
 	const t = useTranslations();
 	const handleSubmit = async (e: React.FormEvent) => {
@@ -47,7 +47,6 @@ export function RejectSelectedModal({
 				ids: selectTimesheetId || []
 			})
 				.then(() => {
-					setSelectTimesheetId([]);
 					closeModal();
 				})
 				.catch((error) => console.error(error));
@@ -88,7 +87,7 @@ export function RejectSelectedModal({
 					<div className="text-sm text-right text-gray-500">
 						{reason.length}/{maxReasonLength}
 					</div>
-					<div className="flex items-center justify-end gap-x-4">
+					<div className="flex gap-x-4 justify-end items-center">
 						<button
 							onClick={closeModal}
 							type="button"
@@ -111,7 +110,7 @@ export function RejectSelectedModal({
 								'disabled:opacity-50 disabled:cursor-not-allowed'
 							)}
 						>
-							{loadingUpdateTimesheetStatus && <ReloadIcon className="w-4 h-4 mr-2 animate-spin" />}
+							{loadingUpdateTimesheetStatus && <ReloadIcon className="mr-2 w-4 h-4 animate-spin" />}
 							{isSubmitting ? 'Rejecting...' : 'Reject Entry'}
 						</button>
 					</div>

--- a/apps/web/core/components/pages/timesheet/calendar-view.tsx
+++ b/apps/web/core/components/pages/timesheet/calendar-view.tsx
@@ -1,4 +1,6 @@
-import { GroupedTimesheet, useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import type { GroupedTimesheet } from '@/core/lib/helpers/timesheet-grouping';
+import { getStatusTimesheet, groupedByTimesheetIds } from '@/core/lib/helpers/timesheet-grouping';
+import { useTimesheetQuery } from '@/core/hooks/timesheet/use-timesheet-query';
 import { statusColor } from '@/core/components';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/core/components/common/accordion';
 import { TranslationHooks, useTranslations } from 'next-intl';
@@ -80,7 +82,7 @@ export function CalendarView({ data, loading }: { data?: GroupedTimesheet[]; loa
 	);
 }
 const CalendarDataView = ({ data }: { data?: GroupedTimesheet[]; t: TranslationHooks }) => {
-	const { getStatusTimesheet, handleSelectRowTimesheet, selectTimesheetId, groupedByTimesheetIds } = useTimesheet({});
+	const { handleSelectRowTimesheet, selectTimesheetId } = useTimesheetQuery({});
 
 	return (
 		<div className="w-full dark:bg-dark--theme">
@@ -226,7 +228,7 @@ const CalendarDataView = ({ data }: { data?: GroupedTimesheet[]; t: TranslationH
 };
 
 const BaseCalendarDataView = ({ data, daysLabels, t, CalendarComponent }: BaseCalendarDataViewProps) => {
-	const { getStatusTimesheet, handleSelectRowTimesheet, selectTimesheetId, groupedByTimesheetIds } = useTimesheet({});
+	const { handleSelectRowTimesheet, selectTimesheetId } = useTimesheetQuery({});
 
 	return (
 		<CalendarComponent

--- a/apps/web/core/components/pages/timesheet/selection-bar.tsx
+++ b/apps/web/core/components/pages/timesheet/selection-bar.tsx
@@ -3,6 +3,8 @@ import { useTranslations } from 'next-intl';
 import { useCallback } from 'react';
 import { ITimeLog } from '@/core/types/interfaces/timer/time-log/time-log';
 import { ETimesheetStatus } from '@/core/types/generics/enums/timesheet';
+import { useUpdateTimesheet } from '@/core/hooks/timesheet/use-update-timesheet';
+import { useDeleteTimesheet } from '@/core/hooks/timesheet/use-delete-timesheet';
 
 type ActionButtonProps = {
 	label: string;
@@ -43,9 +45,9 @@ export const SelectionBar = ({
 				fullWidth && 'x-container'
 			)}
 		>
-			<div className="flex items-center justify-start gap-x-4">
+			<div className="flex gap-x-4 justify-start items-center">
 				<div className="flex items-center justify-center gap-x-2 text-[#282048] dark:text-[#7a62d8]">
-					<div className="bg-primary dark:bg-primary-light text-white rounded-full h-7 w-7 flex items-center justify-center font-bold">
+					<div className="flex justify-center items-center w-7 h-7 font-bold text-white rounded-full bg-primary dark:bg-primary-light">
 						<span>{selectedCount}</span>
 					</div>
 					<span>selected</span>
@@ -67,8 +69,6 @@ export const SelectionBar = ({
 
 interface SelectedTimesheetProps {
 	selectTimesheetId: ITimeLog[];
-	updateTimesheetStatus: ({ status, ids }: { status: ETimesheetStatus; ids: string[] | string }) => Promise<void>;
-	deleteTaskTimesheet: ({ logIds }: { logIds: string[] }) => Promise<void>;
 	setSelectTimesheetId: React.Dispatch<React.SetStateAction<ITimeLog[]>>;
 	fullWidth: boolean;
 }
@@ -78,58 +78,60 @@ interface SelectedTimesheetProps {
  *
  * A component that renders a selection bar to handle tasks in the timesheet.
  * It provides buttons to approve, reject, delete and clear the selected tasks.
+ * Mutations (approve/reject/delete) are handled internally via dedicated hooks.
  *
  * @param selectTimesheetId - The selected timesheet logs.
- * @param updateTimesheetStatus - A function to update the status of the selected timesheet logs.
- * @param deleteTaskTimesheet - A function to delete the selected timesheet logs.
  * @param setSelectTimesheetId - A function to set the selected timesheet logs.
  * @param fullWidth - A boolean to indicate if the component should be rendered in full width.
  * @returns {React.ReactElement} - The rendered timesheet component.
  */
 export const SelectedTimesheet: React.FC<SelectedTimesheetProps> = ({
 	selectTimesheetId,
-	updateTimesheetStatus,
-	deleteTaskTimesheet,
 	setSelectTimesheetId,
 	fullWidth
 }) => {
+	const { updateTimesheetStatus } = useUpdateTimesheet();
+	const { deleteTaskTimesheet } = useDeleteTimesheet();
+
+	const getSelectedIds = useCallback(
+		() => selectTimesheetId.map((select) => select.timesheet?.id || '').filter((id) => id !== undefined),
+		[selectTimesheetId]
+	);
+
 	const handleApprove = useCallback(async () => {
 		try {
-			updateTimesheetStatus({
+			await updateTimesheetStatus({
 				status: ETimesheetStatus.APPROVED,
-				ids: selectTimesheetId.map((select) => select.timesheet?.id || '').filter((id) => id !== undefined)
-			}).then(() => {
-				setSelectTimesheetId([]);
+				ids: getSelectedIds()
 			});
+			setSelectTimesheetId([]);
 		} catch (error) {
 			console.error(error);
 		}
-	}, [selectTimesheetId, updateTimesheetStatus]);
+	}, [getSelectedIds, updateTimesheetStatus, setSelectTimesheetId]);
 
 	const handleReject = useCallback(async () => {
 		try {
-			updateTimesheetStatus({
+			await updateTimesheetStatus({
 				status: ETimesheetStatus.DENIED,
-				ids: selectTimesheetId.map((select) => select.timesheet?.id || '').filter((id) => id !== undefined)
-			}).then(() => {
-				setSelectTimesheetId([]);
+				ids: getSelectedIds()
 			});
+			setSelectTimesheetId([]);
 		} catch (error) {
 			console.error(error);
 		}
-	}, [selectTimesheetId, updateTimesheetStatus]);
+	}, [getSelectedIds, updateTimesheetStatus, setSelectTimesheetId]);
 
 	const handleDelete = useCallback(async () => {
 		try {
-			deleteTaskTimesheet({
-				logIds: selectTimesheetId?.map((select) => select.timesheet?.id || '').filter((id) => id !== undefined)
-			}).then(() => {
-				setSelectTimesheetId([]);
+			await deleteTaskTimesheet({
+				logIds: getSelectedIds()
 			});
+			setSelectTimesheetId([]);
 		} catch (error) {
 			console.error(error);
 		}
-	}, [selectTimesheetId, deleteTaskTimesheet, setSelectTimesheetId]);
+	}, [getSelectedIds, deleteTaskTimesheet, setSelectTimesheetId]);
 
 	return (
 		<SelectionBar

--- a/apps/web/core/components/pages/timesheet/table-time-sheet.tsx
+++ b/apps/web/core/components/pages/timesheet/table-time-sheet.tsx
@@ -26,7 +26,10 @@ import {
 } from '@/core/components/timesheet';
 import { useTranslations } from 'next-intl';
 import { formatDate } from '@/core/lib/helpers/index';
-import { GroupedTimesheet, useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import type { GroupedTimesheet } from '@/core/lib/helpers/timesheet-grouping';
+import { getStatusTimesheet, groupedByTimesheetIds } from '@/core/lib/helpers/timesheet-grouping';
+import { useDeleteTimesheet } from '@/core/hooks/timesheet/use-delete-timesheet';
+import { useUpdateTimesheet } from '@/core/hooks/timesheet/use-update-timesheet';
 import {
 	DisplayTimeForTimesheet,
 	TaskNameInfoDisplay,
@@ -69,13 +72,8 @@ export function DataTableTimeSheet({ data, user }: { data?: GroupedTimesheet[]; 
 		closeModal: closeAlertConfirmation
 	} = alertConfirmationModal;
 
-	const {
-		deleteTaskTimesheet,
-		loadingDeleteTimesheet,
-		getStatusTimesheet,
-		updateTimesheetStatus,
-		groupedByTimesheetIds
-	} = useTimesheet({});
+	const { deleteTaskTimesheet, loadingDeleteTimesheet } = useDeleteTimesheet();
+	const { updateTimesheetStatus } = useUpdateTimesheet();
 	const {
 		timesheetGroupByDays,
 		handleSelectRowByStatusAndDate,
@@ -408,7 +406,7 @@ const TaskActionMenu = ({
 }) => {
 	const { isOpen: isEditTask, openModal: isOpenModalEditTask, closeModal: isCloseModalEditTask } = useModal();
 	const { isOpen: isOpenAlert, openModal: openAlertConfirmation, closeModal: closeAlertConfirmation } = useModal();
-	const { deleteTaskTimesheet, loadingDeleteTimesheet } = useTimesheet({});
+	const { deleteTaskTimesheet, loadingDeleteTimesheet } = useDeleteTimesheet();
 	const canEdit = isManage || user?.id === dataTimesheet.employee?.user.id;
 
 	const t = useTranslations();
@@ -473,7 +471,7 @@ const TaskActionMenu = ({
 
 export const StatusTask = ({ timesheet }: { timesheet: ITimeLog }) => {
 	const t = useTranslations();
-	const { updateTimesheetStatus, updateTimesheet } = useTimesheet({});
+	const { updateTimesheetStatus, updateTimesheet } = useUpdateTimesheet();
 	const handleUpdateTimesheet = async (isBillable: boolean) => {
 		await updateTimesheet({
 			id: timesheet.timesheetId,

--- a/apps/web/core/components/pages/timesheet/timesheet-card.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-card.tsx
@@ -6,7 +6,7 @@ import { Button, statusColor } from '@/core/components';
 import { useTranslations } from 'next-intl';
 import { ReactNode } from 'react';
 import { EmployeeAvatar } from '../../timesheet/compact-timesheet-component';
-import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { getStatusTimesheet, groupByDate } from '@/core/lib/helpers/timesheet-grouping';
 import { useTimelogFilterOptions } from '@/core/hooks';
 import { ETimesheetStatus } from '@/core/types/generics/enums/timesheet';
 import { cn } from '@/core/lib/helpers';
@@ -85,7 +85,7 @@ export function TimesheetCard({ ...props }: ITimesheetCard) {
 }
 
 export const TimesheetCardDetail = ({ data }: { data?: Record<ETimesheetStatus, ITimeLog[]> }) => {
-	const { getStatusTimesheet, groupByDate } = useTimesheet({});
+	// getStatusTimesheet & groupByDate imported as pure functions from timesheet-grouping
 	const { timesheetGroupByDays } = useTimelogFilterOptions();
 	const timesheetGroupByDate = groupByDate(data?.PENDING || []);
 	const t = useTranslations();

--- a/apps/web/core/components/pages/timesheet/timesheet-detail-modal.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-detail-modal.tsx
@@ -5,7 +5,7 @@ import { TimesheetCardDetail } from './timesheet-card';
 import { TranslationHooks, useTranslations } from 'next-intl';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/core/components/common/accordion';
 import { cn } from '@/core/lib/helpers';
-import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { getStatusTimesheet } from '@/core/lib/helpers/timesheet-grouping';
 import { Badge } from '@/core/components/common/badge';
 import { EmployeeAvatar, ProjectLogo } from '../../timesheet/compact-timesheet-component';
 import { groupBy } from '@/core/lib/helpers/array-data';
@@ -77,7 +77,7 @@ const MembersWorkedCard = ({ element, t }: { element: ITimeLog[]; t: Translation
 		.map(([employeeId, element]) => ({ employeeId, element }))
 		.sort((a, b) => b.employeeId.localeCompare(a.employeeId));
 
-	const { getStatusTimesheet } = useTimesheet({});
+	// getStatusTimesheet imported as a pure function from timesheet-grouping
 
 	if (memberWorkItems.length === 0) {
 		return (
@@ -245,7 +245,7 @@ const MenHoursCard = ({ element, t }: MenHoursCardProps) => {
 		.map(([status, element]) => ({ status, element }))
 		.sort((a, b) => b.status.localeCompare(a.status));
 
-	const { getStatusTimesheet } = useTimesheet({});
+	// getStatusTimesheet imported as a pure function from timesheet-grouping
 
 	if (menHoursItems.length === 0) {
 		return (

--- a/apps/web/core/components/pages/timesheet/timesheet-filter-popover.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-filter-popover.tsx
@@ -4,7 +4,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/core/components/commo
 import { SettingFilterIcon } from '@/assets/svg';
 import { useTranslations } from 'next-intl';
 import { useTimelogFilterOptions } from '@/core/hooks';
-import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useTimesheetQuery } from '@/core/hooks/timesheet/use-timesheet-query';
 import { cn } from '@/core/lib/helpers';
 import { statusTable } from '../../timesheet/timesheet-action';
 import { MultiSelect } from '../../common/multi-select';
@@ -22,7 +22,7 @@ export const TimeSheetFilterPopover = React.memo(function TimeSheetFilterPopover
 	const t = useTranslations();
 	const { setEmployeeState, setProjectState, setStatusState, setTaskState, employee, project, statusState, task } =
 		useTimelogFilterOptions();
-	const { timesheet, statusTimesheet, isManage } = useTimesheet({});
+	const { timesheetElementGroup: timesheet, statusTimesheet, isManage } = useTimesheetQuery({});
 
 	React.useEffect(() => {
 		if (shouldRemoveItems) {

--- a/apps/web/core/components/pages/timesheet/timesheet-page-content.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-page-content.tsx
@@ -25,7 +25,7 @@ import { TimesheetDetailModalSkeleton } from '@/core/components/common/skeleton/
 import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
 import { IconsSearch } from '@/core/components/icons';
 import { ViewToggleButton } from '@/core/components/timesheet/timesheet-toggle-view';
-import { useTimesheet } from '@/core/hooks/activities/use-timesheet';
+import { useTimesheetQuery } from '@/core/hooks/timesheet/use-timesheet-query';
 import { useTimesheetFilters } from '@/core/hooks/activities/use-timesheet-filters';
 import { useTimesheetPagination } from '@/core/hooks/activities/use-timesheet-pagination';
 import { useTimesheetViewData } from '@/core/hooks/activities/use-timesheet-view-data';
@@ -129,22 +129,19 @@ export function TimeSheetPageContent({ params }: { params: { memberId: string } 
 	);
 
 	const {
-		timesheet: filterDataTimesheet,
+		timesheetElementGroup: filterDataTimesheet,
 		statusTimesheet,
 		loadingTimesheet,
 		isManage,
 		timesheetGroupByDays,
 		selectTimesheetId,
-		setSelectTimesheetId,
-		updateTimesheetStatus,
-		deleteTaskTimesheet
-	} = useTimesheet({
+		setSelectTimesheetId
+	} = useTimesheetQuery({
 		startDate: timesheetDateRange.startDate,
 		endDate: timesheetDateRange.endDate,
 		timesheetViewMode: timesheetNavigator,
 		inputSearch: search
 	});
-
 	const {
 		paginatedGroups,
 		currentPage,
@@ -349,11 +346,9 @@ export function TimeSheetPageContent({ params }: { params: { memberId: string } 
 								/>
 								{selectTimesheetId.length > 0 && (
 									<SelectedTimesheet
-										deleteTaskTimesheet={deleteTaskTimesheet}
 										fullWidth={fullWidth}
 										selectTimesheetId={selectTimesheetId}
 										setSelectTimesheetId={setSelectTimesheetId}
-										updateTimesheetStatus={updateTimesheetStatus}
 									/>
 								)}
 							</>

--- a/apps/web/core/components/pages/timesheet/timesheet-view.tsx
+++ b/apps/web/core/components/pages/timesheet/timesheet-view.tsx
@@ -1,4 +1,4 @@
-import { GroupedTimesheet } from '@/core/hooks/activities/use-timesheet';
+import type { GroupedTimesheet } from '@/core/lib/helpers/timesheet-grouping';
 import { TUser } from '@/core/types/schemas';
 import { DataTableTimeSheet } from '@/core/components/integration/calendar';
 import { useTranslations } from 'next-intl';

--- a/apps/web/core/components/timesheet/monthly-timesheet-calendar.tsx
+++ b/apps/web/core/components/timesheet/monthly-timesheet-calendar.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import { format, addMonths, eachDayOfInterval, startOfMonth, endOfMonth, addDays, Locale, isLeapYear } from 'date-fns';
-import { GroupedTimesheet } from '@/core/hooks/activities/use-timesheet';
+import type { GroupedTimesheet } from '@/core/lib/helpers/timesheet-grouping';
 import { enGB } from 'date-fns/locale';
 import { cn } from '@/core/lib/helpers';
 import { formatDate } from '@/core/lib/helpers/index';

--- a/apps/web/core/components/timesheet/weekly-timesheet-calendar.tsx
+++ b/apps/web/core/components/timesheet/weekly-timesheet-calendar.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import { format, addDays, startOfWeek, endOfWeek, eachDayOfInterval, Locale } from 'date-fns';
 import { enGB } from 'date-fns/locale';
 import { cn } from '@/core/lib/helpers';
-import { GroupedTimesheet } from '@/core/hooks/activities/use-timesheet';
+import type { GroupedTimesheet } from '@/core/lib/helpers/timesheet-grouping';
 import { formatDate } from '@/core/lib/helpers/index';
 import { TranslationHooks } from 'next-intl';
 import { TotalDurationByDate } from '../tasks/task-displays';

--- a/apps/web/core/hooks/activities/use-timesheet.ts
+++ b/apps/web/core/hooks/activities/use-timesheet.ts
@@ -1,762 +1,86 @@
-import { useAtom } from 'jotai';
-import { timesheetRapportState } from '@/core/stores/timer/time-logs';
-import { useCallback, useMemo, useState, useEffect, useRef } from 'react';
-import moment from 'moment';
-import { useTimelogFilterOptions } from './use-timelog-filter-options';
-import axios from 'axios';
-import { timeLogService } from '@/core/services/client/api/timesheets/time-log.service';
-import { timeSheetService } from '@/core/services/client/api/timesheets/timesheet.service';
-import { useAuthenticateUser } from '../auth';
-import { ITimeLog } from '@/core/types/interfaces/timer/time-log/time-log';
-import { ETimesheetStatus } from '@/core/types/generics/enums/timesheet';
-import { IUpdateTimesheetRequest } from '@/core/types/interfaces/timesheet/timesheet';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '@/core/query/keys';
-import { useConditionalUpdateEffect } from '../common/use-has-mounted';
-
-interface TimesheetParams {
-	startDate?: Date | string;
-	endDate?: Date | string;
-	timesheetViewMode?: 'ListView' | 'CalendarView';
-	inputSearch?: string;
-}
-
-export interface GroupedTimesheet {
-	date: string;
-	tasks: ITimeLog[];
-}
-
-// Helper function for deep array comparison to prevent infinite loops
-const areArraysEqual = <T>(
-	arr1: T[] | undefined,
-	arr2: T[] | undefined,
-	keyExtractor: (item: T) => string | number
-): boolean => {
-	if (!arr1 && !arr2) return true;
-	if (!arr1 || !arr2) return false;
-	if (arr1.length !== arr2.length) return false;
-
-	const keys1 = arr1.map(keyExtractor).sort();
-	const keys2 = arr2.map(keyExtractor).sort();
-
-	return keys1.every((key, index) => key === keys2[index]);
-};
-
-const groupByDate = (items: ITimeLog[]): GroupedTimesheet[] => {
-	if (!items?.length) {
-		return [];
-	}
-
-	// First, group by timesheetId with more flexible validation
-	const groupedByTimesheet = items.reduce(
-		(acc, item, index) => {
-			// More flexible validation - try to work with different data structures
-			const timesheetId = item?.timesheet?.id || item?.timesheetId || `fallback-${index}`;
-			const createdAt =
-				item?.timesheet?.createdAt || item?.createdAt || item?.startedAt || new Date().toISOString();
-
-			if (!item || !createdAt) {
-				console.warn('Skipping item with missing timesheet or createdAt:', item);
-				return acc;
-			}
-
-			if (!acc[timesheetId]) {
-				acc[timesheetId] = [];
-			}
-
-			// Ensure the item has the expected structure
-			const normalizedItem = {
-				...item,
-				timesheet: {
-					...item.timesheet,
-					id: timesheetId,
-					createdAt: createdAt
-				}
-			} as ITimeLog;
-
-			acc[timesheetId].push(normalizedItem);
-			return acc;
-		},
-		{} as Record<string, ITimeLog[]>
-	);
-
-	// Then, for each timesheet group, group by date and merge all results
-	const result: GroupedTimesheet[] = [];
-	Object.values(groupedByTimesheet).forEach((timesheetLogs) => {
-		const groupedByDate = timesheetLogs.reduce(
-			(acc, item) => {
-				try {
-					const date = new Date(String(item.timesheet?.createdAt)).toISOString().split('T')[0];
-					if (!acc[date]) acc[date] = [];
-					acc[date].push(item);
-				} catch (error) {
-					console.error(`Failed to process date for timesheet ${item.timesheet?.id}:`, {
-						createdAt: item.timesheet?.createdAt,
-						error
-					});
-				}
-				return acc;
-			},
-			{} as Record<string, ITimeLog[]>
-		);
-
-		// Convert grouped dates to array format and add to results
-		Object.entries(groupedByDate).forEach(([date, tasks]) => {
-			result.push({ date, tasks });
-		});
-	});
-
-	// Sort by date in descending order
-	const sortedResult = result.sort((a, b) => b.date.localeCompare(a.date));
-
-	// Fallback: if no results but we have items, create a simple grouping
-	if (sortedResult.length === 0 && items.length > 0) {
-		const today = new Date().toISOString().split('T')[0];
-		return [
-			{
-				date: today,
-				tasks: items.map(
-					(item) =>
-						({
-							...item,
-							timesheet: {
-								...item.timesheet,
-								id: item.timesheet?.id || item.id || 'fallback',
-								createdAt:
-									item.timesheet?.createdAt ||
-									item.createdAt ||
-									item.startedAt ||
-									new Date().toISOString()
-							}
-						}) as ITimeLog
-				)
-			}
-		];
-	}
-
-	return sortedResult;
-};
-const getWeekYearKey = (date: Date): string => {
-	try {
-		const year = date.getFullYear();
-		const startOfYear = new Date(year, 0, 1);
-		const days = Math.floor((date.getTime() - startOfYear.getTime()) / (24 * 60 * 60 * 1000));
-		const week = Math.ceil((days + startOfYear.getDay() + 1) / 7);
-		return `${year}-W${week.toString().padStart(2, '0')}`;
-	} catch (error) {
-		console.error('Error in getWeekYearKey:', error);
-		return '';
-	}
-};
-
-const getMonthKey = (date: Date): string => {
-	try {
-		const year = date.getFullYear();
-		const month = (date.getMonth() + 1).toString().padStart(2, '0');
-		return `${year}-${month}`;
-	} catch (error) {
-		console.error('Error in getMonthKey:', error);
-		return '';
-	}
-};
-
-type GroupingKeyFunction = (date: Date) => string;
-
-const createGroupingFunction =
-	(getKey: GroupingKeyFunction) =>
-	(items: ITimeLog[]): GroupedTimesheet[] => {
-		if (!items?.length) return [];
-		const groupedByDate = items.reduce(
-			(acc, item) => {
-				// More flexible validation for different data structures
-				const createdAt = item?.timesheet?.createdAt || item?.createdAt || item?.startedAt;
-				if (!createdAt) {
-					console.warn('Skipping item with missing createdAt:', item);
-					return acc;
-				}
-
-				try {
-					const date = new Date(createdAt);
-					if (isNaN(date.getTime())) {
-						console.warn('Invalid date:', createdAt);
-						return acc;
-					}
-
-					const key = getKey(date);
-					if (!acc[key]) {
-						acc[key] = {
-							date: key,
-							timesheets: {}
-						};
-					}
-
-					const timesheetId = item?.timesheet?.id || item?.timesheetId || item?.id || 'fallback';
-					if (!acc[key].timesheets[timesheetId]) {
-						acc[key].timesheets[timesheetId] = [];
-					}
-
-					// Ensure the item has the expected structure
-					const normalizedItem = {
-						...item,
-						timesheet: {
-							...item?.timesheet,
-							id: timesheetId,
-							createdAt: createdAt
-						}
-					} as ITimeLog;
-
-					acc[key].timesheets[timesheetId].push(normalizedItem);
-				} catch (error) {
-					console.warn('Error processing date:', error);
-				}
-				return acc;
-			},
-			{} as Record<string, { date: string; timesheets: Record<string, ITimeLog[]> }>
-		);
-
-		return Object.values(groupedByDate)
-			.map(({ date, timesheets }) => ({
-				date,
-				tasks: Object.values(timesheets)
-					.flat()
-					.sort((a, b) => {
-						if (a.timesheet?.id !== b.timesheet?.id) {
-							return a.timesheet?.id.localeCompare(String(b.timesheet?.id)) ?? 0;
-						}
-						const dateA = new Date(String(a.timesheet?.createdAt));
-						const dateB = new Date(String(b.timesheet?.createdAt));
-						return dateB.getTime() - dateA.getTime();
-					})
-			}))
-			.sort((a, b) => b.date.localeCompare(a.date));
-	};
-
-const groupByWeek = createGroupingFunction((date) => getWeekYearKey(date));
-const groupByMonth = createGroupingFunction(getMonthKey);
+'use client';
 
 /**
- * @function useTimesheet
+ * @deprecated This hook is deprecated. Use the individual CRUD hooks from `@/core/hooks/timesheet` instead:
+ * - `useTimesheetQuery` — READ: query + params sync + data transformation
+ * - `useCreateTimesheet` — WRITE: create timesheet entries
+ * - `useUpdateTimesheet` — WRITE: update timesheet entries + status
+ * - `useDeleteTimesheet` — WRITE: delete timesheet entries
+ * - Pure functions: import directly from `@/core/lib/helpers/timesheet-grouping`
  *
- * @description
- * Fetches timesheet logs based on the provided date range and filters.
+ * This wrapper composes all split hooks for backward compatibility.
+ * It will be removed in a future release.
  *
- * @param {TimesheetParams} params
- * @prop {Date} startDate - Start date of the period to fetch.
- * @prop {Date} endDate - End date of the period to fetch.
- * @prop {string} timesheetViewMode - "ListView" or "CalendarView"
- * @prop {string} inputSearch - Search string to filter the timesheet logs.
- *
- * @returns
- * @prop {boolean} loadingTimesheet - Whether the timesheet is being fetched.
- * @prop {TimesheetLog[]} timesheet - The list of timesheet logs, grouped by day.
- * @prop {function} getTaskTimesheet - Callable to fetch timesheet logs.
- * @prop {boolean} loadingDeleteTimesheet - Whether a timesheet is being deleted.
- * @prop {function} deleteTaskTimesheet - Callable to delete timesheet logs.
- * @prop {function} getStatusTimesheet - Callable to group timesheet logs by status.
- * @prop {TimesheetStatus} timesheetGroupByDays - The current filter for grouping timesheet logs.
- * @prop {object} statusTimesheet - Timesheet logs grouped by status.
- * @prop {function} updateTimesheetStatus - Callable to update the status of timesheet logs.
- * @prop {boolean} loadingUpdateTimesheetStatus - Whether timesheet logs are being updated.
- * @prop {boolean} puTimesheetStatus - Whether timesheet logs are updatable.
- * @prop {function} createTimesheet - Callable to create a new timesheet log.
- * @prop {boolean} loadingCreateTimesheet - Whether a timesheet log is being created.
- * @prop {function} updateTimesheet - Callable to update a timesheet log.
- * @prop {boolean} loadingUpdateTimesheet - Whether a timesheet log is being updated.
- * @prop {function} groupByDate - Callable to group timesheet logs by date.
- * @prop {boolean} isManage - Whether the user is authorized to manage the timesheet.
+ * @see ETP-224 — Refactor useTimesheet: Separate Transformation from Data Fetching
  */
-export function useTimesheet({ startDate, endDate, timesheetViewMode, inputSearch }: TimesheetParams) {
-	const { user } = useAuthenticateUser();
-	const [timesheet, setTimesheet] = useAtom(timesheetRapportState);
-	const queryClient = useQueryClient();
-	const {
-		employee,
-		project,
-		task,
-		statusState,
-		timesheetGroupByDays,
-		puTimesheetStatus,
-		isUserAllowedToAccess,
-		normalizeText,
-		setSelectTimesheetId,
-		selectTimesheetId,
-		handleSelectRowByStatusAndDate,
-		handleSelectRowTimesheet
-	} = useTimelogFilterOptions();
-	const isManage = user && isUserAllowedToAccess(user);
-	const [timesheetParams, setTimesheetParams] = useState<{
-		organizationId: string;
-		tenantId: string;
-		startDate: string | Date;
-		endDate: string | Date;
-		timeZone?: string | undefined;
-		projectIds?: string[] | undefined;
-		employeeIds?: string[] | undefined;
-		taskIds?: string[] | undefined;
-		status?: ETimesheetStatus[] | undefined;
-	} | null>(null);
 
-	// React Query for timesheet logs
-	const timesheetLogsQuery = useQuery({
-		queryKey: queryKeys.timesheet.logs(
-			timesheetParams?.tenantId,
-			timesheetParams?.organizationId,
-			String(timesheetParams?.startDate),
-			String(timesheetParams?.endDate),
-			timesheetParams?.employeeIds,
-			timesheetParams?.projectIds,
-			timesheetParams?.taskIds,
-			timesheetParams?.status
-		),
-		queryFn: async () => {
-			if (!timesheetParams) {
-				throw new Error('Timesheet query parameters are required');
-			}
-			const response = await timeLogService.getTimeLogs(timesheetParams);
-			return response as unknown as ITimeLog[];
-		},
-		enabled: !!timesheetParams && !!timesheetParams.startDate && !!timesheetParams.endDate,
-		staleTime: 1000 * 60 * 3, // 3 minutes - timesheet data changes moderately
-		gcTime: 1000 * 60 * 15 // 15 minutes in cache
-	});
+import { useTimesheetQuery } from '@/core/hooks/timesheet/use-timesheet-query';
+import { useCreateTimesheet } from '@/core/hooks/timesheet/use-create-timesheet';
+import { useUpdateTimesheet } from '@/core/hooks/timesheet/use-update-timesheet';
+import { useDeleteTimesheet } from '@/core/hooks/timesheet/use-delete-timesheet';
+import {
+	type TimesheetParams,
+	groupByDate,
+	getStatusTimesheet,
+	groupedByTimesheetIds,
+	rowsToObject
+} from '@/core/lib/helpers/timesheet-grouping';
 
-	// Mutations
-	const deleteTimesheetMutation = useMutation({
-		mutationFn: async ({ logIds }: { logIds: string[] }) => {
-			if (!user) {
-				throw new Error('User not authenticated');
-			}
-			return await timeLogService.deleteTaskTimesheetLogs({
-				logIds
-			});
-		},
-		onSuccess: () => {
-			invalidateTimesheetData(timesheetParams);
-		}
-	});
+// Re-export types for backward compatibility
+export type { GroupedTimesheet } from '@/core/lib/helpers/timesheet-grouping';
 
-	const updateTimesheetStatusMutation = useMutation({
-		mutationFn: async ({ status, ids }: { status: ETimesheetStatus; ids: string[] | string }) => {
-			const idsArray = Array.isArray(ids) ? ids : [ids];
-			return await timeSheetService.updateStatusTimesheetFrom({ ids: idsArray, status });
-		},
-		onSuccess: () => {
-			invalidateTimesheetData(timesheetParams);
-		}
-	});
-
-	const createTimesheetMutation = useMutation({
-		mutationFn: async (timesheetParams: IUpdateTimesheetRequest) => {
-			return await timeLogService.createTimesheetFrom(timesheetParams);
-		},
-		onSuccess: () => {
-			invalidateTimesheetData(timesheetParams);
-		}
-	});
-
-	const updateTimesheetMutation = useMutation({
-		mutationFn: async (timesheet: IUpdateTimesheetRequest) => {
-			return await timeLogService.updateTimesheetFrom(timesheet);
-		},
-		onSuccess: () => {
-			invalidateTimesheetData(timesheetParams);
-		}
-	});
-
-	// Invalidate timesheet data
-	const invalidateTimesheetData = useCallback(
-		(params: typeof timesheetParams) => {
-			queryClient.invalidateQueries({
-				queryKey: queryKeys.timesheet.logs(
-					params?.tenantId,
-					params?.organizationId,
-					String(params?.startDate),
-					String(params?.endDate),
-					params?.employeeIds,
-					params?.projectIds,
-					params?.taskIds,
-					params?.status
-				)
-			});
-		},
-		[queryClient]
-	);
-
-	// Memoized filter IDs to prevent infinite loops from array reference changes
-	const memoizedFilterIds = useMemo(
-		() => ({
-			employeeIds: isManage
-				? employee?.map(({ employee }) => employee?.id || '').filter(Boolean) || []
-				: [user?.employee?.id || ''].filter(Boolean),
-			projectIds: project?.map((project) => project.id).filter((id) => id !== undefined) || [],
-			taskIds: task?.map((task) => task.id).filter((id) => id !== undefined) || [],
-			status: statusState?.map((status) => status.value).filter((value) => value !== undefined) || []
-		}),
-		[employee, project, task, statusState, isManage, user?.employee?.id]
-	);
-
-	// Previous filter IDs reference for comparison (prevent unnecessary API calls)
-	const prevFilterIdsRef = useRef(memoizedFilterIds);
-
-	// Synchronize props and filters with timesheetParams (restore filter reactivity)
-	useEffect(() => {
-		if (!user || !startDate || !endDate) return;
-
-		const from = moment(startDate).format('YYYY-MM-DD');
-		const to = moment(endDate).format('YYYY-MM-DD');
-
-		const newParams = {
-			startDate: from,
-			endDate: to,
-			organizationId: user.employee?.organizationId || '',
-			tenantId: user.tenantId ?? '',
-			timeZone: user.timeZone?.split('(')[0].trim() || 'UTC',
-			employeeIds: memoizedFilterIds.employeeIds,
-			projectIds: memoizedFilterIds.projectIds,
-			taskIds: memoizedFilterIds.taskIds,
-			status: memoizedFilterIds.status as ETimesheetStatus[]
-		};
-
-		// Deep comparison to prevent unnecessary updates and infinite API calls
-		const filtersChanged =
-			!areArraysEqual(prevFilterIdsRef.current.employeeIds, memoizedFilterIds.employeeIds, (id) => id) ||
-			!areArraysEqual(prevFilterIdsRef.current.projectIds, memoizedFilterIds.projectIds, (id) => id) ||
-			!areArraysEqual(prevFilterIdsRef.current.taskIds, memoizedFilterIds.taskIds, (id) => id) ||
-			!areArraysEqual(prevFilterIdsRef.current.status, memoizedFilterIds.status, (val) => val);
-
-		const paramsChanged =
-			!timesheetParams ||
-			timesheetParams.startDate !== from ||
-			timesheetParams.endDate !== to ||
-			timesheetParams.organizationId !== newParams.organizationId ||
-			timesheetParams.tenantId !== newParams.tenantId ||
-			filtersChanged;
-
-		if (paramsChanged) {
-			setTimesheetParams(newParams);
-			prevFilterIdsRef.current = memoizedFilterIds;
-		}
-	}, [
-		startDate, // Date props changes
-		endDate, // Date props changes
-		user?.employee?.organizationId, // User org changes
-		user?.tenantId, // Tenant changes
-		user?.timeZone, // Timezone changes
-		memoizedFilterIds, // Memoized filter changes (stable reference)
-		timesheetParams // Current params for comparison
-	]);
-
-	// Sync React Query data with Jotai state (removed problematic condition)
-	useConditionalUpdateEffect(
-		() => {
-			if (timesheetLogsQuery.data) {
-				setTimesheet(timesheetLogsQuery.data);
-			}
-		},
-		[timesheetLogsQuery.data],
-		() => timesheetLogsQuery.isLoading // Only skip during loading, not based on existing data
-	);
-
-	/**
-	 * Memoized date range with fallback to defaults
-	 * Ensures all dates are converted to Date objects
-	 */
-	const currentDateRange = useMemo(() => {
-		const now = moment();
-		// Default to Today (start and end of current day)
-		const defaultStart = now.clone().startOf('day').toDate();
-		const defaultEnd = now.clone().endOf('day').toDate();
-
-		const parseDate = (date: Date | string | undefined, defaultValue: Date) => {
-			if (!date) return defaultValue;
-			const parsed = moment(date);
-			return parsed.isValid() ? parsed.toDate() : defaultValue;
-		};
-
-		return {
-			startDate: parseDate(startDate, defaultStart),
-			endDate: parseDate(endDate, defaultEnd)
-		};
-	}, [startDate, endDate]);
-
-	/**
-	 * Format date to YYYY-MM-DD ensuring valid date input
-	 * @param date - Input date (optional)
-	 * @returns Formatted date string
-	 */
-	const formatDate = useCallback((date: Date | string | undefined): string => {
-		if (!date) {
-			return moment().format('YYYY-MM-DD');
-		}
-
-		if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
-			return date;
-		}
-
-		try {
-			const parsedDate = moment(date);
-			if (!parsedDate.isValid()) {
-				console.warn('Invalid date provided, using current date');
-				return moment().format('YYYY-MM-DD');
-			}
-			return parsedDate.format('YYYY-MM-DD');
-		} catch (error) {
-			console.warn('Error parsing date:', error);
-			return moment().format('YYYY-MM-DD');
-		}
-	}, []);
-
-	// Simplified getTaskTimesheet - now just updates params, React Query handles the rest automatically
-	const getTaskTimesheet = useCallback(
-		async (params: TimesheetParams) => {
-			try {
-				if (!user) return;
-
-				const { startDate, endDate } = params;
-				const from = moment(startDate).format('YYYY-MM-DD');
-				const to = moment(endDate).format('YYYY-MM-DD');
-
-				const queryParams = {
-					startDate: from,
-					endDate: to,
-					organizationId: user.employee?.organizationId || '',
-					tenantId: user.tenantId ?? '',
-					timeZone: user.timeZone?.split('(')[0].trim() || 'UTC',
-					employeeIds: memoizedFilterIds.employeeIds,
-					projectIds: memoizedFilterIds.projectIds,
-					taskIds: memoizedFilterIds.taskIds,
-					status: memoizedFilterIds.status as ETimesheetStatus[]
-				};
-
-				// React Query will automatically refetch when queryKey changes (no manual refetch needed)
-				setTimesheetParams(queryParams);
-
-				// Return current data immediately, new data will be available via React Query
-				return timesheetLogsQuery.data;
-			} catch (error) {
-				console.error('Error updating timesheet params:', error);
-			}
-		},
-		[user, memoizedFilterIds, timesheetLogsQuery.data] // Stable dependencies prevent infinite loops
-	);
-
-	// Removed duplicate useEffect - using the one below that handles all dependencies
-
-	const createTimesheet = useCallback(
-		async ({ ...timesheetParams }: IUpdateTimesheetRequest) => {
-			if (!user) {
-				throw new Error('User not authenticated');
-			}
-			try {
-				const response = await createTimesheetMutation.mutateAsync(timesheetParams);
-				return response.data;
-			} catch (error) {
-				if (axios.isAxiosError(error)) {
-					console.error('Axios Error:', {
-						status: error.response?.status,
-						statusText: error.response?.statusText,
-						data: error.response?.data
-					});
-					throw new Error(`Request failed: ${error.message}`);
-				}
-				console.error('Error:', error instanceof Error ? error.message : error);
-				throw error;
-			}
-		},
-		[createTimesheetMutation, user]
-	);
-
-	const updateTimesheet = useCallback(
-		async (timesheet: IUpdateTimesheetRequest) => {
-			if (!user) {
-				console.warn('User not authenticated!');
-				return;
-			}
-			try {
-				const response = await updateTimesheetMutation.mutateAsync(timesheet);
-				return response.data;
-			} catch (error) {
-				console.error('Error updating the timesheet:', error);
-				throw error;
-			}
-		},
-		[updateTimesheetMutation, user]
-	);
-
-	const updateTimesheetStatus = useCallback(
-		async ({ status, ids }: { status: ETimesheetStatus; ids: string[] | string }) => {
-			if (!user) return;
-			const idsArray = Array.isArray(ids) ? ids : [ids];
-			try {
-				await updateTimesheetStatusMutation.mutateAsync({ status, ids: idsArray });
-			} catch (error) {
-				console.error('Error updating timesheet status:', error);
-			}
-		},
-		[updateTimesheetStatusMutation, user]
-	);
-
-	const getStatusTimesheet = (items: ITimeLog[] = []) => {
-		const STATUS_MAP: Record<ETimesheetStatus, ITimeLog[]> = {
-			[ETimesheetStatus.PENDING]: [],
-			[ETimesheetStatus.APPROVED]: [],
-			[ETimesheetStatus.DENIED]: [],
-			[ETimesheetStatus.DRAFT]: [],
-			[ETimesheetStatus.IN_REVIEW]: []
-		};
-
-		const result = items.reduce((acc, item) => {
-			const status = item.timesheet?.status;
-
-			if (isTimesheetStatus(status)) {
-				acc[status].push(item);
-			} else {
-				console.warn(`Invalid timesheet status: ${status}`, 'item:', item);
-			}
-			return acc;
-		}, STATUS_MAP);
-		return result;
-	};
-
-	// Type guard
-	function isTimesheetStatus(status: unknown): status is ETimesheetStatus {
-		const timesheetStatusValues = Object.values(ETimesheetStatus);
-		return Object.values(timesheetStatusValues).includes(status as ETimesheetStatus);
-	}
-
-	const deleteTaskTimesheet = useCallback(
-		async ({ logIds }: { logIds: string[] }) => {
-			if (!user) {
-				throw new Error('User not authenticated');
-			}
-			if (!logIds.length) {
-				throw new Error('No timesheet IDs provided for deletion');
-			}
-			try {
-				await deleteTimesheetMutation.mutateAsync({ logIds });
-			} catch (error) {
-				console.error('Failed to delete timesheets:', error);
-				throw error;
-			}
-		},
-		[user, deleteTimesheetMutation]
-	);
-
-	const groupedByTimesheetIds = ({ rows }: { rows: ITimeLog[] }): Record<string, ITimeLog[]> => {
-		if (!rows) {
-			return {};
-		}
-		return rows.reduce(
-			(acc, row) => {
-				if (!row) {
-					return acc;
-				}
-				const timesheetId = row.timesheetId ?? 'unassigned';
-				if (!acc[timesheetId]) {
-					acc[timesheetId] = [];
-				}
-				acc[timesheetId].push(row);
-				return acc;
-			},
-			{} as Record<string, ITimeLog[]>
-		);
-	};
-
-	const filterDataTimesheet = useMemo(() => {
-		if (!timesheet || !inputSearch) {
-			return timesheet;
-		}
-		const searchTerms = normalizeText(inputSearch).split(/\s+/).filter(Boolean);
-		if (searchTerms.length === 0) {
-			return timesheet;
-		}
-
-		const filtered = timesheet.filter((task: any) => {
-			const searchableContent = {
-				title: normalizeText(task.task?.title),
-				employee: normalizeText(task.employee?.fullName),
-				project: normalizeText(task.project?.name)
-			};
-			return searchTerms.every((term) =>
-				Object.values(searchableContent).some((content) => content.includes(term))
-			);
-		});
-		return filtered;
-	}, [timesheet, inputSearch, normalizeText]);
-
-	const reGroupByDate = (groupedTimesheets: GroupedTimesheet[]): GroupedTimesheet[] => {
-		return groupedTimesheets.reduce((acc, { date, tasks }) => {
-			const existingGroup = acc.find((group) => group.date === date);
-			if (existingGroup) {
-				existingGroup.tasks = existingGroup.tasks.concat(tasks);
-			} else {
-				acc.push({ date, tasks });
-			}
-			return acc;
-		}, [] as GroupedTimesheet[]);
-	};
-
-	const timesheetElementGroup = useMemo(() => {
-		if (!timesheet) {
-			return [];
-		}
-
-		if (timesheetViewMode === 'ListView') {
-			const groupedTimesheets = groupByDate(filterDataTimesheet as any);
-			const reGroupedByDate = reGroupByDate(groupedTimesheets);
-			switch (timesheetGroupByDays) {
-				case 'Daily':
-					return reGroupedByDate;
-				case 'Weekly':
-					return groupByWeek(filterDataTimesheet as any);
-				case 'Monthly':
-					return groupByMonth(filterDataTimesheet as any);
-				default:
-					return reGroupedByDate;
-			}
-		}
-		return reGroupByDate(groupByDate(filterDataTimesheet as any));
-	}, [timesheet, timesheetViewMode, filterDataTimesheet, timesheetGroupByDays]);
-
-	const rowsToObject = (rows: ITimeLog[]): Record<string, { task: ITimeLog; status: ETimesheetStatus }> => {
-		return rows.reduce(
-			(acc, row) => {
-				acc[row.timesheet?.id ?? ''] = { task: row, status: row.timesheet?.status ?? ETimesheetStatus.DRAFT };
-				return acc;
-			},
-			{} as Record<string, { task: ITimeLog; status: ETimesheetStatus }>
-		);
-	};
-
-	// React Query now automatically refetches when timesheetParams changes (queryKey dependency)
-	// Date filters (Today, Last 7 days, etc.) work automatically through props → timesheetParams sync
+/** @deprecated Use individual hooks from `@/core/hooks/timesheet` instead */
+export function useTimesheet(params: TimesheetParams) {
+	const query = useTimesheetQuery(params);
+	const { createTimesheet, loadingCreateTimesheet } = useCreateTimesheet();
+	const { updateTimesheet, loadingUpdateTimesheet, updateTimesheetStatus, loadingUpdateTimesheetStatus } =
+		useUpdateTimesheet();
+	const { deleteTaskTimesheet, loadingDeleteTimesheet } = useDeleteTimesheet();
 
 	return {
-		loadingTimesheet: timesheetLogsQuery.isLoading,
-		timesheet: timesheetElementGroup,
-		getTaskTimesheet,
-		loadingDeleteTimesheet: deleteTimesheetMutation.isPending,
+		// Query state — NOTE: original returned grouped data as `timesheet`
+		loadingTimesheet: query.loadingTimesheet,
+		timesheet: query.timesheetElementGroup,
+		getTaskTimesheet: query.getTaskTimesheet,
+
+		// Delete
+		loadingDeleteTimesheet,
 		deleteTaskTimesheet,
+
+		// Pure functions (direct re-exports for backward compat)
 		getStatusTimesheet,
-		timesheetGroupByDays,
-		statusTimesheet: getStatusTimesheet((filterDataTimesheet as ITimeLog[]) || []),
-		updateTimesheetStatus,
-		loadingUpdateTimesheetStatus: updateTimesheetStatusMutation.isPending,
-		puTimesheetStatus,
-		createTimesheet,
-		loadingCreateTimesheet: createTimesheetMutation.isPending,
-		updateTimesheet,
-		loadingUpdateTimesheet: updateTimesheetMutation.isPending,
 		groupByDate,
-		isManage,
-		normalizeText,
-		setSelectTimesheetId,
-		selectTimesheetId,
-		handleSelectRowByStatusAndDate,
-		handleSelectRowTimesheet,
 		groupedByTimesheetIds,
 		rowsToObject,
-		formatDate,
-		currentDateRange
+
+		// Grouping & status
+		timesheetGroupByDays: query.timesheetGroupByDays,
+		statusTimesheet: query.statusTimesheet,
+
+		// Update
+		updateTimesheetStatus,
+		loadingUpdateTimesheetStatus,
+
+		// Filter options
+		puTimesheetStatus: query.puTimesheetStatus,
+
+		// Create
+		createTimesheet,
+		loadingCreateTimesheet,
+
+		// Update content
+		updateTimesheet,
+		loadingUpdateTimesheet,
+
+		// Misc
+		isManage: query.isManage,
+		normalizeText: query.normalizeText,
+		setSelectTimesheetId: query.setSelectTimesheetId,
+		selectTimesheetId: query.selectTimesheetId,
+		handleSelectRowByStatusAndDate: query.handleSelectRowByStatusAndDate,
+		handleSelectRowTimesheet: query.handleSelectRowTimesheet,
+		formatDate: query.formatDate,
+		currentDateRange: query.currentDateRange
 	};
 }
+

--- a/apps/web/core/hooks/organizations/teams/use-organization-teams.ts
+++ b/apps/web/core/hooks/organizations/teams/use-organization-teams.ts
@@ -96,21 +96,11 @@ export function useOrganizationTeams() {
 
 	// ==================== SIDE EFFECTS ====================
 
-	const isManager = useCallback(() => {
-		const $u = user;
-		const isM = members.find((member) => {
-			const isUser = member.employee?.userId === $u?.id;
-			return isUser && member.role && member.role.name === 'MANAGER';
-		});
-		setIsTeamManager(!!isM);
-	}, [user, members, setIsTeamManager]);
-
 	useEffect(() => {
 		if (activeTeam?.projects && activeTeam?.projects?.length) {
 			setActiveProjectIdCookie(activeTeam?.projects[0]?.id);
 		}
 		setIsTrackingEnabledState(isTrackingEnabled);
-		isManager();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [activeTeam]);
 

--- a/apps/web/core/hooks/organizations/teams/use-team-member.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-member.ts
@@ -1,14 +1,15 @@
 'use client';
-import { useAtomValue } from 'jotai';
-import { useMemo } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useCallback, useEffect, useMemo } from 'react';
 
-import { activeTeamState } from '@/core/stores';
+import { activeTeamState, isTeamManagerState } from '@/core/stores';
 import { ERoleName } from '@/core/types/generics/enums/role';
 import { TUser } from '@/core/types/schemas';
 
 export function useIsMemberManager(user?: TUser | null) {
 	const activeTeam = useAtomValue(activeTeamState);
 
+	const members = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 	const activeManager = useMemo(() => {
 		if (!user || !activeTeam?.members) return undefined;
 
@@ -17,7 +18,10 @@ export function useIsMemberManager(user?: TUser | null) {
 			const roleName = member.role?.name;
 			return (
 				isUser &&
-				(roleName === ERoleName.MANAGER || roleName === ERoleName.SUPER_ADMIN || roleName === ERoleName.ADMIN)
+				(member.isManager === true ||
+					roleName === ERoleName.MANAGER ||
+					roleName === ERoleName.SUPER_ADMIN ||
+					roleName === ERoleName.ADMIN)
 			);
 		});
 	}, [user?.id, activeTeam?.members]);
@@ -29,10 +33,28 @@ export function useIsMemberManager(user?: TUser | null) {
 
 	// Team creator should automatically be considered a manager (business logic fix)
 	const isTeamManager = !!activeManager || isTeamCreator;
+
+	// Sync isTeamManagerState atom for global consumers (sidebar, project modal, task info)
+	const setIsTeamManager = useSetAtom(isTeamManagerState);
+
+	const isManager = useCallback(() => {
+		const $u = user;
+		const isM = members.find((member) => {
+			const isUser = member.employee?.userId === $u?.id;
+			return isUser && (member.isManager === true || (member.role && member.role.name === 'MANAGER'));
+		});
+		setIsTeamManager(!!isM);
+	}, [user, members, setIsTeamManager]);
+	useEffect(() => {
+		setIsTeamManager(isTeamManager);
+		isManager()
+	}, [isTeamManager, setIsTeamManager]);
+
 	return {
 		isTeamManager,
 		isTeamCreator,
 		activeTeam,
-		activeManager
+		activeManager,
+		isManager
 	};
 }

--- a/apps/web/core/hooks/timesheet/index.ts
+++ b/apps/web/core/hooks/timesheet/index.ts
@@ -1,0 +1,25 @@
+// ─── Timesheet CRUD Hooks ────────────────────────────────────────────────────
+// Split from the original monolithic useTimesheet hook (ETP-224)
+// following the CRUD-split pattern used across the codebase.
+
+export { useTimesheetInvalidation } from './use-timesheet-invalidation';
+export { useTimesheetQuery } from './use-timesheet-query';
+export { useCreateTimesheet } from './use-create-timesheet';
+export { useUpdateTimesheet } from './use-update-timesheet';
+export { useDeleteTimesheet } from './use-delete-timesheet';
+
+// Re-export pure utility functions and types for convenience
+export {
+	type TimesheetParams,
+	type GroupedTimesheet,
+	areArraysEqual,
+	groupByDate,
+	groupByWeek,
+	groupByMonth,
+	reGroupByDate,
+	getStatusTimesheet,
+	isTimesheetStatus,
+	groupedByTimesheetIds,
+	rowsToObject
+} from '@/core/lib/helpers/timesheet-grouping';
+

--- a/apps/web/core/hooks/timesheet/use-create-timesheet.ts
+++ b/apps/web/core/hooks/timesheet/use-create-timesheet.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import { timeLogService } from '@/core/services/client/api/timesheets/time-log.service';
+import { IUpdateTimesheetRequest } from '@/core/types/interfaces/timesheet/timesheet';
+import { useAuthenticateUser } from '../auth';
+import { useTimesheetInvalidation } from './use-timesheet-invalidation';
+
+/**
+ * Hook for creating timesheet entries.
+ * Handles the create mutation with automatic cache invalidation.
+ */
+export function useCreateTimesheet() {
+	const { user } = useAuthenticateUser();
+	const { invalidateTimesheetData } = useTimesheetInvalidation();
+
+	const createTimesheetMutation = useMutation({
+		mutationFn: async (timesheetParams: IUpdateTimesheetRequest) => {
+			return await timeLogService.createTimesheetFrom(timesheetParams);
+		},
+		onSuccess: () => {
+			invalidateTimesheetData();
+		}
+	});
+
+	const createTimesheet = useCallback(
+		async ({ ...timesheetParams }: IUpdateTimesheetRequest) => {
+			if (!user) {
+				throw new Error('User not authenticated');
+			}
+			try {
+				const response = await createTimesheetMutation.mutateAsync(timesheetParams);
+				return response.data;
+			} catch (error) {
+				if (axios.isAxiosError(error)) {
+					console.error('Axios Error:', {
+						status: error.response?.status,
+						statusText: error.response?.statusText,
+						data: error.response?.data
+					});
+					throw new Error(`Request failed: ${error.message}`);
+				}
+				console.error('Error:', error instanceof Error ? error.message : error);
+				throw error;
+			}
+		},
+		[createTimesheetMutation, user]
+	);
+
+	return {
+		createTimesheet,
+		loadingCreateTimesheet: createTimesheetMutation.isPending
+	};
+}
+

--- a/apps/web/core/hooks/timesheet/use-delete-timesheet.ts
+++ b/apps/web/core/hooks/timesheet/use-delete-timesheet.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { timeLogService } from '@/core/services/client/api/timesheets/time-log.service';
+import { useAuthenticateUser } from '../auth';
+import { useTimesheetInvalidation } from './use-timesheet-invalidation';
+
+/**
+ * Hook for deleting timesheet entries.
+ * Handles the delete mutation with automatic cache invalidation.
+ */
+export function useDeleteTimesheet() {
+	const { user } = useAuthenticateUser();
+	const { invalidateTimesheetData } = useTimesheetInvalidation();
+
+	const deleteTimesheetMutation = useMutation({
+		mutationFn: async ({ logIds }: { logIds: string[] }) => {
+			if (!user) {
+				throw new Error('User not authenticated');
+			}
+			return await timeLogService.deleteTaskTimesheetLogs({ logIds });
+		},
+		onSuccess: () => {
+			invalidateTimesheetData();
+		}
+	});
+
+	const deleteTaskTimesheet = useCallback(
+		async ({ logIds }: { logIds: string[] }) => {
+			if (!user) {
+				throw new Error('User not authenticated');
+			}
+			if (!logIds.length) {
+				throw new Error('No timesheet IDs provided for deletion');
+			}
+			try {
+				await deleteTimesheetMutation.mutateAsync({ logIds });
+			} catch (error) {
+				console.error('Failed to delete timesheets:', error);
+				throw error;
+			}
+		},
+		[user, deleteTimesheetMutation]
+	);
+
+	return {
+		deleteTaskTimesheet,
+		loadingDeleteTimesheet: deleteTimesheetMutation.isPending
+	};
+}
+

--- a/apps/web/core/hooks/timesheet/use-timesheet-invalidation.ts
+++ b/apps/web/core/hooks/timesheet/use-timesheet-invalidation.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { queryKeys } from '@/core/query/keys';
+
+/**
+ * Shared cache invalidation logic for timesheet mutations.
+ * Uses broad prefix invalidation (`queryKeys.timesheet.all`) to ensure
+ * all timesheet-related queries (logs, dailyReport, timerLogsDailyReport, timeLog)
+ * are invalidated consistently across all operations.
+ *
+ * @returns Object containing the invalidation function
+ */
+export function useTimesheetInvalidation() {
+	const queryClient = useQueryClient();
+
+	const invalidateTimesheetData = useCallback(() => {
+		queryClient.invalidateQueries({
+			queryKey: queryKeys.timesheet.all
+		});
+	}, [queryClient]);
+
+	return {
+		invalidateTimesheetData
+	};
+}
+

--- a/apps/web/core/hooks/timesheet/use-timesheet-query.ts
+++ b/apps/web/core/hooks/timesheet/use-timesheet-query.ts
@@ -1,0 +1,259 @@
+'use client';
+
+import { useAtom } from 'jotai';
+import { timesheetRapportState } from '@/core/stores/timer/time-logs';
+import { useCallback, useMemo, useState, useEffect, useRef } from 'react';
+import moment from 'moment';
+import { useTimelogFilterOptions } from '../activities/use-timelog-filter-options';
+import { timeLogService } from '@/core/services/client/api/timesheets/time-log.service';
+import { useAuthenticateUser } from '../auth';
+import { ITimeLog } from '@/core/types/interfaces/timer/time-log/time-log';
+import { ETimesheetStatus } from '@/core/types/generics/enums/timesheet';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/core/query/keys';
+import { useConditionalUpdateEffect } from '../common/use-has-mounted';
+import {
+	type TimesheetParams,
+	areArraysEqual,
+	groupByDate,
+	groupByWeek,
+	groupByMonth,
+	reGroupByDate,
+	getStatusTimesheet
+} from '@/core/lib/helpers/timesheet-grouping';
+
+/**
+ * Hook for fetching and transforming timesheet data.
+ * Handles: query, params synchronization, Jotai sync, search filtering, and view-mode grouping.
+ */
+export function useTimesheetQuery({ startDate, endDate, timesheetViewMode, inputSearch }: TimesheetParams) {
+	const { user } = useAuthenticateUser();
+	const [timesheet, setTimesheet] = useAtom(timesheetRapportState);
+	const {
+		employee,
+		project,
+		task,
+		statusState,
+		timesheetGroupByDays,
+		puTimesheetStatus,
+		isUserAllowedToAccess,
+		normalizeText,
+		setSelectTimesheetId,
+		selectTimesheetId,
+		handleSelectRowByStatusAndDate,
+		handleSelectRowTimesheet
+	} = useTimelogFilterOptions();
+
+	const isManage = user && isUserAllowedToAccess(user);
+
+	// ─── Query Params State ──────────────────────────────────────────────────
+	const [timesheetParams, setTimesheetParams] = useState<{
+		organizationId: string;
+		tenantId: string;
+		startDate: string | Date;
+		endDate: string | Date;
+		timeZone?: string;
+		projectIds?: string[];
+		employeeIds?: string[];
+		taskIds?: string[];
+		status?: ETimesheetStatus[];
+	} | null>(null);
+
+	// ─── React Query ─────────────────────────────────────────────────────────
+	const timesheetLogsQuery = useQuery({
+		queryKey: queryKeys.timesheet.logs(
+			timesheetParams?.tenantId,
+			timesheetParams?.organizationId,
+			String(timesheetParams?.startDate),
+			String(timesheetParams?.endDate),
+			timesheetParams?.employeeIds,
+			timesheetParams?.projectIds,
+			timesheetParams?.taskIds,
+			timesheetParams?.status
+		),
+		queryFn: async () => {
+			if (!timesheetParams) {
+				throw new Error('Timesheet query parameters are required');
+			}
+			// organizationId & tenantId are handled by the service instance — exclude them from the request
+			const { organizationId: _orgId, tenantId: _tenantId, ...requestParams } = timesheetParams;
+			const response = await timeLogService.getTimeLogs(requestParams);
+			return response as unknown as ITimeLog[];
+		},
+		enabled: !!timesheetParams && !!timesheetParams.startDate && !!timesheetParams.endDate,
+		staleTime: 1000 * 60 * 3,
+		gcTime: 1000 * 60 * 15
+	});
+
+	// ─── Memoized Filter IDs ─────────────────────────────────────────────────
+	const memoizedFilterIds = useMemo(
+		() => ({
+			employeeIds: isManage
+				? employee?.map(({ employee }) => employee?.id || '').filter(Boolean) || []
+				: [user?.employee?.id || ''].filter(Boolean),
+			projectIds: project?.map((p) => p.id).filter((id) => id !== undefined) || [],
+			taskIds: task?.map((t) => t.id).filter((id) => id !== undefined) || [],
+			status: statusState?.map((s) => s.value).filter((v) => v !== undefined) || []
+		}),
+		[employee, project, task, statusState, isManage, user?.employee?.id]
+	);
+
+	const prevFilterIdsRef = useRef(memoizedFilterIds);
+
+	// ─── Params Synchronization ──────────────────────────────────────────────
+	useEffect(() => {
+		if (!user || !startDate || !endDate) return;
+
+		const from = moment(startDate).format('YYYY-MM-DD');
+		const to = moment(endDate).format('YYYY-MM-DD');
+
+		const newParams = {
+			startDate: from,
+			endDate: to,
+			organizationId: user.employee?.organizationId || '',
+			tenantId: user.tenantId ?? '',
+			timeZone: user.timeZone?.split('(')[0].trim() || 'UTC',
+			employeeIds: memoizedFilterIds.employeeIds,
+			projectIds: memoizedFilterIds.projectIds,
+			taskIds: memoizedFilterIds.taskIds,
+			status: memoizedFilterIds.status as ETimesheetStatus[]
+		};
+
+		const filtersChanged =
+			!areArraysEqual(prevFilterIdsRef.current.employeeIds, memoizedFilterIds.employeeIds, (id) => id) ||
+			!areArraysEqual(prevFilterIdsRef.current.projectIds, memoizedFilterIds.projectIds, (id) => id) ||
+			!areArraysEqual(prevFilterIdsRef.current.taskIds, memoizedFilterIds.taskIds, (id) => id) ||
+			!areArraysEqual(prevFilterIdsRef.current.status, memoizedFilterIds.status, (val) => val);
+
+		const paramsChanged =
+			!timesheetParams ||
+			timesheetParams.startDate !== from ||
+			timesheetParams.endDate !== to ||
+			timesheetParams.organizationId !== newParams.organizationId ||
+			timesheetParams.tenantId !== newParams.tenantId ||
+			filtersChanged;
+
+		if (paramsChanged) {
+			setTimesheetParams(newParams);
+			prevFilterIdsRef.current = memoizedFilterIds;
+		}
+	}, [startDate, endDate, user?.employee?.organizationId, user?.tenantId, user?.timeZone, memoizedFilterIds, timesheetParams]);
+
+
+	// ─── Jotai Sync (backward compat) ────────────────────────────────────────
+	useConditionalUpdateEffect(
+		() => {
+			if (timesheetLogsQuery.data) {
+				setTimesheet(timesheetLogsQuery.data);
+			}
+		},
+		[timesheetLogsQuery.data],
+		() => timesheetLogsQuery.isLoading
+	);
+
+	// ─── Date Utilities ──────────────────────────────────────────────────────
+	const currentDateRange = useMemo(() => {
+		if (!startDate || !endDate) return '';
+		const start = moment(startDate);
+		const end = moment(endDate);
+		if (start.isSame(end, 'day')) return start.format('MMMM DD, YYYY');
+		if (start.isSame(end, 'month')) return `${start.format('MMMM DD')} - ${end.format('DD, YYYY')}`;
+		return `${start.format('MMMM DD')} - ${end.format('MMMM DD, YYYY')}`;
+	}, [startDate, endDate]);
+
+	const formatDate = useCallback((date: Date | string) => moment(date).format('YYYY-MM-DD'), []);
+
+	// ─── Imperative API (getTaskTimesheet) ───────────────────────────────────
+	const getTaskTimesheet = useCallback(
+		async (params: Record<string, string | string[] | boolean | undefined>) => {
+			if (!user) return [];
+			try {
+				const response = await timeLogService.getTimeLogs({
+					startDate: moment(startDate).format('YYYY-MM-DD'),
+					endDate: moment(endDate).format('YYYY-MM-DD'),
+					timeZone: user.timeZone?.split('(')[0].trim() || 'UTC',
+					...params
+				});
+				return response as unknown as ITimeLog[];
+			} catch (error) {
+				console.error('Error fetching task timesheet:', error);
+				return [];
+			}
+		},
+		[user, startDate, endDate]
+	);
+
+	// ─── Status Timesheet (memoized) ─────────────────────────────────────────
+	const statusTimesheet = useMemo(
+		() => getStatusTimesheet(timesheetLogsQuery.data ?? timesheet),
+		[timesheetLogsQuery.data, timesheet]
+	);
+
+	// ─── Search Filtering ────────────────────────────────────────────────────
+	const filterDataTimesheet = useMemo(() => {
+		const data = timesheetLogsQuery.data ?? timesheet;
+		if (!inputSearch?.trim()) return data;
+		const searchTerm = normalizeText(inputSearch);
+		return data.filter((item) => {
+			const taskName = normalizeText(item.task?.title || '');
+			const employeeName = normalizeText(item.employee?.fullName || '');
+			const projectName = normalizeText(item.project?.name || '');
+			return taskName.includes(searchTerm) || employeeName.includes(searchTerm) || projectName.includes(searchTerm);
+		});
+	}, [timesheetLogsQuery.data, timesheet, inputSearch, normalizeText]);
+
+	// ─── View-Mode Grouping ──────────────────────────────────────────────────
+	const timesheetElementGroup = useMemo(() => {
+		const data = filterDataTimesheet;
+		switch (timesheetViewMode) {
+			case 'ListView': {
+				const grouped = (() => {
+					switch (timesheetGroupByDays) {
+						case 'Daily':
+							return groupByDate(data);
+						case 'Weekly':
+							return groupByWeek(data);
+						case 'Monthly':
+							return groupByMonth(data);
+						default:
+							return groupByDate(data);
+					}
+				})();
+				return reGroupByDate(grouped);
+			}
+			case 'CalendarView':
+				return reGroupByDate(groupByDate(data));
+			default:
+				return reGroupByDate(groupByDate(data));
+		}
+	}, [filterDataTimesheet, timesheetViewMode, timesheetGroupByDays]);
+
+	// ─── Return ──────────────────────────────────────────────────────────────
+	return {
+		// Query state
+		timesheet: filterDataTimesheet,
+		loadingTimesheet: timesheetLogsQuery.isLoading,
+		timesheetLogsQuery,
+
+		// Grouping & status
+		statusTimesheet,
+		timesheetElementGroup,
+
+		// Date utilities
+		currentDateRange,
+		formatDate,
+
+		// Imperative API
+		getTaskTimesheet,
+
+		// Filter options (pass-through)
+		isManage,
+		timesheetGroupByDays,
+		puTimesheetStatus,
+		selectTimesheetId,
+		setSelectTimesheetId,
+		handleSelectRowByStatusAndDate,
+		handleSelectRowTimesheet,
+		normalizeText
+	};
+}

--- a/apps/web/core/hooks/timesheet/use-update-timesheet.ts
+++ b/apps/web/core/hooks/timesheet/use-update-timesheet.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { timeLogService } from '@/core/services/client/api/timesheets/time-log.service';
+import { timeSheetService } from '@/core/services/client/api/timesheets/timesheet.service';
+import { IUpdateTimesheetRequest } from '@/core/types/interfaces/timesheet/timesheet';
+import { ETimesheetStatus } from '@/core/types/generics/enums/timesheet';
+import { useAuthenticateUser } from '../auth';
+import { useTimesheetInvalidation } from './use-timesheet-invalidation';
+
+/**
+ * Hook for updating timesheet entries and their statuses.
+ * Groups both update operations (content + status) since they share the same domain.
+ */
+export function useUpdateTimesheet() {
+	const { user } = useAuthenticateUser();
+	const { invalidateTimesheetData } = useTimesheetInvalidation();
+
+	const updateTimesheetMutation = useMutation({
+		mutationFn: async (timesheet: IUpdateTimesheetRequest) => {
+			return await timeLogService.updateTimesheetFrom(timesheet);
+		},
+		onSuccess: () => {
+			invalidateTimesheetData();
+		}
+	});
+
+	const updateTimesheetStatusMutation = useMutation({
+		mutationFn: async ({ status, ids }: { status: ETimesheetStatus; ids: string[] | string }) => {
+			const idsArray = Array.isArray(ids) ? ids : [ids];
+			return await timeSheetService.updateStatusTimesheetFrom({ ids: idsArray, status });
+		},
+		onSuccess: () => {
+			invalidateTimesheetData();
+		}
+	});
+
+	const updateTimesheet = useCallback(
+		async (timesheet: IUpdateTimesheetRequest) => {
+			if (!user) {
+				console.warn('User not authenticated!');
+				return;
+			}
+			try {
+				const response = await updateTimesheetMutation.mutateAsync(timesheet);
+				return response.data;
+			} catch (error) {
+				console.error('Error updating the timesheet:', error);
+				throw error;
+			}
+		},
+		[updateTimesheetMutation, user]
+	);
+
+	const updateTimesheetStatus = useCallback(
+		async ({ status, ids }: { status: ETimesheetStatus; ids: string[] | string }) => {
+			if (!user) return;
+			const idsArray = Array.isArray(ids) ? ids : [ids];
+			try {
+				await updateTimesheetStatusMutation.mutateAsync({ status, ids: idsArray });
+			} catch (error) {
+				console.error('Error updating timesheet status:', error);
+			}
+		},
+		[updateTimesheetStatusMutation, user]
+	);
+
+	return {
+		updateTimesheet,
+		loadingUpdateTimesheet: updateTimesheetMutation.isPending,
+		updateTimesheetStatus,
+		loadingUpdateTimesheetStatus: updateTimesheetStatusMutation.isPending
+	};
+}
+

--- a/apps/web/core/lib/helpers/timesheet-grouping.ts
+++ b/apps/web/core/lib/helpers/timesheet-grouping.ts
@@ -1,0 +1,260 @@
+import { ITimeLog } from '@/core/types/interfaces/timer/time-log/time-log';
+import { ETimesheetStatus } from '@/core/types/generics/enums/timesheet';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface TimesheetParams {
+	startDate?: Date | string;
+	endDate?: Date | string;
+	timesheetViewMode?: 'ListView' | 'CalendarView';
+	inputSearch?: string;
+}
+
+export interface GroupedTimesheet {
+	date: string;
+	tasks: ITimeLog[];
+}
+
+export type GroupingKeyFunction = (date: Date) => string;
+
+// ─── Deep Array Comparison ───────────────────────────────────────────────────
+
+export const areArraysEqual = <T>(
+	arr1: T[] | undefined,
+	arr2: T[] | undefined,
+	keyExtractor: (item: T) => string | number
+): boolean => {
+	if (!arr1 && !arr2) return true;
+	if (!arr1 || !arr2) return false;
+	if (arr1.length !== arr2.length) return false;
+	const keys1 = arr1.map(keyExtractor).sort();
+	const keys2 = arr2.map(keyExtractor).sort();
+	return keys1.every((key, index) => key === keys2[index]);
+};
+
+// ─── Date Key Extractors ─────────────────────────────────────────────────────
+
+export const getWeekYearKey = (date: Date): string => {
+	try {
+		const year = date.getFullYear();
+		const startOfYear = new Date(year, 0, 1);
+		const days = Math.floor((date.getTime() - startOfYear.getTime()) / (24 * 60 * 60 * 1000));
+		const week = Math.ceil((days + startOfYear.getDay() + 1) / 7);
+		return `${year}-W${week.toString().padStart(2, '0')}`;
+	} catch (error) {
+		console.error('Error in getWeekYearKey:', error);
+		return '';
+	}
+};
+
+export const getMonthKey = (date: Date): string => {
+	try {
+		const year = date.getFullYear();
+		const month = (date.getMonth() + 1).toString().padStart(2, '0');
+		return `${year}-${month}`;
+	} catch (error) {
+		console.error('Error in getMonthKey:', error);
+		return '';
+	}
+};
+
+// ─── Grouping Factory ────────────────────────────────────────────────────────
+
+export const createGroupingFunction =
+	(getKey: GroupingKeyFunction) =>
+	(items: ITimeLog[]): GroupedTimesheet[] => {
+		if (!items?.length) return [];
+		const grouped = items.reduce(
+			(acc, item) => {
+				const createdAt = item?.timesheet?.createdAt || item?.createdAt || item?.startedAt;
+				if (!createdAt) {
+					console.warn('Skipping item with missing createdAt:', item);
+					return acc;
+				}
+				try {
+					const date = new Date(createdAt);
+					if (isNaN(date.getTime())) {
+						console.warn('Invalid date:', createdAt);
+						return acc;
+					}
+					const key = getKey(date);
+					if (!acc[key]) {
+						acc[key] = { date: key, timesheets: {} };
+					}
+					const timesheetId = item?.timesheet?.id || item?.timesheetId || item?.id || 'fallback';
+					if (!acc[key].timesheets[timesheetId]) {
+						acc[key].timesheets[timesheetId] = [];
+					}
+					acc[key].timesheets[timesheetId].push({
+						...item,
+						timesheet: { ...item?.timesheet, id: timesheetId, createdAt }
+					} as ITimeLog);
+				} catch (error) {
+					console.warn('Error processing date:', error);
+				}
+				return acc;
+			},
+			{} as Record<string, { date: string; timesheets: Record<string, ITimeLog[]> }>
+		);
+
+		return Object.values(grouped)
+			.map(({ date, timesheets }) => ({
+				date,
+				tasks: Object.values(timesheets)
+					.flat()
+					.sort((a, b) => {
+						if (a.timesheet?.id !== b.timesheet?.id) {
+							return a.timesheet?.id.localeCompare(String(b.timesheet?.id)) ?? 0;
+						}
+						const dateA = new Date(String(a.timesheet?.createdAt));
+						const dateB = new Date(String(b.timesheet?.createdAt));
+						return dateB.getTime() - dateA.getTime();
+					})
+			}))
+			.sort((a, b) => b.date.localeCompare(a.date));
+	};
+
+export const groupByWeek = createGroupingFunction((date) => getWeekYearKey(date));
+export const groupByMonth = createGroupingFunction(getMonthKey);
+
+
+// ─── Group by Date (Daily) ───────────────────────────────────────────────────
+
+export const groupByDate = (items: ITimeLog[]): GroupedTimesheet[] => {
+	if (!items?.length) return [];
+
+	const groupedByTimesheet = items.reduce(
+		(acc, item, index) => {
+			const timesheetId = item?.timesheet?.id || item?.timesheetId || `fallback-${index}`;
+			const createdAt =
+				item?.timesheet?.createdAt || item?.createdAt || item?.startedAt || new Date().toISOString();
+			if (!item || !createdAt) return acc;
+			if (!acc[timesheetId]) acc[timesheetId] = [];
+			acc[timesheetId].push({
+				...item,
+				timesheet: { ...item.timesheet, id: timesheetId, createdAt }
+			} as ITimeLog);
+			return acc;
+		},
+		{} as Record<string, ITimeLog[]>
+	);
+
+	const result: GroupedTimesheet[] = [];
+	Object.values(groupedByTimesheet).forEach((timesheetLogs) => {
+		const byDate = timesheetLogs.reduce(
+			(acc, item) => {
+				try {
+					const date = new Date(String(item.timesheet?.createdAt)).toISOString().split('T')[0];
+					if (!acc[date]) acc[date] = [];
+					acc[date].push(item);
+				} catch (error) {
+					console.error(`Failed to process date for timesheet ${item.timesheet?.id}:`, {
+						createdAt: item.timesheet?.createdAt,
+						error
+					});
+				}
+				return acc;
+			},
+			{} as Record<string, ITimeLog[]>
+		);
+		Object.entries(byDate).forEach(([date, tasks]) => result.push({ date, tasks }));
+	});
+
+	const sorted = result.sort((a, b) => b.date.localeCompare(a.date));
+
+	if (sorted.length === 0 && items.length > 0) {
+		const today = new Date().toISOString().split('T')[0];
+		return [
+			{
+				date: today,
+				tasks: items.map(
+					(item) =>
+						({
+							...item,
+							timesheet: {
+								...item.timesheet,
+								id: item.timesheet?.id || item.id || 'fallback',
+								createdAt:
+									item.timesheet?.createdAt || item.createdAt || item.startedAt || new Date().toISOString()
+							}
+						}) as ITimeLog
+				)
+			}
+		];
+	}
+
+	return sorted;
+};
+
+// ─── Re-group by Date (merge duplicates) ────────────────────────────────────
+
+export const reGroupByDate = (groupedTimesheets: GroupedTimesheet[]): GroupedTimesheet[] => {
+	return groupedTimesheets.reduce((acc, { date, tasks }) => {
+		const existingGroup = acc.find((group) => group.date === date);
+		if (existingGroup) {
+			existingGroup.tasks = existingGroup.tasks.concat(tasks);
+		} else {
+			acc.push({ date, tasks });
+		}
+		return acc;
+	}, [] as GroupedTimesheet[]);
+};
+
+// ─── Status Grouping ─────────────────────────────────────────────────────────
+
+/** Type guard for ETimesheetStatus */
+export function isTimesheetStatus(status: unknown): status is ETimesheetStatus {
+	const timesheetStatusValues = Object.values(ETimesheetStatus);
+	return Object.values(timesheetStatusValues).includes(status as ETimesheetStatus);
+}
+
+/** Group time logs by their timesheet status */
+export const getStatusTimesheet = (items: ITimeLog[] = []): Record<ETimesheetStatus, ITimeLog[]> => {
+	const STATUS_MAP: Record<ETimesheetStatus, ITimeLog[]> = {
+		[ETimesheetStatus.PENDING]: [],
+		[ETimesheetStatus.APPROVED]: [],
+		[ETimesheetStatus.DENIED]: [],
+		[ETimesheetStatus.DRAFT]: [],
+		[ETimesheetStatus.IN_REVIEW]: []
+	};
+
+	return items.reduce((acc, item) => {
+		const status = item.timesheet?.status;
+		if (isTimesheetStatus(status)) {
+			acc[status].push(item);
+		} else {
+			console.warn(`Invalid timesheet status: ${status}`, 'item:', item);
+		}
+		return acc;
+	}, STATUS_MAP);
+};
+
+// ─── Timesheet ID Grouping ───────────────────────────────────────────────────
+
+/** Group time log rows by their timesheetId */
+export const groupedByTimesheetIds = ({ rows }: { rows: ITimeLog[] }): Record<string, ITimeLog[]> => {
+	if (!rows) return {};
+	return rows.reduce(
+		(acc, row) => {
+			if (!row) return acc;
+			const timesheetId = row.timesheetId ?? 'unassigned';
+			if (!acc[timesheetId]) acc[timesheetId] = [];
+			acc[timesheetId].push(row);
+			return acc;
+		},
+		{} as Record<string, ITimeLog[]>
+	);
+};
+
+// ─── Rows to Object ──────────────────────────────────────────────────────────
+
+/** Convert time log rows to a record keyed by timesheet ID */
+export const rowsToObject = (rows: ITimeLog[]): Record<string, { task: ITimeLog; status: ETimesheetStatus }> => {
+	return rows.reduce(
+		(acc, row) => {
+			acc[row.timesheet?.id ?? ''] = { task: row, status: row.timesheet?.status ?? ETimesheetStatus.DRAFT };
+			return acc;
+		},
+		{} as Record<string, { task: ITimeLog; status: ETimesheetStatus }>
+	);
+};

--- a/apps/web/core/stores/teams/organization-team.ts
+++ b/apps/web/core/stores/teams/organization-team.ts
@@ -65,6 +65,7 @@ export const activeTeamManagersState = atom<TOrganizationTeamEmployee[]>((get) =
 	return (
 		members?.filter(
 			(member) =>
+				member?.isManager === true ||
 				member?.role?.name === ERoleName.MANAGER ||
 				member?.role?.name === ERoleName.SUPER_ADMIN ||
 				member?.role?.name === ERoleName.ADMIN


### PR DESCRIPTION
# 🚀 [ETP-224](https://evertech.atlassian.net/browse/ETP-224)  Refactor `useTimesheet` into CRUD Hooks & Fix Sidebar Team Manager Detection

## Description

This PR addresses **two related issues** discovered during the CRUD-split migration of the `useTimesheet` hook:

1. **ETP-224 — Refactor `useTimesheet`**: The monolithic `useTimesheet` hook (760+ lines) mixed data fetching, mutations, and pure transformations. It has been split into specialized CRUD hooks following the same pattern established by the `useTeamInvitations` refactor (ETP-228).

2. **Sidebar "Reports" not visible for team managers**: During the migration audit, we discovered that team-level managers (`member.isManager === true`) could not see the Reports section in the sidebar. Two root causes were identified and fixed:
   - **Missing check**: `member.isManager` (team-level boolean) was never checked — only `member.role.name` (organization-level role) was evaluated.
   - **Broken atom sync**: The `isTeamManagerState` Jotai atom was never written to because the only writer lived in the deprecated `useOrganizationTeams()` hook, which is no longer mounted by any component.

## What Was Changed

### Major Changes

- **New CRUD hooks** replacing the monolithic `useTimesheet`:
  - `use-timesheet-query.ts` — Read operations (fetch timesheets with filters)
  - `use-create-timesheet.ts` — Create timesheet entries
  - `use-update-timesheet.ts` — Update/approve/reject timesheets
  - `use-delete-timesheet.ts` — Delete timesheet entries
  - `use-timesheet-invalidation.ts` — Shared React Query cache invalidation
  - `core/hooks/timesheet/index.ts` — Barrel export for all hooks

- **Pure utility extraction** to `core/lib/helpers/timesheet-grouping.ts`:
  - `groupTimesheetsByDate`, `groupByProjectAndTask`, `groupByWeek`, `groupByMonth`, and related helper functions moved out of the hook into stateless pure functions.

- **`useIsMemberManager` (`use-team-member.ts`)** — Added `member.isManager === true` check and `useEffect` to sync `isTeamManagerState` atom for global consumers (sidebar, project modal, task info).

- **`activeTeamManagersState` (`organization-team.ts`)** — Added `member?.isManager === true` to the derived atom filter so team-level managers are included.

- **`useOrganizationTeams` (`use-organization-teams.ts`)** — Removed the now-redundant `isManager()` callback since the logic has been moved to `useIsMemberManager`.

### Minor Changes

- Migrated 10+ consumer components from `useTimesheet()` to the new specialized hooks
- `use-timesheet.ts` is now a thin deprecated wrapper re-exporting from the new hooks
- Internalized `useUpdateTimesheet()` and `useDeleteTimesheet()` in `SelectedTimesheet` component (props reduced from 5 → 3)

## How to Test This PR

1. Run the app with `yarn web:dev`
2. Open the browser at `http://localhost:3030`

**Test team manager sidebar access:**
3. Log in as a user who is a **team-level manager** (`isManager=true` on `OrganizationTeamEmployee`, but NOT necessarily `role.name=MANAGER`)
4. Check the sidebar — the **Reports** section should be visible
5. Verify the Reports page loads correctly

**Test timesheet functionality:**
6. Navigate to the Timesheet page (`/timesheet`)
7. Verify:
   - Timesheet entries load correctly with all view modes (calendar, table, card)
   - Filtering by date range, status, and members works
   - Creating a new timesheet entry works
   - Approving/rejecting timesheets works (if you have manager permissions)
   - Deleting timesheet entries works
   - Selection bar actions (approve/reject selected) work

## Screenshots (if needed)

### Previous screenshots

> Sidebar missing "Reports" section for team-level managers with `isManager=true`.

### Current screenshots

> Sidebar now correctly shows "Reports" for team-level managers.

## Related Issues

- Closes ETP-224 (Refactor useTimesheet — separate transformation from data fetching)
- Related to ETP-228 (Refactor useTeamInvitations — pattern reference)
- Fixes: Sidebar Reports section not visible for team-level managers

## Type of Change

- [x] Bug fix (fixes a problem)
- [x] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

- The deprecated `useOrganizationTeams` hook still exists as a thin re-export wrapper for backward compatibility. No components mount it directly anymore — all consumers have been migrated.
- The `isManager()` callback was moved from `useOrganizationTeams` to `useIsMemberManager` because the latter is called at boot time via `init-state → useAuthenticateUser → useIsMemberManager`, ensuring the atom is synced on app load.
- `isTrackingEnabledState` atom sync (also lost during migration) is a known remaining item — it was not included in this PR to keep the scope focused.
- `memberActiveTaskIdState` atom sync was initially added but reverted due to side effects — requires further investigation in a separate PR.
- `tsc --noEmit` passes with 0 errors.

### Files changed (24 files — 914 insertions, 824 deletions)

| File | Change |
|------|--------|
| `core/hooks/timesheet/use-timesheet-query.ts` | **New** — Read operations |
| `core/hooks/timesheet/use-create-timesheet.ts` | **New** — Create operations |
| `core/hooks/timesheet/use-update-timesheet.ts` | **New** — Update operations |
| `core/hooks/timesheet/use-delete-timesheet.ts` | **New** — Delete operations |
| `core/hooks/timesheet/use-timesheet-invalidation.ts` | **New** — Shared invalidation |
| `core/hooks/timesheet/index.ts` | **New** — Barrel export |
| `core/lib/helpers/timesheet-grouping.ts` | **New** — Pure grouping utilities |
| `core/hooks/activities/use-timesheet.ts` | **Modified** — Deprecated, thin wrapper |
| `core/hooks/organizations/teams/use-team-member.ts` | **Modified** — `isManager` check + atom sync |
| `core/hooks/organizations/teams/use-organization-teams.ts` | **Modified** — Removed redundant `isManager()` |
| `core/stores/teams/organization-team.ts` | **Modified** — `isManager` in derived atom |
| 13 consumer components | **Modified** — Migrated to new hooks |


[ETP-224]: https://evertech.atlassian.net/browse/ETP-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored timesheet logic by splitting the monolithic useTimesheet into focused CRUD hooks and moving grouping into pure helpers, making the code simpler and easier to maintain. Fixed sidebar “Reports” visibility for team-level managers by properly detecting and syncing manager status. Aligns with ETP-224.

- **Refactors**
  - Added hooks: useTimesheetQuery, useCreateTimesheet, useUpdateTimesheet, useDeleteTimesheet, and shared cache invalidation.
  - Extracted pure grouping utilities to core/lib/helpers/timesheet-grouping.
  - Deprecated useTimesheet as a thin wrapper; migrated affected components to new hooks.

- **Bug Fixes**
  - useIsMemberManager now checks member.isManager and syncs isTeamManagerState.
  - activeTeamManagersState includes team-level managers.
  - Removed redundant isManager logic from useOrganizationTeams.

<sup>Written for commit a6b452633715ac70b0e48592a0ba8724aaafb265. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured timesheet operations to use dedicated, specialized functions for creating, updating, deleting, and querying timesheet entries, improving reliability and maintainability.
  * Reorganized timesheet data utilities into a centralized module for consistent filtering and grouping behavior.
  * Optimized timesheet data fetching with improved cache invalidation and state synchronization.

* **Bug Fixes**
  * Enhanced manager role detection within teams to correctly identify members with manager status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->