### PR TITLE
Streamline timesheet selection logic and team management hooks

### DIFF
--- a/apps/web/core/components/pages/timesheet/selection-bar.tsx
+++ b/apps/web/core/components/pages/timesheet/selection-bar.tsx
@@ -94,7 +94,7 @@ export const SelectedTimesheet: React.FC<SelectedTimesheetProps> = ({
 	const { deleteTaskTimesheet } = useDeleteTimesheet();
 
 	const getSelectedIds = useCallback(
-		() => selectTimesheetId.map((select) => select.timesheet?.id || '').filter((id) => id !== undefined),
+		() => selectTimesheetId.map((select) => select.timesheet?.id).filter((id): id is string => Boolean(id)),
 		[selectTimesheetId]
 	);
 

--- a/apps/web/core/hooks/organizations/teams/use-organization-teams.ts
+++ b/apps/web/core/hooks/organizations/teams/use-organization-teams.ts
@@ -22,7 +22,7 @@ import {
 	organizationTeamsState,
 	timerStatusState
 } from '@/core/stores';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 
 // Import specialized hooks
@@ -47,7 +47,7 @@ export function useOrganizationTeams() {
 	const activeTeamManagers = useAtomValue(activeTeamManagersState);
 	const timerStatus = useAtomValue(timerStatusState);
 	const [isTeamMember] = useAtom(isTeamMemberState);
-	const [isTeamManager, setIsTeamManager] = useAtom(isTeamManagerState);
+	const [isTeamManager] = useAtom(isTeamManagerState);
 	const setIsTrackingEnabledState = useSetAtom(isTrackingEnabledState);
 
 	// ==================== SPECIALIZED HOOKS ====================

--- a/apps/web/core/hooks/organizations/teams/use-team-member.ts
+++ b/apps/web/core/hooks/organizations/teams/use-team-member.ts
@@ -1,6 +1,6 @@
 'use client';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { activeTeamState, isTeamManagerState } from '@/core/stores';
 import { ERoleName } from '@/core/types/generics/enums/role';
@@ -9,7 +9,6 @@ import { TUser } from '@/core/types/schemas';
 export function useIsMemberManager(user?: TUser | null) {
 	const activeTeam = useAtomValue(activeTeamState);
 
-	const members = useMemo(() => activeTeam?.members || [], [activeTeam?.members]);
 	const activeManager = useMemo(() => {
 		if (!user || !activeTeam?.members) return undefined;
 
@@ -36,25 +35,14 @@ export function useIsMemberManager(user?: TUser | null) {
 
 	// Sync isTeamManagerState atom for global consumers (sidebar, project modal, task info)
 	const setIsTeamManager = useSetAtom(isTeamManagerState);
-
-	const isManager = useCallback(() => {
-		const $u = user;
-		const isM = members.find((member) => {
-			const isUser = member.employee?.userId === $u?.id;
-			return isUser && (member.isManager === true || (member.role && member.role.name === 'MANAGER'));
-		});
-		setIsTeamManager(!!isM);
-	}, [user, members, setIsTeamManager]);
 	useEffect(() => {
 		setIsTeamManager(isTeamManager);
-		isManager()
 	}, [isTeamManager, setIsTeamManager]);
 
 	return {
 		isTeamManager,
 		isTeamCreator,
 		activeTeam,
-		activeManager,
-		isManager
+		activeManager
 	};
 }


### PR DESCRIPTION
# Streamline timesheet selection logic and team management hooks

- Updated the `getSelectedIds` function in the `SelectedTimesheet` component to improve type safety by ensuring only valid string IDs are returned.
- Simplified the `useOrganizationTeams` hook by removing the `isTeamManager` setter, enhancing clarity in team management logic.
- Cleaned up the `useIsMemberManager` hook by removing unnecessary memoization and the `isManager` callback, improving overall maintainability and readability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens timesheet ID selection to only valid strings and simplifies team manager state handling for clearer, safer code.

- **Refactors**
  - SelectedTimesheet: getSelectedIds now returns only string IDs via a proper type guard.
  - useOrganizationTeams: removed the isTeamManager setter; the hook no longer mutates this state.
  - useIsMemberManager: removed unnecessary memoization and the isManager callback; the effect now only syncs the derived isTeamManager.

<sup>Written for commit 95e23921377ba367649b7c512cb1062b32849cc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved timesheet ID extraction logic with stricter type checking.
  * Simplified team manager state management in hooks.
  * Streamlined team member status computation and removed redundant memoization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->