### PR TITLE
[ETP-225] task web refactor use report activity split into granular query hooks

### DIFF
--- a/apps/web/app/[locale]/(main)/dashboard/app-url/[teamId]/page.tsx
+++ b/apps/web/app/[locale]/(main)/dashboard/app-url/[teamId]/page.tsx
@@ -11,7 +11,8 @@ import { ArrowLeftIcon } from '@radix-ui/react-icons';
 import { useRouter } from 'next/navigation';
 import { Container } from '@/core/components';
 
-import { GroupByType, useReportActivity } from '@/core/hooks/activities/use-report-activity';
+import { type GroupByType, useActivityFilters } from '@/core/hooks/activities/use-activity-filters';
+import { useActivityReportListQuery } from '@/core/hooks/activities/queries/use-activity-report-list-query';
 import { Card } from '@/core/components/common/card';
 import { useAuthenticateUser } from '@/core/hooks/auth';
 import { useLocalStorageState, useModal } from '@/core/hooks/common';
@@ -56,16 +57,8 @@ function AppUrls() {
 	const { closeModal, isOpen, openModal } = useModal();
 	const { user } = useAuthenticateUser();
 
-	const {
-		activityReport,
-		handleGroupByChange,
-		updateDateRange,
-		updateFilters,
-		currentFilters,
-		isManage,
-		loading,
-		fetchActivityReport
-	} = useReportActivity({ types: 'APPS-URLS' });
+	const { mergedProps, enabled, currentFilters, updateDateRange, updateFilters, handleGroupByChange, isManage } = useActivityFilters();
+	const { activityReport, isLoading: loading, refetchActivityReport } = useActivityReportListQuery({ mergedProps, enabled });
 
 	const handleGroupTypeChange = (type: GroupByType) => {
 		setGroupByType(type);
@@ -75,8 +68,8 @@ function AppUrls() {
 	// Handle filter application - triggers data refetch
 	const handleFiltersApply = useCallback(() => {
 		// Refetch activity report data with current filter state
-		fetchActivityReport();
-	}, [fetchActivityReport]);
+		refetchActivityReport();
+	}, [refetchActivityReport]);
 
 	const generateMonthData = (date: Date): ProductivityData[] => {
 		const year = date.getFullYear();

--- a/apps/web/app/[locale]/(main)/dashboard/team-dashboard/[teamId]/page.tsx
+++ b/apps/web/app/[locale]/(main)/dashboard/team-dashboard/[teamId]/page.tsx
@@ -11,7 +11,10 @@ import { cn } from '@/core/lib/helpers';
 import { useAtomValue } from 'jotai';
 import { fullWidthState } from '@/core/stores/common/full-width';
 import { withAuthentication } from '@/core/components/layouts/app/authenticator';
-import { useReportActivity } from '@/core/hooks/activities/use-report-activity';
+import { useActivityFilters } from '@/core/hooks/activities/use-activity-filters';
+import { useActivityChartQuery } from '@/core/hooks/activities/queries/use-activity-chart-query';
+import { useActivityDailyReportQuery } from '@/core/hooks/activities/queries/use-activity-daily-report-query';
+import { useActivityStatisticsQuery } from '@/core/hooks/activities/queries/use-activity-statistics-query';
 import { useTranslations } from 'next-intl';
 
 import { TeamStatsTableSkeleton } from '@/core/components/common/skeleton/team-stats-table-skeleton';
@@ -35,18 +38,11 @@ function TeamDashboard() {
 	const paramsUrl = useParams<{ locale: string }>();
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 
-	const {
-		rapportChartActivity,
-		rapportDailyActivity,
-		statisticsCounts,
-		updateDateRange,
-		loading,
-		isManage,
-		currentFilters,
-		fetchReportActivity,
-		fetchDailyReport,
-		fetchStatisticsCounts
-	} = useReportActivity({ types: 'TEAM-DASHBOARD' });
+	const { mergedProps, enabled, currentFilters, updateDateRange, isManage } = useActivityFilters();
+	const { rapportChartActivity, refetchChartActivity } = useActivityChartQuery({ mergedProps, enabled });
+	const { rapportDailyActivity, refetchDailyReport, isLoading: isDailyLoading } = useActivityDailyReportQuery({ mergedProps, enabled });
+	const { statisticsCounts, refetchStatisticsCounts, isLoading: isStatsLoading } = useActivityStatisticsQuery({ mergedProps, enabled });
+	const loading = isDailyLoading || isStatsLoading;
 
 	const currentLocale = paramsUrl?.locale;
 
@@ -63,10 +59,10 @@ function TeamDashboard() {
 	// Handle filter application - triggers data refetch
 	const handleFiltersApply = useCallback(() => {
 		// Refetch all dashboard data with current filter state
-		fetchReportActivity();
-		fetchDailyReport();
-		fetchStatisticsCounts();
-	}, [fetchReportActivity, fetchDailyReport, fetchStatisticsCounts]);
+		refetchChartActivity();
+		refetchDailyReport();
+		refetchStatisticsCounts();
+	}, [refetchChartActivity, refetchDailyReport, refetchStatisticsCounts]);
 
 	// IMPORTANT: This must be AFTER all hooks to avoid "Rendered fewer hooks than expected" error
 	if (loading && (!rapportDailyActivity || rapportDailyActivity.length === 0)) {

--- a/apps/web/core/components/common/date-range-picker.tsx
+++ b/apps/web/core/components/common/date-range-picker.tsx
@@ -31,11 +31,18 @@ interface DateRangePickerProps {
 	className?: string;
 	onDateRangeChange?: (range: DateRange | undefined) => void;
 	data?: ITimeLogGroupedDailyReport[];
+	/** Optional initial date range. When provided the picker starts with this
+	 *  range instead of the hardcoded "full current month" fallback.
+	 *  This keeps the UI in sync with the data-layer defaults from useActivityFilters. */
+	initialRange?: DateRange;
 }
 
-export function DateRangePicker({ className, onDateRangeChange, data }: DateRangePickerProps) {
+export function DateRangePicker({ className, onDateRangeChange, data, initialRange }: DateRangePickerProps) {
 	const t = useTranslations();
 	const [dateRange, setDateRange] = React.useState<DateRange | undefined>(() => {
+		if (initialRange?.from && initialRange?.to) {
+			return initialRange;
+		}
 		const today = new Date();
 		return {
 			from: startOfMonth(today),

--- a/apps/web/core/components/pages/dashboard/dashboard-header.tsx
+++ b/apps/web/core/components/pages/dashboard/dashboard-header.tsx
@@ -86,13 +86,19 @@ export function DashboardHeader({
 				</Suspense>
 			)}
 
-			<div className="flex items-center justify-between w-full">
+			<div className="flex justify-between items-center w-full">
 				<h1 className="text-2xl font-semibold">{title}</h1>
-				<div className="flex items-center gap-4">
+				<div className="flex gap-4 items-center">
 					{showGroupBy && (
 						<LazyGroupBySelectTimeActivity groupByType={groupByType} onGroupByChange={onGroupByChange} />
 					)}
-					<LazyDateRangePicker onDateRangeChange={handleDateRangeChange} data={reportData} />
+					<LazyDateRangePicker
+						onDateRangeChange={handleDateRangeChange}
+						data={reportData}
+						initialRange={
+							startDate && endDate ? { from: startDate, to: endDate } : undefined
+						}
+					/>
 					<LazyTeamDashboardFilter isManage={isManage} onFiltersApply={onFiltersApply} />
 
 					<ExportMenu

--- a/apps/web/core/components/pages/time-and-activity/date-range-picker-time-activity.tsx
+++ b/apps/web/core/components/pages/time-and-activity/date-range-picker-time-activity.tsx
@@ -32,11 +32,18 @@ import { SettingsIcon } from '../../common/team-icon';
 interface DateRangePickerProps {
 	className?: string;
 	onDateRangeChange?: (range: DateRange | undefined) => void;
+	/** Optional initial date range. When provided the picker starts with this
+	 *  range instead of the hardcoded "full current month" fallback.
+	 *  This keeps the UI in sync with the data-layer defaults from useActivityFilters. */
+	initialRange?: DateRange;
 }
 
-export function DateRangePickerTimeActivity({ className, onDateRangeChange }: DateRangePickerProps) {
+export function DateRangePickerTimeActivity({ className, onDateRangeChange, initialRange }: DateRangePickerProps) {
 	const t = useTranslations();
 	const [dateRange, setDateRange] = React.useState<DateRange | undefined>(() => {
+		if (initialRange?.from && initialRange?.to) {
+			return initialRange;
+		}
 		const today = new Date();
 		return {
 			from: startOfMonth(today),

--- a/apps/web/core/components/pages/time-and-activity/page-component.tsx
+++ b/apps/web/core/components/pages/time-and-activity/page-component.tsx
@@ -10,7 +10,9 @@ import { ArrowLeftIcon } from '@radix-ui/react-icons';
 import { useMemo, useState, useCallback } from 'react';
 import { Card } from '@/core/components/common/card';
 import { useOrganizationAndTeamManagers } from '@/core/hooks/organizations/teams/use-organization-teams-managers';
-import { GroupByType, useReportActivity } from '@/core/hooks/activities/use-report-activity';
+import { type GroupByType, useActivityFilters } from '@/core/hooks/activities/use-activity-filters';
+import { useActivityDailyReportQuery } from '@/core/hooks/activities/queries/use-activity-daily-report-query';
+import { useActivityStatisticsQuery } from '@/core/hooks/activities/queries/use-activity-statistics-query';
 import { useTimeActivityStats } from '@/core/hooks/activities/use-time-activity-stats';
 import { ViewOption } from '@/core/components/common/view-select';
 import { Breadcrumb } from '@/core/components/duplicated-components/breadcrumb';
@@ -36,17 +38,10 @@ const getDefaultViewOptions = (t: any): ViewOption[] => [
 ];
 
 const TimeActivityComponents = () => {
-	const {
-		rapportDailyActivity,
-		updateDateRange,
-		loading,
-		statisticsCounts,
-		isManage,
-		updateFilters,
-		currentFilters
-	} = useReportActivity({
-		types: 'TEAM-DASHBOARD'
-	});
+	const { mergedProps, enabled, currentFilters, updateDateRange, updateFilters, isManage } = useActivityFilters();
+	const { rapportDailyActivity, isLoading: isDailyLoading } = useActivityDailyReportQuery({ mergedProps, enabled });
+	const { statisticsCounts, isLoading: isStatsLoading } = useActivityStatisticsQuery({ mergedProps, enabled });
+	const loading = isDailyLoading || isStatsLoading;
 	const [groupByType, setGroupByType] = useState<GroupByType>('daily');
 	const [dateRange, setDateRange] = useState<{ startDate?: Date; endDate?: Date }>(() => {
 		// Initialize with current filter dates if available

--- a/apps/web/core/components/pages/time-and-activity/time-activity-header.tsx
+++ b/apps/web/core/components/pages/time-and-activity/time-activity-header.tsx
@@ -78,7 +78,14 @@ function TimeActivityHeader({
 				<GroupBySelectTimeActivity onGroupByChange={props.onGroupByChange} groupByType={props.groupByType} />
 				<TimeActivityFilterPopover {...props} />
 				<ViewSelect viewOptions={currentViewOptions} onChange={handleViewOptionsChange} />
-				<DateRangePickerTimeActivity onDateRangeChange={handleDateRangeChange} />
+				<DateRangePickerTimeActivity
+					onDateRangeChange={handleDateRangeChange}
+					initialRange={
+						props.startDate && props.endDate
+							? { from: props.startDate, to: props.endDate }
+							: undefined
+					}
+				/>
 				<TimeActivityExportMenu
 					rapportDailyActivity={props.rapportDailyActivity}
 					isManage={props.isManage}

--- a/apps/web/core/hooks/activities/index.ts
+++ b/apps/web/core/hooks/activities/index.ts
@@ -1,3 +1,5 @@
+export * from './use-activity-filters';
+export * from './queries';
 export * from './use-manual-time';
 export * from './use-report-activity';
 export * from './use-start-stop-timer-handler';

--- a/apps/web/core/hooks/activities/queries/index.ts
+++ b/apps/web/core/hooks/activities/queries/index.ts
@@ -1,0 +1,5 @@
+export * from './use-activity-chart-query';
+export * from './use-activity-daily-report-query';
+export * from './use-activity-statistics-query';
+export * from './use-activity-report-list-query';
+

--- a/apps/web/core/hooks/activities/queries/use-activity-chart-query.ts
+++ b/apps/web/core/hooks/activities/queries/use-activity-chart-query.ts
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/core/query/keys';
+import { timeLogService } from '@/core/services/client/api/timesheets/time-log.service';
+import { UseReportActivityProps } from '../use-activity-filters';
+import { shouldRetryQuery } from '../../../lib/helpers/retry-utils';
+
+// ==================== TYPES ====================
+
+export interface UseActivityChartQueryOptions {
+	/** Merged props from useActivityFilters (includes auth, filters, date range) */
+	mergedProps: Required<UseReportActivityProps> | null;
+	/** Whether the query should be enabled */
+	enabled?: boolean;
+}
+
+// ==================== HOOK ====================
+
+/**
+ * Dedicated query hook for the **chart activity** data.
+ * Wraps `timeLogService.getTimeLogReportDailyChart`.
+ *
+ * Use this hook when you need the daily chart data (bar/line chart on the team dashboard).
+ *
+ * @param options.mergedProps - Merged filter props from `useActivityFilters`
+ * @param options.enabled - Controls whether the query fires. Defaults to `true`.
+ *
+ * @example
+ * ```typescript
+ * const { mergedProps, enabled } = useActivityFilters();
+ * const { data, isLoading, refetch } = useActivityChartQuery({ mergedProps, enabled });
+ * ```
+ */
+export function useActivityChartQuery({ mergedProps, enabled = true }: UseActivityChartQueryOptions) {
+	const query = useQuery({
+		queryKey: [
+			queryKeys.activities.dailyChart({
+				tenantId: mergedProps?.tenantId,
+				organizationId: mergedProps?.organizationId,
+				startDate: mergedProps?.startDate,
+				endDate: mergedProps?.endDate,
+				groupBy: mergedProps?.groupBy
+			})
+		],
+		queryFn: () => timeLogService.getTimeLogReportDailyChart(mergedProps!),
+		enabled: enabled && !!mergedProps,
+		staleTime: 1000 * 60 * 10,
+		gcTime: 1000 * 60 * 30,
+		retry: shouldRetryQuery,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000)
+	});
+
+	// ==================== REFETCH ====================
+
+	const refetchChartActivity = useCallback(async () => {
+		return query.refetch();
+	}, [query]);
+
+	return {
+		/** Chart activity data array — defensive extraction handles unexpected API response shapes */
+		rapportChartActivity: Array.isArray(query.data?.data) ? query.data.data : [],
+		/** Whether the chart query is currently loading */
+		isLoading: query.isLoading,
+		/** Refetch chart data */
+		refetchChartActivity,
+		/** Full React Query object for advanced usage */
+		query
+	};
+}
+

--- a/apps/web/core/hooks/activities/queries/use-activity-chart-query.ts
+++ b/apps/web/core/hooks/activities/queries/use-activity-chart-query.ts
@@ -33,15 +33,13 @@ export interface UseActivityChartQueryOptions {
  */
 export function useActivityChartQuery({ mergedProps, enabled = true }: UseActivityChartQueryOptions) {
 	const query = useQuery({
-		queryKey: [
-			queryKeys.activities.dailyChart({
-				tenantId: mergedProps?.tenantId,
-				organizationId: mergedProps?.organizationId,
-				startDate: mergedProps?.startDate,
-				endDate: mergedProps?.endDate,
-				groupBy: mergedProps?.groupBy
-			})
-		],
+		queryKey: queryKeys.activities.dailyChart({
+			tenantId: mergedProps?.tenantId,
+			organizationId: mergedProps?.organizationId,
+			startDate: mergedProps?.startDate,
+			endDate: mergedProps?.endDate,
+			groupBy: mergedProps?.groupBy
+		}),
 		queryFn: () => timeLogService.getTimeLogReportDailyChart(mergedProps!),
 		enabled: enabled && !!mergedProps,
 		staleTime: 1000 * 60 * 10,

--- a/apps/web/core/hooks/activities/queries/use-activity-daily-report-query.ts
+++ b/apps/web/core/hooks/activities/queries/use-activity-daily-report-query.ts
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/core/query/keys';
+import { timeLogService } from '@/core/services/client/api/timesheets/time-log.service';
+import { UseReportActivityProps } from '../use-activity-filters';
+import { shouldRetryQuery } from '../../../lib/helpers/retry-utils';
+
+// ==================== TYPES ====================
+
+export interface UseActivityDailyReportQueryOptions {
+	/** Merged props from useActivityFilters (includes auth, filters, date range) */
+	mergedProps: Required<UseReportActivityProps> | null;
+	/** Whether the query should be enabled */
+	enabled?: boolean;
+}
+
+// ==================== HOOK ====================
+
+/**
+ * Dedicated query hook for the **daily report** data.
+ * Wraps `timeLogService.getTimeLogReportDaily`.
+ *
+ * Use this hook when you need the daily grouped report (table data on team dashboard / time-and-activity).
+ *
+ * @param options.mergedProps - Merged filter props from `useActivityFilters`
+ * @param options.enabled - Controls whether the query fires. Defaults to `true`.
+ *
+ * @example
+ * ```typescript
+ * const { mergedProps, enabled } = useActivityFilters();
+ * const { rapportDailyActivity, isLoading } = useActivityDailyReportQuery({ mergedProps, enabled });
+ * ```
+ */
+export function useActivityDailyReportQuery({ mergedProps, enabled = true }: UseActivityDailyReportQueryOptions) {
+	const query = useQuery({
+		queryKey: [
+			queryKeys.activities.daily({
+				tenantId: mergedProps?.tenantId,
+				organizationId: mergedProps?.organizationId,
+				startDate: mergedProps?.startDate,
+				endDate: mergedProps?.endDate,
+				groupBy: mergedProps?.groupBy
+			})
+		],
+		queryFn: () => timeLogService.getTimeLogReportDaily(mergedProps!),
+		enabled: enabled && !!mergedProps,
+		staleTime: 1000 * 60 * 10,
+		gcTime: 1000 * 60 * 30,
+		retry: shouldRetryQuery,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000)
+	});
+
+	// ==================== REFETCH ====================
+
+	const refetchDailyReport = useCallback(async () => {
+		return query.refetch();
+	}, [query]);
+
+	return {
+		/** Daily report data array — defensive extraction handles unexpected API response shapes */
+		rapportDailyActivity: Array.isArray(query.data?.data) ? query.data.data : [],
+		/** Whether the daily report query is currently loading */
+		isLoading: query.isLoading,
+		/** Refetch daily report data */
+		refetchDailyReport,
+		/** Full React Query object for advanced usage */
+		query
+	};
+}
+

--- a/apps/web/core/hooks/activities/queries/use-activity-daily-report-query.ts
+++ b/apps/web/core/hooks/activities/queries/use-activity-daily-report-query.ts
@@ -33,15 +33,13 @@ export interface UseActivityDailyReportQueryOptions {
  */
 export function useActivityDailyReportQuery({ mergedProps, enabled = true }: UseActivityDailyReportQueryOptions) {
 	const query = useQuery({
-		queryKey: [
-			queryKeys.activities.daily({
-				tenantId: mergedProps?.tenantId,
-				organizationId: mergedProps?.organizationId,
-				startDate: mergedProps?.startDate,
-				endDate: mergedProps?.endDate,
-				groupBy: mergedProps?.groupBy
-			})
-		],
+		queryKey: queryKeys.activities.daily({
+			tenantId: mergedProps?.tenantId,
+			organizationId: mergedProps?.organizationId,
+			startDate: mergedProps?.startDate,
+			endDate: mergedProps?.endDate,
+			groupBy: mergedProps?.groupBy
+		}),
 		queryFn: () => timeLogService.getTimeLogReportDaily(mergedProps!),
 		enabled: enabled && !!mergedProps,
 		staleTime: 1000 * 60 * 10,

--- a/apps/web/core/hooks/activities/queries/use-activity-report-list-query.ts
+++ b/apps/web/core/hooks/activities/queries/use-activity-report-list-query.ts
@@ -33,15 +33,13 @@ export interface UseActivityReportListQueryOptions {
  */
 export function useActivityReportListQuery({ mergedProps, enabled = true }: UseActivityReportListQueryOptions) {
 	const query = useQuery({
-		queryKey: [
-			queryKeys.activities.activityReport({
-				tenantId: mergedProps?.tenantId,
-				organizationId: mergedProps?.organizationId,
-				startDate: mergedProps?.startDate,
-				endDate: mergedProps?.endDate,
-				groupBy: mergedProps?.groupBy
-			})
-		],
+		queryKey: queryKeys.activities.activityReport({
+			tenantId: mergedProps?.tenantId,
+			organizationId: mergedProps?.organizationId,
+			startDate: mergedProps?.startDate,
+			endDate: mergedProps?.endDate,
+			groupBy: mergedProps?.groupBy
+		}),
 		queryFn: () => activityService.getActivitiesReport(mergedProps!),
 		enabled: enabled && !!mergedProps,
 		staleTime: 1000 * 60 * 10,

--- a/apps/web/core/hooks/activities/queries/use-activity-report-list-query.ts
+++ b/apps/web/core/hooks/activities/queries/use-activity-report-list-query.ts
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/core/query/keys';
+import { activityService } from '@/core/services/client/api/activities';
+import { UseReportActivityProps } from '../use-activity-filters';
+import { shouldRetryQuery } from '../../../lib/helpers/retry-utils';
+
+// ==================== TYPES ====================
+
+export interface UseActivityReportListQueryOptions {
+	/** Merged props from useActivityFilters (includes auth, filters, date range) */
+	mergedProps: Required<UseReportActivityProps> | null;
+	/** Whether the query should be enabled */
+	enabled?: boolean;
+}
+
+// ==================== HOOK ====================
+
+/**
+ * Dedicated query hook for the **activity report list** (Apps & URLs page).
+ * Wraps `activityService.getActivitiesReport`.
+ *
+ * Use this hook when you need the activity report grouped by date/employee/project/application.
+ *
+ * @param options.mergedProps - Merged filter props from `useActivityFilters`
+ * @param options.enabled - Controls whether the query fires. Defaults to `true`.
+ *
+ * @example
+ * ```typescript
+ * const { mergedProps, enabled } = useActivityFilters();
+ * const { activityReport, isLoading } = useActivityReportListQuery({ mergedProps, enabled });
+ * ```
+ */
+export function useActivityReportListQuery({ mergedProps, enabled = true }: UseActivityReportListQueryOptions) {
+	const query = useQuery({
+		queryKey: [
+			queryKeys.activities.activityReport({
+				tenantId: mergedProps?.tenantId,
+				organizationId: mergedProps?.organizationId,
+				startDate: mergedProps?.startDate,
+				endDate: mergedProps?.endDate,
+				groupBy: mergedProps?.groupBy
+			})
+		],
+		queryFn: () => activityService.getActivitiesReport(mergedProps!),
+		enabled: enabled && !!mergedProps,
+		staleTime: 1000 * 60 * 10,
+		gcTime: 1000 * 60 * 30,
+		retry: shouldRetryQuery,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000)
+	});
+
+	// ==================== REFETCH ====================
+
+	const refetchActivityReport = useCallback(async () => {
+		return query.refetch();
+	}, [query]);
+
+	return {
+		/** Activity report data array */
+		activityReport: Array.isArray(query.data?.data) ? query.data.data : [],
+		/** Whether the activity report query is currently loading */
+		isLoading: query.isLoading,
+		/** Refetch activity report data */
+		refetchActivityReport,
+		/** Full React Query object for advanced usage */
+		query
+	};
+}
+

--- a/apps/web/core/hooks/activities/queries/use-activity-statistics-query.ts
+++ b/apps/web/core/hooks/activities/queries/use-activity-statistics-query.ts
@@ -34,14 +34,12 @@ export interface UseActivityStatisticsQueryOptions {
  */
 export function useActivityStatisticsQuery({ mergedProps, enabled = true }: UseActivityStatisticsQueryOptions) {
 	const query = useQuery({
-		queryKey: [
-			queryKeys.activities.statisticsCounts({
-				tenantId: mergedProps?.tenantId,
-				organizationId: mergedProps?.organizationId,
-				startDate: mergedProps?.startDate,
-				endDate: mergedProps?.endDate
-			})
-		],
+		queryKey: queryKeys.activities.statisticsCounts({
+			tenantId: mergedProps?.tenantId,
+			organizationId: mergedProps?.organizationId,
+			startDate: mergedProps?.startDate,
+			endDate: mergedProps?.endDate
+		}),
 		queryFn: () =>
 			statisticsService.getTimesheetStatisticsCounts({
 				...mergedProps!,

--- a/apps/web/core/hooks/activities/queries/use-activity-statistics-query.ts
+++ b/apps/web/core/hooks/activities/queries/use-activity-statistics-query.ts
@@ -1,0 +1,74 @@
+import { useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/core/query/keys';
+import { statisticsService } from '@/core/services/client/api/timesheets/statistic.service';
+import { ETimeLogType } from '@/core/types/generics/enums/timer';
+import { UseReportActivityProps } from '../use-activity-filters';
+import { shouldRetryQuery } from '../../../lib/helpers/retry-utils';
+
+// ==================== TYPES ====================
+
+export interface UseActivityStatisticsQueryOptions {
+	/** Merged props from useActivityFilters (includes auth, filters, date range) */
+	mergedProps: Required<UseReportActivityProps> | null;
+	/** Whether the query should be enabled */
+	enabled?: boolean;
+}
+
+// ==================== HOOK ====================
+
+/**
+ * Dedicated query hook for **timesheet statistics counts**.
+ * Wraps `statisticsService.getTimesheetStatisticsCounts`.
+ *
+ * Use this hook when you need employee/project counts, weekly/today activity & duration stats.
+ *
+ * @param options.mergedProps - Merged filter props from `useActivityFilters`
+ * @param options.enabled - Controls whether the query fires. Defaults to `true`.
+ *
+ * @example
+ * ```typescript
+ * const { mergedProps, enabled } = useActivityFilters();
+ * const { statisticsCounts, isLoading } = useActivityStatisticsQuery({ mergedProps, enabled });
+ * ```
+ */
+export function useActivityStatisticsQuery({ mergedProps, enabled = true }: UseActivityStatisticsQueryOptions) {
+	const query = useQuery({
+		queryKey: [
+			queryKeys.activities.statisticsCounts({
+				tenantId: mergedProps?.tenantId,
+				organizationId: mergedProps?.organizationId,
+				startDate: mergedProps?.startDate,
+				endDate: mergedProps?.endDate
+			})
+		],
+		queryFn: () =>
+			statisticsService.getTimesheetStatisticsCounts({
+				...mergedProps!,
+				logType: [ETimeLogType.TRACKED]
+			}),
+		enabled: enabled && !!mergedProps,
+		staleTime: 1000 * 60 * 10,
+		gcTime: 1000 * 60 * 30,
+		retry: shouldRetryQuery,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000)
+	});
+
+	// ==================== REFETCH ====================
+
+	const refetchStatisticsCounts = useCallback(async () => {
+		return query.refetch();
+	}, [query]);
+
+	return {
+		/** Statistics counts data (employeesCount, projectsCount, weekActivities, etc.) */
+		statisticsCounts: query.data?.data || null,
+		/** Whether the statistics query is currently loading */
+		isLoading: query.isLoading,
+		/** Refetch statistics data */
+		refetchStatisticsCounts,
+		/** Full React Query object for advanced usage */
+		query
+	};
+}
+

--- a/apps/web/core/hooks/activities/use-activity-filters.ts
+++ b/apps/web/core/hooks/activities/use-activity-filters.ts
@@ -41,12 +41,13 @@ const formatLocalDate = (date: Date): string => {
 // ==================== DEFAULTS ====================
 
 /** Default date range: last 7 days (today inclusive).
+ *  today − 6 = 7 inclusive days (e.g. Feb 9 → Feb 15).
  *  Keeps the initial API payload light — users can still widen the range
  *  via the date-picker in the UI.
  */
 const now = new Date();
 const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-const sevenDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
+const sevenDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6);
 
 const defaultProps: Required<
 	Pick<
@@ -133,7 +134,7 @@ export function useActivityFilters() {
 			endDate: (currentFilters.endDate || defaultProps.endDate) as string,
 			groupBy: (currentFilters.groupBy || defaultProps.groupBy) as string,
 			projectIds: (currentFilters.projectIds || defaultProps.projectIds) as string[],
-			employeeIds: isManage ? employeeIds : [user?.employee?.id],
+			employeeIds,
 			teamIds: teamIds,
 			activityLevel: {
 				start: currentFilters.activityLevel?.start ?? defaultProps.activityLevel.start,

--- a/apps/web/core/hooks/activities/use-activity-filters.ts
+++ b/apps/web/core/hooks/activities/use-activity-filters.ts
@@ -40,16 +40,7 @@ const formatLocalDate = (date: Date): string => {
 
 // ==================== DEFAULTS ====================
 
-/** Default date range: last 7 days (today inclusive).
- *  today − 6 = 7 inclusive days (e.g. Feb 9 → Feb 15).
- *  Keeps the initial API payload light — users can still widen the range
- *  via the date-picker in the UI.
- */
-const now = new Date();
-const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-const sevenDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6);
-
-const defaultProps: Required<
+type DefaultProps = Required<
 	Pick<
 		UseReportActivityProps,
 		| 'startDate'
@@ -63,21 +54,33 @@ const defaultProps: Required<
 		| 'projectIds'
 		| 'teamIds'
 	>
-> = {
-	startDate: formatLocalDate(sevenDaysAgo),
-	endDate: formatLocalDate(today),
-	groupBy: 'date',
-	activityLevel: {
+>;
+
+/** Build default filter props with a **fresh** date range (last 7 inclusive days).
+ *  Called at hook-instantiation time so the range stays accurate even in
+ *  long-lived SPA sessions that span midnight.
+ */
+function getDefaultProps(): DefaultProps {
+	const now = new Date();
+	const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+	const sevenDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6);
+
+	return {
+		startDate: formatLocalDate(sevenDaysAgo),
+		endDate: formatLocalDate(today),
+		groupBy: 'date',
+		activityLevel: {
+			start: 0,
+			end: 100
+		},
+		logType: [ETimeLogType.TRACKED],
 		start: 0,
-		end: 100
-	},
-	logType: [ETimeLogType.TRACKED],
-	start: 0,
-	end: 100,
-	employeeIds: [],
-	projectIds: [],
-	teamIds: []
-};
+		end: 100,
+		employeeIds: [],
+		projectIds: [],
+		teamIds: []
+	};
+}
 
 // ==================== HOOK ====================
 
@@ -100,8 +103,8 @@ export function useActivityFilters() {
 	const { allteamsState, alluserState, isUserAllowedToAccess } = useTimelogFilterOptions();
 	const isManage = useMemo(() => user && isUserAllowedToAccess(user), [user, isUserAllowedToAccess]);
 
-	// State management
-	const [currentFilters, setCurrentFilters] = useState<Partial<UseReportActivityProps>>(defaultProps);
+	// State management — lazy initializer so dates are fresh at mount time
+	const [currentFilters, setCurrentFilters] = useState<Partial<UseReportActivityProps>>(getDefaultProps);
 
 	// Memoized employee and team IDs
 	const employeeIds = useMemo(
@@ -116,32 +119,34 @@ export function useActivityFilters() {
 
 	const teamIds = useMemo(() => allteamsState?.map(({ id }) => id).filter(Boolean) || [], [allteamsState]);
 
-	// Props merging logic
+	// Props merging logic — getDefaultProps() called here so fallback dates stay fresh
 	const mergedProps = useMemo(() => {
 		if (!user?.employee?.organizationId) {
 			return null;
 		}
 
+		const defaults = getDefaultProps();
+
 		return {
-			...defaultProps,
+			...defaults,
 			...currentFilters,
 			organizationId: user.employee.organizationId,
 			teamId: currentFilters.teamId,
 			userId: currentFilters.userId,
 			tenantId: user.tenantId ?? '',
-			logType: (currentFilters.logType || defaultProps.logType) as ETimeLogType[],
-			startDate: (currentFilters.startDate || defaultProps.startDate) as string,
-			endDate: (currentFilters.endDate || defaultProps.endDate) as string,
-			groupBy: (currentFilters.groupBy || defaultProps.groupBy) as string,
-			projectIds: (currentFilters.projectIds || defaultProps.projectIds) as string[],
+			logType: (currentFilters.logType || defaults.logType) as ETimeLogType[],
+			startDate: (currentFilters.startDate || defaults.startDate) as string,
+			endDate: (currentFilters.endDate || defaults.endDate) as string,
+			groupBy: (currentFilters.groupBy || defaults.groupBy) as string,
+			projectIds: (currentFilters.projectIds || defaults.projectIds) as string[],
 			employeeIds,
 			teamIds: teamIds,
 			activityLevel: {
-				start: currentFilters.activityLevel?.start ?? defaultProps.activityLevel.start,
-				end: currentFilters.activityLevel?.end ?? defaultProps.activityLevel.end
+				start: currentFilters.activityLevel?.start ?? defaults.activityLevel.start,
+				end: currentFilters.activityLevel?.end ?? defaults.activityLevel.end
 			},
-			start: currentFilters.start ?? defaultProps.start,
-			end: currentFilters.end ?? defaultProps.end
+			start: currentFilters.start ?? defaults.start,
+			end: currentFilters.end ?? defaults.end
 		} as Required<UseReportActivityProps>;
 	}, [user?.employee?.organizationId, user?.employee?.id, user?.tenantId, currentFilters, isManage, employeeIds, teamIds]);
 

--- a/apps/web/core/hooks/activities/use-activity-filters.ts
+++ b/apps/web/core/hooks/activities/use-activity-filters.ts
@@ -1,0 +1,182 @@
+import { useCallback, useState, useMemo } from 'react';
+import { useAuthenticateUser } from '../auth';
+import { useTimelogFilterOptions } from './use-timelog-filter-options';
+import { ETimeLogType } from '@/core/types/generics/enums/timer';
+import { ITimeLogReportDailyChartProps } from '@/core/types/interfaces/activity/activity-report';
+
+// ==================== TYPES ====================
+
+export interface UseReportActivityProps
+	extends Omit<ITimeLogReportDailyChartProps, 'logType' | 'activityLevel' | 'start' | 'end' | 'groupBy'> {
+	logType?: ETimeLogType[];
+	activityLevel: {
+		start: number;
+		end: number;
+	};
+	start?: number;
+	end?: number;
+	projectIds?: string[];
+	employeeIds?: string[];
+	teamIds?: string[];
+	groupBy?: string;
+}
+
+export type GroupByType = 'date' | 'project' | 'employee' | 'application' | 'daily' | 'weekly' | 'member';
+
+// ==================== HELPERS ====================
+
+/**
+ * Formats a Date to a 'YYYY-MM-DD' string using **local** time.
+ *
+ * `Date.toISOString()` converts to UTC first, which silently shifts the day
+ * for users east of UTC (e.g. UTC+1: Feb 1 00:00 local → Jan 31 23:00 UTC).
+ */
+const formatLocalDate = (date: Date): string => {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+};
+
+// ==================== DEFAULTS ====================
+
+/** Default date range: last 7 days (today inclusive).
+ *  Keeps the initial API payload light — users can still widen the range
+ *  via the date-picker in the UI.
+ */
+const now = new Date();
+const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+const sevenDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
+
+const defaultProps: Required<
+	Pick<
+		UseReportActivityProps,
+		| 'startDate'
+		| 'endDate'
+		| 'groupBy'
+		| 'activityLevel'
+		| 'logType'
+		| 'start'
+		| 'end'
+		| 'employeeIds'
+		| 'projectIds'
+		| 'teamIds'
+	>
+> = {
+	startDate: formatLocalDate(sevenDaysAgo),
+	endDate: formatLocalDate(today),
+	groupBy: 'date',
+	activityLevel: {
+		start: 0,
+		end: 100
+	},
+	logType: [ETimeLogType.TRACKED],
+	start: 0,
+	end: 100,
+	employeeIds: [],
+	projectIds: [],
+	teamIds: []
+};
+
+// ==================== HOOK ====================
+
+/**
+ * Hook for managing activity report filters, auth context, and merged props.
+ *
+ * Extracts the shared filter logic from the old monolithic `useReportActivity`.
+ * All granular query hooks (`useActivityChartQuery`, `useActivityDailyReportQuery`, etc.)
+ * consume the `mergedProps` returned by this hook.
+ *
+ * @example
+ * ```typescript
+ * const { mergedProps, currentFilters, updateDateRange, isManage } = useActivityFilters();
+ * const { data: chartData } = useActivityChartQuery({ mergedProps, enabled: true });
+ * ```
+ */
+export function useActivityFilters() {
+	// User and authentication
+	const { user } = useAuthenticateUser();
+	const { allteamsState, alluserState, isUserAllowedToAccess } = useTimelogFilterOptions();
+	const isManage = useMemo(() => user && isUserAllowedToAccess(user), [user, isUserAllowedToAccess]);
+
+	// State management
+	const [currentFilters, setCurrentFilters] = useState<Partial<UseReportActivityProps>>(defaultProps);
+
+	// Memoized employee and team IDs
+	const employeeIds = useMemo(
+		() =>
+			isManage
+				? alluserState?.map(({ employee }) => employee?.id).filter(Boolean)
+				: user?.employee?.id
+					? [user.employee.id]
+					: [],
+		[isManage, alluserState, user?.employee?.id]
+	);
+
+	const teamIds = useMemo(() => allteamsState?.map(({ id }) => id).filter(Boolean) || [], [allteamsState]);
+
+	// Props merging logic
+	const mergedProps = useMemo(() => {
+		if (!user?.employee?.organizationId) {
+			return null;
+		}
+
+		return {
+			...defaultProps,
+			...currentFilters,
+			organizationId: user.employee.organizationId,
+			teamId: currentFilters.teamId,
+			userId: currentFilters.userId,
+			tenantId: user.tenantId ?? '',
+			logType: (currentFilters.logType || defaultProps.logType) as ETimeLogType[],
+			startDate: (currentFilters.startDate || defaultProps.startDate) as string,
+			endDate: (currentFilters.endDate || defaultProps.endDate) as string,
+			groupBy: (currentFilters.groupBy || defaultProps.groupBy) as string,
+			projectIds: (currentFilters.projectIds || defaultProps.projectIds) as string[],
+			employeeIds: isManage ? employeeIds : [user?.employee?.id],
+			teamIds: teamIds,
+			activityLevel: {
+				start: currentFilters.activityLevel?.start ?? defaultProps.activityLevel.start,
+				end: currentFilters.activityLevel?.end ?? defaultProps.activityLevel.end
+			},
+			start: currentFilters.start ?? defaultProps.start,
+			end: currentFilters.end ?? defaultProps.end
+		} as Required<UseReportActivityProps>;
+	}, [user?.employee?.organizationId, user?.employee?.id, user?.tenantId, currentFilters, isManage, employeeIds, teamIds]);
+
+	const enabled = !!user && !!mergedProps;
+
+	// ==================== UPDATE HANDLERS ====================
+
+	const updateDateRange = useCallback((startDate: Date, endDate: Date) => {
+		setCurrentFilters((prev) => ({
+			...prev,
+			startDate: formatLocalDate(startDate),
+			endDate: formatLocalDate(endDate)
+		}));
+	}, []);
+
+	const handleGroupByChange = useCallback((groupByType: GroupByType) => {
+		const options = {
+			groupBy: groupByType === 'application' ? 'date' : groupByType
+		};
+		setCurrentFilters((prev) => ({ ...prev, ...options }));
+	}, []);
+
+	const updateFilters = useCallback((newFilters: Partial<UseReportActivityProps>) => {
+		setCurrentFilters((prev) => ({ ...prev, ...newFilters }));
+	}, []);
+
+	return {
+		user,
+		isManage,
+		mergedProps,
+		enabled,
+		currentFilters,
+		setCurrentFilters,
+		updateDateRange,
+		handleGroupByChange,
+		updateFilters
+	};
+}
+

--- a/apps/web/core/hooks/activities/use-report-activity.ts
+++ b/apps/web/core/hooks/activities/use-report-activity.ts
@@ -1,342 +1,92 @@
-import { useCallback, useEffect, useState, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { useAtom } from 'jotai';
-import {
-	activityReportState,
-	timeLogsRapportChartState,
-	timeLogsRapportDailyState,
-	timesheetStatisticsCountsState
-} from '@/core/stores';
-import { useTimelogFilterOptions } from './use-timelog-filter-options';
-import { activityService } from '@/core/services/client/api/activities';
-import { statisticsService } from '@/core/services/client/api/timesheets/statistic.service';
-import { timeLogService } from '@/core/services/client/api/timesheets/time-log.service';
-import { useAuthenticateUser } from '../auth';
-import { ETimeLogType } from '@/core/types/generics/enums/timer';
-import { queryKeys } from '@/core/query/keys';
-import { ITimeLogReportDailyChartProps } from '@/core/types/interfaces/activity/activity-report';
+import { useMemo } from 'react';
+import { useActivityFilters } from './use-activity-filters';
+import { useActivityChartQuery } from './queries/use-activity-chart-query';
+import { useActivityDailyReportQuery } from './queries/use-activity-daily-report-query';
+import { useActivityStatisticsQuery } from './queries/use-activity-statistics-query';
+import { useActivityReportListQuery } from './queries/use-activity-report-list-query';
 
-export interface UseReportActivityProps
-	extends Omit<ITimeLogReportDailyChartProps, 'logType' | 'activityLevel' | 'start' | 'end' | 'groupBy'> {
-	logType?: ETimeLogType[];
-	activityLevel: {
-		start: number;
-		end: number;
-	};
-	start?: number;
-	end?: number;
-	projectIds?: string[];
-	employeeIds?: string[];
-	teamIds?: string[];
-	groupBy?: string;
-}
+// Re-export types for backward compatibility
+export type { UseReportActivityProps, GroupByType } from './use-activity-filters';
 
-const now = new Date();
-const firstDayOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-const lastDayOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-
-const defaultProps: Required<
-	Pick<
-		UseReportActivityProps,
-		| 'startDate'
-		| 'endDate'
-		| 'groupBy'
-		| 'activityLevel'
-		| 'logType'
-		| 'start'
-		| 'end'
-		| 'employeeIds'
-		| 'projectIds'
-		| 'teamIds'
-	>
-> = {
-	startDate: firstDayOfMonth.toISOString().split('T')[0],
-	endDate: lastDayOfMonth.toISOString().split('T')[0],
-	groupBy: 'date',
-	activityLevel: {
-		start: 0,
-		end: 100
-	},
-	logType: [ETimeLogType.TRACKED],
-	start: 0,
-	end: 100,
-	employeeIds: [],
-	projectIds: [],
-	teamIds: []
-};
-
-export type GroupByType = 'date' | 'project' | 'employee' | 'application' | 'daily' | 'weekly' | 'member';
-
+/**
+ * @deprecated Use the granular hooks directly instead:
+ * - `useActivityFilters()` for filter state, auth context, and merged props
+ * - `useActivityChartQuery()` for chart data
+ * - `useActivityDailyReportQuery()` for daily report data
+ * - `useActivityStatisticsQuery()` for statistics counts
+ * - `useActivityReportListQuery()` for activity report (Apps & URLs)
+ *
+ * This wrapper composes the new hooks to maintain backward compatibility.
+ * It will be removed in a future release.
+ */
 export function useReportActivity({ types }: { types?: 'TEAM-DASHBOARD' | 'APPS-URLS' | 'TIME-AND-ACTIVITY' }) {
-	// User and authentication
-	const { user } = useAuthenticateUser();
-	const { allteamsState, alluserState, isUserAllowedToAccess } = useTimelogFilterOptions();
-	const isManage = useMemo(() => user && isUserAllowedToAccess(user), [user, isUserAllowedToAccess]);
-
-	// State management - For compatibility
-	const [currentFilters, setCurrentFilters] = useState<Partial<UseReportActivityProps>>(defaultProps);
-	const [, setRapportChartActivity] = useAtom(timeLogsRapportChartState);
-	const [, setRapportDailyActivity] = useAtom(timeLogsRapportDailyState);
-	const [, setStatisticsCounts] = useAtom(timesheetStatisticsCountsState);
-	const [, setActivityReport] = useAtom(activityReportState);
-
-	// Memoized employee and team IDs
-	const employeeIds = useMemo(
-		() =>
-			isManage
-				? alluserState?.map(({ employee }) => employee?.id).filter(Boolean)
-				: user?.employee?.id
-					? [user.employee.id]
-					: [],
-		[isManage, alluserState, user?.employee?.id]
-	);
-
-	const teamIds = useMemo(() => allteamsState?.map(({ id }) => id).filter(Boolean) || [], [allteamsState]);
-
-	// Props merging logic
-	const getMergedProps = useMemo(() => {
-		if (!user?.employee?.organizationId) {
-			return null;
-		}
-
-		return (customProps?: Partial<UseReportActivityProps>) => {
-			const merged = {
-				...defaultProps,
-				...currentFilters,
-				...(customProps || {}),
-				organizationId: user?.employee?.organizationId,
-				teamId: customProps?.teamId || currentFilters.teamId,
-				userId: customProps?.userId || currentFilters.userId,
-				tenantId: user?.tenantId ?? '',
-				logType: (customProps?.logType || currentFilters.logType || defaultProps.logType) as ETimeLogType[],
-				startDate: (customProps?.startDate || currentFilters.startDate || defaultProps.startDate) as string,
-				endDate: (customProps?.endDate || currentFilters.endDate || defaultProps.endDate) as string,
-				groupBy: (customProps?.groupBy || currentFilters.groupBy || defaultProps.groupBy) as string,
-				projectIds: (customProps?.projectIds ||
-					currentFilters.projectIds ||
-					defaultProps.projectIds) as string[],
-				employeeIds: isManage ? employeeIds : [user?.employee?.id],
-				teamIds: teamIds,
-				activityLevel: {
-					start:
-						customProps?.activityLevel?.start ??
-						currentFilters.activityLevel?.start ??
-						defaultProps.activityLevel.start,
-					end:
-						customProps?.activityLevel?.end ??
-						currentFilters.activityLevel?.end ??
-						defaultProps.activityLevel.end
-				},
-				start: customProps?.start ?? currentFilters.start ?? defaultProps.start,
-				end: customProps?.end ?? currentFilters.end ?? defaultProps.end
-			};
-			return merged as Required<UseReportActivityProps>;
-		};
-	}, [
-		user?.employee?.organizationId,
-		user?.employee?.id,
-		user?.tenantId,
-		currentFilters,
+	const {
 		isManage,
-		employeeIds,
-		teamIds
-	]);
+		mergedProps,
+		enabled,
+		currentFilters,
+		updateDateRange,
+		handleGroupByChange,
+		updateFilters
+	} = useActivityFilters();
 
-	// True MIGRATION REACT QUERY - Using useQuery (for compatibility)
-	const mergedProps = getMergedProps?.() || null;
-	const enabled = !!user && !!mergedProps;
+	const isNotAppsUrls = types !== 'APPS-URLS';
+	const isAppsUrls = types === 'APPS-URLS';
 
-	// Chart Activity Query
-	const chartActivityQuery = useQuery({
-		queryKey: [
-			queryKeys.activities.dailyChart({
-				tenantId: user?.tenantId,
-				organizationId: user?.employee?.organizationId,
-				...currentFilters
-			})
-		],
-		queryFn: () => timeLogService.getTimeLogReportDailyChart(mergedProps!),
-		enabled: enabled && types !== 'APPS-URLS',
-		staleTime: 1000 * 60 * 10,
-		gcTime: 1000 * 60 * 30,
-		retry: 3,
-		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000)
-	});
+	const {
+		rapportChartActivity,
+		refetchChartActivity,
+		query: chartActivityQuery
+	} = useActivityChartQuery({ mergedProps, enabled: enabled && isNotAppsUrls });
 
-	// Daily Report Query
-	const dailyReportQuery = useQuery({
-		queryKey: [
-			queryKeys.activities.daily({
-				tenantId: user?.tenantId,
-				organizationId: user?.employee?.organizationId,
-				...currentFilters
-			})
-		],
-		queryFn: () => timeLogService.getTimeLogReportDaily(mergedProps!),
-		enabled: enabled && types !== 'APPS-URLS',
-		staleTime: 1000 * 60 * 10,
-		gcTime: 1000 * 60 * 30,
-		retry: 3
-	});
+	const {
+		rapportDailyActivity,
+		refetchDailyReport,
+		query: dailyReportQuery
+	} = useActivityDailyReportQuery({ mergedProps, enabled: enabled && isNotAppsUrls });
 
-	// Statistics Query
-	const statisticsQuery = useQuery({
-		queryKey: [
-			queryKeys.activities.statisticsCounts({
-				tenantId: user?.tenantId,
-				organizationId: user?.employee?.organizationId,
-				...currentFilters
-			})
-		],
-		queryFn: () =>
-			statisticsService.getTimesheetStatisticsCounts({
-				...mergedProps!,
-				logType: [ETimeLogType.TRACKED]
-			}),
-		enabled: enabled && types !== 'APPS-URLS',
-		staleTime: 1000 * 60 * 10,
-		gcTime: 1000 * 60 * 30,
-		retry: 3
-	});
+	const {
+		statisticsCounts,
+		refetchStatisticsCounts,
+		query: statisticsQuery
+	} = useActivityStatisticsQuery({ mergedProps, enabled: enabled && isNotAppsUrls });
 
-	// Activity Report Query
-	const activityReportQuery = useQuery({
-		queryKey: [
-			queryKeys.activities.activityReport({
-				tenantId: user?.tenantId,
-				organizationId: user?.employee?.organizationId,
-				...currentFilters
-			})
-		],
-		queryFn: () => activityService.getActivitiesReport(mergedProps!),
-		enabled: enabled && types === 'APPS-URLS',
-		staleTime: 1000 * 60 * 10,
-		gcTime: 1000 * 60 * 30,
-		retry: 3
-	});
-	// Sync React Query data with Jotai atoms (for compatibility)
-	useEffect(() => {
-		if (chartActivityQuery.data?.data) {
-			setRapportChartActivity(chartActivityQuery.data.data);
-		}
-	}, [chartActivityQuery.data, setRapportChartActivity]);
-
-	useEffect(() => {
-		if (dailyReportQuery.data?.data) {
-			setRapportDailyActivity(dailyReportQuery.data.data);
-		}
-	}, [dailyReportQuery.data, setRapportDailyActivity]);
-
-	useEffect(() => {
-		if (statisticsQuery.data?.data) {
-			setStatisticsCounts(statisticsQuery.data.data);
-		}
-	}, [statisticsQuery.data, setStatisticsCounts]);
-
-	useEffect(() => {
-		if (activityReportQuery.data?.data) {
-			setActivityReport(activityReportQuery.data.data);
-		}
-	}, [activityReportQuery.data, setActivityReport]);
+	const {
+		activityReport,
+		refetchActivityReport,
+		query: activityReportQuery
+	} = useActivityReportListQuery({ mergedProps, enabled: enabled && isAppsUrls });
 
 	// Combined loading state
 	const loading = useMemo(() => {
-		if (types === 'APPS-URLS') {
+		if (isAppsUrls) {
 			return activityReportQuery.isLoading;
 		}
 		return chartActivityQuery.isLoading || dailyReportQuery.isLoading || statisticsQuery.isLoading;
-	}, [
-		types,
-		chartActivityQuery.isLoading,
-		dailyReportQuery.isLoading,
-		statisticsQuery.isLoading,
-		activityReportQuery.isLoading
-	]);
-
-	// Update handlers with React Query invalidation
-	const updateDateRange = useCallback((startDate: Date, endDate: Date) => {
-		const newFilters = {
-			startDate: startDate.toISOString().split('T')[0],
-			endDate: endDate.toISOString().split('T')[0]
-		};
-		setCurrentFilters((prev) => ({ ...prev, ...newFilters }));
-	}, []);
-
-	const handleGroupByChange = useCallback((groupByType: GroupByType) => {
-		const options = {
-			groupBy: groupByType === 'application' ? 'date' : groupByType
-		};
-		setCurrentFilters((prev) => ({ ...prev, ...options }));
-	}, []);
-
-	const updateFilters = useCallback((newFilters: Partial<UseReportActivityProps>) => {
-		setCurrentFilters((prev) => ({ ...prev, ...newFilters }));
-	}, []);
-
-	// Refetch functions for compatibility
-	const fetchReportActivity = useCallback(
-		async (customProps?: Partial<UseReportActivityProps>) => {
-			if (customProps) {
-				setCurrentFilters((prev) => ({ ...prev, ...customProps }));
-			}
-			return chartActivityQuery.refetch();
-		},
-		[chartActivityQuery]
-	);
-
-	const fetchDailyReport = useCallback(
-		async (customProps?: Partial<UseReportActivityProps>) => {
-			if (customProps) {
-				setCurrentFilters((prev) => ({ ...prev, ...customProps }));
-			}
-			return dailyReportQuery.refetch();
-		},
-		[dailyReportQuery]
-	);
-
-	const fetchActivityReport = useCallback(
-		async (customProps?: Partial<UseReportActivityProps>) => {
-			if (customProps) {
-				setCurrentFilters((prev) => ({ ...prev, ...customProps }));
-			}
-			return activityReportQuery.refetch();
-		},
-		[activityReportQuery]
-	);
-
-	const fetchStatisticsCounts = useCallback(
-		async (customProps?: Partial<UseReportActivityProps>) => {
-			if (customProps) {
-				setCurrentFilters((prev) => ({ ...prev, ...customProps }));
-			}
-			return statisticsQuery.refetch();
-		},
-		[statisticsQuery]
-	);
+	}, [isAppsUrls, chartActivityQuery.isLoading, dailyReportQuery.isLoading, statisticsQuery.isLoading, activityReportQuery.isLoading]);
 
 	return {
 		// Loading states
 		loading,
-		// Data states - Direct access to React Query data
-		rapportChartActivity: chartActivityQuery.data?.data || [],
-		rapportDailyActivity: dailyReportQuery.data?.data || [],
-		statisticsCounts: statisticsQuery.data?.data || null,
-		activityReport: Array.isArray(activityReportQuery.data?.data) ? activityReportQuery.data.data : [],
+		// Data states
+		rapportChartActivity,
+		rapportDailyActivity,
+		statisticsCounts,
+		activityReport,
 
 		// Update handlers
 		updateDateRange,
 		updateFilters,
 		handleGroupByChange,
-		fetchActivityReport,
 
-		// Refetch functions for compatibility
-		fetchReportActivity,
-		fetchDailyReport,
-		fetchStatisticsCounts,
+		// Refetch functions
+		fetchReportActivity: refetchChartActivity,
+		fetchActivityReport: refetchActivityReport,
+		fetchDailyReport: refetchDailyReport,
+		fetchStatisticsCounts: refetchStatisticsCounts,
 
 		// Other states
 		currentFilters,
-		setStatisticsCounts,
 		isManage,
 
 		// React Query states for debug/monitoring

--- a/apps/web/core/lib/helpers/retry-utils.ts
+++ b/apps/web/core/lib/helpers/retry-utils.ts
@@ -1,0 +1,69 @@
+/**
+ * Smart retry logic for activity query hooks.
+ *
+ * Prevents the "timeout cascade" problem where multiple slow queries
+ * each retry 3 times with a 60s Axios timeout, saturating the browser's
+ * 6-connection-per-origin limit and freezing the entire application.
+ *
+ * Rules:
+ * - Timeouts (408 / 504)  → never retry (server is too slow, retrying will cascade)
+ * - Cancellations (499)    → never retry (intentional abort)
+ * - Network / 5xx errors   → retry once (transient, may recover)
+ * - 4xx client errors      → never retry (bad request, won't change)
+ */
+
+// HTTP status codes produced by ApiErrorService.fromAxiosError for timeout scenarios
+const TIMEOUT_STATUS_CODES = new Set([408, 504]);
+// Status code for intentionally cancelled requests (ERR_CANCELED → 499 in ApiErrorService)
+const CANCELLED_STATUS_CODE = 499;
+
+/**
+ * Determines whether a failed React Query should be retried.
+ *
+ * Designed for **display-only** activity queries (dashboard, charts, reports)
+ * where aggressive retries are harmful — they saturate the connection pool
+ * and block the rest of the application.
+ *
+ * @param failureCount - How many times the query has already failed (0-based from React Query)
+ * @param error - The error thrown by the queryFn (typically an ApiErrorService instance)
+ * @returns `true` to retry, `false` to stop
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+	// --- Extract status code from the error (handles both ApiErrorService and raw AxiosError) ---
+
+	let statusCode: number | undefined;
+	let axiosCode: string | undefined;
+
+	if (error && typeof error === 'object') {
+		if ('statusCode' in error) {
+			statusCode = (error as { statusCode: number }).statusCode;
+		}
+		if ('code' in error) {
+			axiosCode = (error as { code: string }).code;
+		}
+	}
+
+	// --- Never retry timeouts ---
+	// ApiErrorService maps ECONNABORTED → 408, ETIMEDOUT → 504
+	if (statusCode !== undefined && TIMEOUT_STATUS_CODES.has(statusCode)) {
+		return false;
+	}
+	// Safety net: raw AxiosError that somehow bypassed ApiErrorService wrapping
+	if (axiosCode === 'ECONNABORTED' || axiosCode === 'ETIMEDOUT') {
+		return false;
+	}
+
+	// --- Never retry intentional cancellations ---
+	if (statusCode === CANCELLED_STATUS_CODE || axiosCode === 'ERR_CANCELED') {
+		return false;
+	}
+
+	// --- Never retry 4xx client errors (except 408 already handled above) ---
+	if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
+		return false;
+	}
+
+	// --- Retry transient errors (network, 5xx) at most once ---
+	return failureCount < 1;
+}
+


### PR DESCRIPTION
# 🚀 [ETP-225](https://evertech.atlassian.net/browse/ETP-225). Refactor: Split useReportActivity into Granular Query Hooks (ETP-225)

## Description

This PR refactors the monolithic `useReportActivity` hook (~350 lines) into focused, composable hooks following the **"pay only for what you use"** principle.

- **Problem:** The `useReportActivity` hook was a "God Query Hook" bundling 4 distinct API calls (Charts, Daily Reports, Statistics, Activity Logs), complex filter merging, and Jotai atom synchronization — causing over-fetching, unnecessary re-renders, and a timeout cascade that could freeze the entire application.
- **Root Cause:** All-or-nothing dependency (components needing only Statistics still initialized Charts/Daily Reports), legacy Jotai sync causing double-renders, aggressive `retry: 3` with 60s Axios timeout saturating the browser's 6-connection-per-origin limit, and a desynchronized DateRangePicker UI showing "This Month" while data loaded for 7 days.
- **Solution:** Split into 4 granular query hooks + 1 shared filter hook, removed Jotai atom sync, added smart retry logic that prevents timeout cascades, fixed timezone bug in date defaults, and synchronized the DateRangePicker UI with the data layer.

## What Was Changed

### Major Changes

- **New: `apps/web/core/hooks/activities/use-activity-filters.ts`**
  - Extracted shared filter logic (auth context, date range, employee/team IDs, props merging) into a dedicated hook
  - Fixed timezone bug: replaced `toISOString().split('T')[0]` with `formatLocalDate()` helper (prevents day-shift for UTC+ timezones)
  - Optimized default date range from full month (~28 days) to last 7 days for lighter API payloads

- **New: `apps/web/core/hooks/activities/queries/use-activity-chart-query.ts`**
  - Dedicated query hook for chart data (`/timesheet/time-log/report/daily-chart`)

- **New: `apps/web/core/hooks/activities/queries/use-activity-daily-report-query.ts`**
  - Dedicated query hook for daily report data (`/timesheet/time-log/report/daily`)

- **New: `apps/web/core/hooks/activities/queries/use-activity-statistics-query.ts`**
  - Dedicated query hook for statistics counts (`/timesheet/statistics/counts`)

- **New: `apps/web/core/hooks/activities/queries/use-activity-report-list-query.ts`**
  - Dedicated query hook for activity report / Apps & URLs (`/timesheet/activity/report`)

- **New: `apps/web/core/lib/helpers/retry-utils.ts`**
  - Smart `shouldRetryQuery()` function that prevents the timeout cascade problem:
    - Never retries timeouts (408/504) — server is too slow, retrying just saturates connections
    - Never retries cancellations (499) — intentional abort
    - Never retries 4xx client errors — bad request won't change
    - Retries transient errors (network/5xx) at most once
  - Reduces worst-case from 12 pending requests (3 hooks × 4 attempts) to 3-6

- **Modified: `apps/web/core/hooks/activities/use-report-activity.ts`**
  - Rewritten as a thin backward-compatible wrapper composing the new granular hooks
  - Marked `@deprecated` — will be removed in a future release
  - Removed all Jotai atom synchronization (eliminated double-render issue)

- **Modified: `apps/web/app/[locale]/(main)/dashboard/team-dashboard/[teamId]/page.tsx`**
  - Migrated from `useReportActivity({ types: 'TEAM-DASHBOARD' })` to direct granular hook calls
  - Now imports only `useActivityChartQuery`, `useActivityDailyReportQuery`, `useActivityStatisticsQuery`

- **Modified: `apps/web/app/[locale]/(main)/dashboard/app-url/[teamId]/page.tsx`**
  - Migrated from `useReportActivity({ types: 'APPS-URLS' })` to direct granular hook calls
  - Now imports only `useActivityReportListQuery` (no chart/daily/stats overhead)

- **Modified: `apps/web/core/components/pages/time-and-activity/page-component.tsx`**
  - Migrated from `useReportActivity({ types: 'TEAM-DASHBOARD' })` to direct granular hook calls
  - Now imports only `useActivityDailyReportQuery`, `useActivityStatisticsQuery`

### Minor Changes

- **Modified: `apps/web/core/components/common/date-range-picker.tsx`**
  - Added optional `initialRange` prop so the picker starts with the data-layer's date range instead of hardcoded "full current month"
  - Backward compatible: falls back to `startOfMonth/endOfMonth` when prop is not provided

- **Modified: `apps/web/core/components/pages/time-and-activity/date-range-picker-time-activity.tsx`**
  - Same `initialRange` prop addition as above for the Time & Activity page variant

- **Modified: `apps/web/core/components/pages/dashboard/dashboard-header.tsx`**
  - Passes `initialRange={{ from: startDate, to: endDate }}` to `LazyDateRangePicker`

- **Modified: `apps/web/core/components/pages/time-and-activity/time-activity-header.tsx`**
  - Passes `initialRange={{ from: startDate, to: endDate }}` to `DateRangePickerTimeActivity`

- **Modified: `apps/web/core/hooks/activities/index.ts`**
  - Added barrel exports for `use-activity-filters` and `queries/`

- **New: `apps/web/core/hooks/activities/queries/index.ts`**
  - Barrel export for all 4 granular query hooks

## How to Test This PR

1. Run the app with `yarn web:dev`
2. Open the browser at `http://localhost:3030`
3. Navigate to **Team Dashboard** (`/dashboard/team-dashboard/[teamId]`)
4. Verify:
   - Dashboard loads with data for the **last 7 days** (not full month)
   - DateRangePicker shows the correct 7-day range selected (not "This Month")
   - Chart, daily report table, and statistics cards all render correctly
   - Changing the date range updates all 3 data sections
5. Navigate to **Apps & URLs** (`/dashboard/app-url/[teamId]`)
6. Verify:
   - Only the activity report loads (no chart/stats network requests in DevTools Network tab)
   - Data renders correctly in all group-by modes (date, project, employee, application)
7. Navigate to **Time & Activity** (`/reports/time-and-activity`)
8. Verify:
   - Daily report and statistics load correctly
   - DateRangePicker shows the correct 7-day range

**Timeout cascade regression test:**

- Open DevTools → Network tab
- Throttle to "Slow 3G" or block the API endpoint temporarily
- Verify that failed requests do NOT retry 3 times (should retry at most once for network errors, zero times for timeouts)
- Verify the app remains responsive even when API calls fail

## Related Issues

- Closes [ETP-225](https://evertech.atlassian.net/browse/ETP-225)

## Type of Change

- [ ] Bug fix (fixes a problem)
- [x] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

- **Backward compatibility preserved**: `useReportActivity` still works as a deprecated wrapper — no breaking change for any code that hasn't been migrated yet.
- **No Jotai atoms removed**: The atoms (`timeLogsRapportChartState`, `timeLogsRapportDailyState`, etc.) still exist in the store but are no longer written to by the new hooks. They can be cleaned up in a follow-up PR once all consumers are confirmed migrated.
- **`retry-utils.ts` is generic**: The `shouldRetryQuery` function is placed in `core/lib/helpers/` and can be reused by any React Query hook in the project, not just activity queries.
- **The `types` parameter** (`'TEAM-DASHBOARD' | 'APPS-URLS' | 'TIME-AND-ACTIVITY'`) was never sent to the backend API — it only controlled which queries were enabled client-side. With granular hooks, each page imports only the hooks it needs, making `types` unnecessary.

### Architecture: Before vs After

```text
BEFORE (monolithic):
useReportActivity({ types })
  ├── filter merging logic (~80 lines)
  ├── 4× useQuery (all initialized, conditionally enabled via `types`)
  ├── 4× Jotai atom sync (useEffect → double render)
  ├── retry: 3 × 60s timeout = cascade risk
  └── returns everything (chart + daily + stats + report + filters + refetch)

AFTER (granular):
useActivityFilters()           → shared filter state, auth, merged props
useActivityChartQuery()        → chart data only (smart retry)
useActivityDailyReportQuery()  → daily report only (smart retry)
useActivityStatisticsQuery()   → statistics only (smart retry)
useActivityReportListQuery()   → activity report only (smart retry)
shouldRetryQuery()             → no timeout retry, max 1 retry for transient errors
```


[ETP-225]: https://evertech.atlassian.net/browse/ETP-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ETP-225]: https://evertech.atlassian.net/browse/ETP-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the monolithic useReportActivity into focused query hooks plus a shared useActivityFilters, aligning with ETP-225. This adds a fresh 7-day default date range computed at hook mount, reduces over‑fetching, prevents timeout cascades, and keeps the date range UI in sync with data.

- **New Features**
  - Added useActivityFilters with local‑time formatting and a dynamic 7‑day default range built at hook mount.
  - Added query hooks: useActivityChartQuery, useActivityDailyReportQuery, useActivityStatisticsQuery, useActivityReportListQuery.
  - Introduced shouldRetryQuery: no retries for 408/504/499/4xx; one retry for transient network/5xx.
  - Date range pickers now support initialRange; headers pass start/end to sync UI with data.

- **Refactors**
  - Deprecated useReportActivity (kept as a thin wrapper); removed Jotai sync to avoid double renders.
  - Migrated Team Dashboard, Apps & URLs, and Time & Activity pages to granular hooks to load only needed data.
  - Simplified queryKey construction in granular hooks; added barrel exports for activities/queries.

<sup>Written for commit 7df022a0b3077581d01f22202f0513642499e9c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Date range pickers in activity dashboards now pre-fill with your previously selected ranges.

* **Bug Fixes**
  * Applying filters now reliably refreshes all activity charts, reports, and statistics.

* **Refactor**
  * Activity filtering and data fetching restructured into smaller, focused modules for more consistent loading and faster, more maintainable dashboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->