### PR TITLE
[ETP-226] task web refactor use kanban move filtering logic to selectors

### DIFF
--- a/apps/web/app/[locale]/(main)/kanban/page.tsx
+++ b/apps/web/app/[locale]/(main)/kanban/page.tsx
@@ -48,7 +48,8 @@ import { activeTeamState, isTrackingEnabledState } from '@/core/stores';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 
 const Kanban = () => {
-	// Get all required hooks and states
+	// Get all required hooks and states — single instance for the entire Kanban page.
+	// Board operations are passed down to KanbanView via props (no duplicate hook instance).
 	const {
 		data,
 		setSearchTasks,
@@ -59,8 +60,19 @@ const Kanban = () => {
 		setLabels,
 		setEpics,
 		setIssues,
-		issues
+		issues,
+		columns,
+		taskStatuses,
+		updateKanbanBoard,
+		updateTaskStatus,
+		isColumnCollapse,
+		reorderStatus,
+		addNewTask,
+		toggleColumn
 	} = useKanban();
+
+	// TODO: Remove debug logs after fixing kanban
+	console.log('[KANBAN] isLoading:', isLoading, 'data keys:', Object.keys(data ?? {}), 'data values count:', Object.values(data ?? {}).map((v: any) => v?.length));
 
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 
@@ -172,6 +184,9 @@ const Kanban = () => {
 		return board;
 	}, [data, activeTab]);
 
+	// TODO: Remove debug log after fixing kanban
+	console.log('[KANBAN] activeTab:', activeTab, 'filteredBoard values count:', Object.values(filteredBoard).map((v: any) => v?.length));
+
 	useEffect(() => {
 		const lastPath = breadcrumbPath.slice(-1)[0];
 		if (employee) {
@@ -241,7 +256,7 @@ const Kanban = () => {
 
 									<button
 										onClick={openModal}
-										className="p-2 rounded-full relative z-10 border-2 border-[#0000001a] dark:border-white"
+										className="p-2 rounded-full relative z-50 border-2 border-[#0000001a] dark:border-white bg-white dark:bg-black"
 									>
 										<AddIcon className="w-6 h-6 text-foreground" />
 									</button>
@@ -374,9 +389,20 @@ const Kanban = () => {
 
 				{activeTab && (
 					<div className="overflow-x-hidden px-0 mx-0 w-full">
-						{Object.keys(filteredBoard).length > 0 ? (
+						{Object.keys(data).length > 0 ? (
 							<div className="w-full h-full">
-								<LazyKanbanView isLoading={isLoading} kanbanBoardTasks={filteredBoard} />
+								<LazyKanbanView
+									isLoading={isLoading}
+									kanbanBoardTasks={data}
+									kanbanColumns={columns}
+									taskStatuses={taskStatuses}
+									updateKanbanBoard={updateKanbanBoard}
+									updateTaskStatus={updateTaskStatus}
+									isColumnCollapse={isColumnCollapse}
+									reorderStatus={reorderStatus}
+									addNewTask={addNewTask}
+									toggleColumn={toggleColumn}
+								/>
 							</div>
 						) : (
 							<div className="flex flex-col flex-1 w-full h-full">

--- a/apps/web/app/[locale]/(main)/kanban/page.tsx
+++ b/apps/web/app/[locale]/(main)/kanban/page.tsx
@@ -312,8 +312,7 @@ const Kanban = () => {
 												taskStatusClassName="!bg-transparent !p-0 !text-sm"
 												showIssueLabels
 												className={cn(
-													'!border-none !bg-transparent dark:!text-white !p-0 !h-auto',
-													issues?.value ? '' : ''
+													'border-none! bg-transparent! dark:text-white! p-0! h-auto!'
 												)}
 												items={items}
 												value={issues}

--- a/apps/web/app/[locale]/(main)/kanban/page.tsx
+++ b/apps/web/app/[locale]/(main)/kanban/page.tsx
@@ -60,6 +60,7 @@ const Kanban = () => {
 		setLabels,
 		setEpics,
 		setIssues,
+		epics,
 		issues,
 		columns,
 		taskStatuses,
@@ -71,9 +72,6 @@ const Kanban = () => {
 		toggleColumn
 	} = useKanban();
 
-	// TODO: Remove debug logs after fixing kanban
-	console.log('[KANBAN] isLoading:', isLoading, 'data keys:', Object.keys(data ?? {}), 'data values count:', Object.values(data ?? {}).map((v: any) => v?.length));
-
 	const isTrackingEnabled = useAtomValue(isTrackingEnabledState);
 
 	const activeTeam = useAtomValue(activeTeamState);
@@ -81,7 +79,7 @@ const Kanban = () => {
 	const params = useParams<{ locale: string }>();
 	const fullWidth = useAtomValue(fullWidthState);
 	const currentLocale = params ? params.locale : null;
-	const [activeTab, setActiveTab] = useState(KanbanTabs.TODAY);
+	const [activeTab, setActiveTab] = useState(KanbanTabs.ALL);
 	const employee = useSearchParams().get('employee');
 	const { data: user } = useUserQuery();
 	const { openModal, isOpen, closeModal } = useModal();
@@ -116,6 +114,7 @@ const Kanban = () => {
 	// Memoize tabs to prevent recreation on each render
 	const tabs = useMemo(
 		() => [
+			{ name: t('common.FILTER_ALL'), value: KanbanTabs.ALL },
 			{ name: t('common.TODAY'), value: KanbanTabs.TODAY },
 			{ name: t('common.YESTERDAY'), value: KanbanTabs.YESTERDAY },
 			{ name: t('common.TOMORROW'), value: KanbanTabs.TOMORROW }
@@ -175,6 +174,7 @@ const Kanban = () => {
 				case KanbanTabs.TOMORROW:
 					filteredStatusTasks = filterByDate(tasks as TTask[], tomorrow);
 					break;
+				case KanbanTabs.ALL:
 				default:
 					filteredStatusTasks = tasks;
 			}
@@ -183,9 +183,6 @@ const Kanban = () => {
 
 		return board;
 	}, [data, activeTab]);
-
-	// TODO: Remove debug log after fixing kanban
-	console.log('[KANBAN] activeTab:', activeTab, 'filteredBoard values count:', Object.values(filteredBoard).map((v: any) => v?.length));
 
 	useEffect(() => {
 		const lastPath = breadcrumbPath.slice(-1)[0];
@@ -262,52 +259,61 @@ const Kanban = () => {
 									</button>
 								</div>
 							</div>
-							<div className="flex flex-col-reverse justify-between items-center pt-6 -mb-1 bg-white xl:flex-row dark:bg-dark-high">
-								<div className="flex flex-row">
+							<div className="flex flex-col gap-4 justify-between items-start pt-6 mb-4 bg-white xl:flex-row xl:items-center dark:bg-dark-high">
+								<div className="flex flex-row overflow-x-auto no-scrollbar w-full xl:w-auto border-b border-gray-100 dark:border-[#26272C]">
 									{tabs.map((tab) => (
 										<div
 											key={tab.name}
 											onClick={() => setActiveTab(tab.value)}
-											className={`cursor-pointer pt-2 px-5 pb-[30px] text-base font-semibold ${
+											className={cn(
+												'cursor-pointer px-4 pb-3 text-sm font-medium transition-all duration-200 whitespace-nowrap relative',
 												activeTab === tab.value
-													? 'border-b-[#3826A6] text-[#3826A6] dark:text-white dark:border-b-white'
-													: 'border-b-white dark:border-b-[#191A20] dark:text-white text-[#282048]'
-											}`}
-											style={{
-												borderBottomWidth: '3px',
-												borderBottomStyle: 'solid'
-											}}
+													? 'text-[#3826A6] dark:text-white'
+													: 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+											)}
 										>
 											{tab.name}
+											{activeTab === tab.value && (
+												<div className="absolute bottom-0 left-0 w-full h-0.5 bg-[#3826A6] dark:bg-white rounded-t-full" />
+											)}
 										</div>
 									))}
 								</div>
-								<div className="flex gap-5 mt-4 max-h-10 lg:mt-0 min-h-8">
+
+								<div className="flex flex-wrap gap-2 items-center w-full xl:w-auto">
 									<LazyEpicPropertiesDropdown
 										onValueChange={(_, values) => setEpics(values || [])}
-										className="min-w-fit lg:mt-0 input-border flex flex-col justify-center rounded-xl bg-[#F2F2F2] dark:bg-dark--theme-light min-h-6 px-2 max-h-full"
+										className="h-8 min-w-fit input-border flex items-center justify-center rounded-lg bg-white dark:bg-dark--theme-light px-2.5 text-sm"
 										multiple
+										taskStatusClassName="!text-sm"
+										defaultValues={epics}
 									/>
-									<div className="relative z-10 flex items-center justify-center min-w-28 max-w-fit  lg:mt-0 input-border flex-col bg-[#F2F2F2] dark:bg-dark--theme-light min-h-6 px-4 max-h-full rounded-[8px]">
-										<div className="absolute inset-0 flex items-center w-full h-full gap-0.5">
+
+									<div className="flex relative z-10 justify-center items-center px-3 h-8 bg-white rounded-lg transition-colors min-w-fit input-border dark:bg-dark--theme-light hover:border-gray-300 dark:hover:border-gray-600">
+										<div className="flex gap-2 items-center">
 											{!issues?.value && (
 												<svg
 													xmlns="http://www.w3.org/2000/svg"
 													fill="none"
 													stroke="currentColor"
-													viewBox="0 0 17 18"
-													className="ml-2 w-4 h-4"
+													viewBox="0 0 24 24"
+													className="w-4 h-4 text-gray-500 dark:text-gray-400"
 												>
-													<path d="M8.5 16.5c4.125 0 7.5-3.375 7.5-7.5s-3.375-7.5-7.5-7.5S1 4.875 1 9s3.375 7.5 7.5 7.5Z" />
+													<path
+														strokeLinecap="round"
+														strokeLinejoin="round"
+														strokeWidth={2}
+														d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+													/>
 												</svg>
 											)}
 
 											<LazyStatusDropdown
-												taskStatusClassName="w-40 h-10 !bg-transparent"
+												taskStatusClassName="!bg-transparent !p-0 !text-sm"
 												showIssueLabels
 												className={cn(
-													'h-fit w-fit !border-none !bg-transparent dark:!text-white ',
-													issues?.value ? 'ml-2' : 'ml-0'
+													'!border-none !bg-transparent dark:!text-white !p-0 !h-auto',
+													issues?.value ? '' : ''
 												)}
 												items={items}
 												value={issues}
@@ -316,68 +322,69 @@ const Kanban = () => {
 												}
 												issueType="issue"
 											/>
-											<div className="flex items-center gap-1.5">
-												{issues?.value && (
-													<button
-														onClick={() =>
-															setIssues((prev: TStatusItem) => ({
-																...prev,
-																name: 'Issues',
-																icon: null,
-																bgColor: '',
-																value: ''
-															}))
-														}
-														className="flex items-center justify-center w-5 h-5 p-0.5 rounded-md cursor-pointer hover:bg-gray-100  dark:hover:bg-gray-900 dark:hover:text-white"
-													>
-														<XMarkIcon className="w-4 h-4 dark:text-white" />
-													</button>
-												)}
 
-												{!issues?.value && (
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														viewBox="0 0 20 20"
-														fill="currentColor"
-														aria-hidden="true"
-														data-slot="icon"
-														className="w-5 h-5 text-default dark:text-white"
-													>
-														<path
-															fillRule="evenodd"
-															d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
-															clipRule="evenodd"
-														/>
-													</svg>
-												)}
-											</div>
+											{issues?.value ? (
+												<button
+													onClick={() =>
+														setIssues((prev: TStatusItem) => ({
+															...prev,
+															name: 'Issues',
+															icon: null,
+															bgColor: '',
+															value: ''
+														}))
+													}
+													className="flex justify-center items-center ml-1 w-5 h-5 rounded transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+												>
+													<XMarkIcon className="w-3.5 h-3.5 text-gray-500 dark:text-gray-300" />
+												</button>
+											) : (
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													viewBox="0 0 20 20"
+													fill="currentColor"
+													className="ml-1 w-4 h-4 text-gray-400 dark:text-gray-500"
+												>
+													<path
+														fillRule="evenodd"
+														d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+														clipRule="evenodd"
+													/>
+												</svg>
+											)}
 										</div>
 									</div>
 
 									<LazyTaskLabelsDropdown
 										onValueChange={(_, values: any) => setLabels(values || [])}
-										className="relative min-w-fit lg:mt-0 input-border flex flex-col justify-center rounded-xl text-gray-900 dark:text-white bg-[#F2F2F2] dark:bg-dark--theme-light min-h-6 px-2 max-h-full"
-										dropdownContentClassName="top-10"
+										className="h-8 relative min-w-fit input-border flex flex-col justify-center rounded-lg bg-white dark:bg-dark--theme-light px-2.5 text-sm"
+										dropdownContentClassName="top-9"
 										multiple
+										taskStatusClassName="!text-sm"
 									/>
 
 									<LazyTaskPropertiesDropdown
 										isMultiple={false}
 										onValueChange={(_, values: any) => setPriority(values || [])}
-										className="min-w-fit lg:mt-0 input-border rounded-xl bg-[#F2F2F2] dark:bg-dark--theme-light flex flex-col justify-center"
+										className="h-8 min-w-fit input-border rounded-lg bg-white dark:bg-dark--theme-light flex flex-col justify-center px-2.5 text-sm"
 										multiple
+										taskStatusClassName="!text-sm"
 									/>
 
 									<LazyTaskSizesDropdown
 										onValueChange={(_, values: any) => setSizes(values || [])}
-										className="relative min-w-fit lg:mt-0 input-border flex flex-col justify-center rounded-xl bg-[#F2F2F2] dark:bg-dark--theme-light min-h-6 px-2 max-h-full"
+										className="h-8 relative min-w-fit input-border flex flex-col justify-center rounded-lg bg-white dark:bg-dark--theme-light px-2.5 text-sm"
 										multiple
+										taskStatusClassName="!text-sm"
 									/>
-									<Separator
-										className="inline-block mt-1 shrink-0 min-h-10 h-full w-0.5"
-										orientation="vertical"
+
+									<div className="mx-1 w-px h-6 bg-gray-200 dark:bg-gray-700" />
+
+									<LazyKanbanSearch
+										setSearchTasks={setSearchTasks}
+										searchTasks={searchTasks}
+										className="mb-0!"
 									/>
-									<LazyKanbanSearch setSearchTasks={setSearchTasks} searchTasks={searchTasks} />
 								</div>
 							</div>
 							{/* <div className="w-full h-20 bg-red-500/50"></div> */}
@@ -389,11 +396,11 @@ const Kanban = () => {
 
 				{activeTab && (
 					<div className="overflow-x-hidden px-0 mx-0 w-full">
-						{Object.keys(data).length > 0 ? (
+						{Object.keys(filteredBoard).length > 0 ? (
 							<div className="w-full h-full">
 								<LazyKanbanView
 									isLoading={isLoading}
-									kanbanBoardTasks={data}
+									kanbanBoardTasks={filteredBoard}
 									kanbanColumns={columns}
 									taskStatuses={taskStatuses}
 									updateKanbanBoard={updateKanbanBoard}

--- a/apps/web/core/components/pages/kanban/search-bar.tsx
+++ b/apps/web/core/components/pages/kanban/search-bar.tsx
@@ -3,13 +3,16 @@ import { useState, useEffect, useRef } from 'react';
 import { SearchNormalIcon } from 'assets/svg';
 import { useTranslations } from 'next-intl';
 import { InputField } from '../../duplicated-components/_input';
+import { cn } from '@/core/lib/helpers';
 
 const KanbanSearch = ({
 	setSearchTasks,
-	searchTasks
+	searchTasks,
+	className
 }: {
 	setSearchTasks: (value: string) => void;
 	searchTasks: string;
+	className?: string;
 }) => {
 	const [isExpanded, setIsExpanded] = useState(false);
 	const searchRef: any = useRef(null);
@@ -41,10 +44,18 @@ const KanbanSearch = ({
 				value={searchTasks}
 				onChange={({ target }) => setSearchTasks(target.value)}
 				placeholder={t('common.SEARCH')}
-				className={`mb-0 h-10 transition-all ${isExpanded ? 'w-64' : 'w-44'} !bg-transparent`}
+				className={cn(
+					`mb-0 h-8 text-sm transition-all bg-transparent! border-none focus:ring-0`,
+					isExpanded ? 'w-64' : 'w-44'
+				)}
+				wrapperClassName={className}
 				leadingNode={
-					<Button variant="ghost" className="p-0 m-0 ml-[0.9rem] min-w-0 absolute right-3" type="submit">
-						<SearchNormalIcon className="w-4 h-4" />
+					<Button
+						variant="ghost"
+						className="p-0 m-0 ml-[0.9rem] min-w-0 absolute right-3 h-8 w-8 flex items-center justify-center"
+						type="submit"
+					>
+						<SearchNormalIcon className="w-3.5 h-3.5" />
 					</Button>
 				}
 			/>

--- a/apps/web/core/components/pages/kanban/team-members-kanban-view.tsx
+++ b/apps/web/core/components/pages/kanban/team-members-kanban-view.tsx
@@ -10,22 +10,23 @@ import {
 } from '@hello-pangea/dnd';
 import { ScrollArea, ScrollBar } from '@/core/components/common/scroll-area';
 import { cn } from '@/core/lib/helpers';
-import { IKanban, useKanban } from '@/core/hooks/tasks/use-kanban';
+import { IKanban } from '@/core/hooks/tasks/use-kanban';
 import { TTaskStatus } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
-import { useTaskStatusesQuery } from '@/core/hooks/tasks/use-task-statuses-query';
 
-export const KanbanView = ({ kanbanBoardTasks, isLoading }: { kanbanBoardTasks: IKanban; isLoading: boolean }) => {
-	const {
-		data: items,
-		columns: kanbanColumns,
-		updateKanbanBoard,
-		updateTaskStatus,
-		isColumnCollapse,
-		reorderStatus,
-		addNewTask,
-		toggleColumn // Extract toggleColumn to pass to child components
-	} = useKanban();
+export const KanbanView = ({
+	kanbanBoardTasks,
+	isLoading,
+	kanbanColumns,
+	taskStatuses,
+	updateKanbanBoard,
+	updateTaskStatus,
+	isColumnCollapse,
+	reorderStatus,
+	addNewTask,
+	toggleColumn
+}: KanbanViewProps) => {
+	const items = kanbanBoardTasks;
 	const [columns, setColumn] = useState<any[]>(
 		Object.keys(kanbanBoardTasks).map((key) => {
 			const columnInfo = kanbanColumns.find((item) => item.name === key);
@@ -38,7 +39,6 @@ export const KanbanView = ({ kanbanBoardTasks, isLoading }: { kanbanBoardTasks: 
 		})
 	);
 	const containerRef = useRef<HTMLDivElement>(null);
-	const { taskStatuses } = useTaskStatusesQuery();
 
 	const reorderTask = (list: TTask[], startIndex: number, endIndex: number) => {
 		const tasks = Array.from(list);

--- a/apps/web/core/components/pages/kanban/team-members-kanban-view.tsx
+++ b/apps/web/core/components/pages/kanban/team-members-kanban-view.tsx
@@ -10,9 +10,9 @@ import {
 } from '@hello-pangea/dnd';
 import { ScrollArea, ScrollBar } from '@/core/components/common/scroll-area';
 import { cn } from '@/core/lib/helpers';
-import { IKanban } from '@/core/hooks/tasks/use-kanban';
 import { TTaskStatus } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { IKanban, KanbanViewProps } from '@/core/types/interfaces/task/task';
 
 export const KanbanView = ({
 	kanbanBoardTasks,

--- a/apps/web/core/components/tasks/multiple-status-dropdown.tsx
+++ b/apps/web/core/components/tasks/multiple-status-dropdown.tsx
@@ -40,7 +40,7 @@ export function MultipleStatusDropdown<T extends TStatusItem>({
 }: PropsWithChildren<{
 	value: T | undefined;
 	values?: NonNullable<T['name']>[];
-	onChange?(value: string[]): void;
+	onChange?(value: string|string[]): void;
 	items: T[];
 	className?: string;
 	dropdownContentClassName?: string;
@@ -115,7 +115,7 @@ export function MultipleStatusDropdown<T extends TStatusItem>({
 	const renderItem = (item: T, isSelected: boolean) => {
 		const item_value = item.value || item.name;
 		return (
-			<div className="relative w-full outline-hidden cursor-pointer">
+			<div className="relative w-full cursor-pointer outline-hidden">
 				<TaskStatus
 					showIcon={showIcon}
 					{...item}
@@ -140,7 +140,7 @@ export function MultipleStatusDropdown<T extends TStatusItem>({
 
 							onRemoveSelected?.();
 						}}
-						className="absolute top-1/2 -translate-y-1/2 right-1 h-4 w-4 bg-transparent"
+						className="absolute right-1 top-1/2 w-4 h-4 bg-transparent -translate-y-1/2"
 					>
 						<XMarkIcon className="text-dark" height={16} width={16} aria-hidden="true" />
 					</button>

--- a/apps/web/core/components/tasks/task-status.tsx
+++ b/apps/web/core/components/tasks/task-status.tsx
@@ -236,7 +236,8 @@ export function EpicPropertiesDropdown({
 	multiple,
 	sidebarUI = false,
 	children,
-	taskStatusClassName
+	taskStatusClassName,
+	defaultValues
 }: TTaskStatusesDropdown<'epic'>) {
 	const tasks = useAtomValue(tasksByTeamState);
 	const status = useMemo(() => {
@@ -261,26 +262,25 @@ export function EpicPropertiesDropdown({
 		status,
 		value: defaultValue,
 		onValueChange,
-		multiple
+		multiple,
+		defaultValues
 	});
 
 	return (
-		<StatusDropdown
+		<MultipleStatusDropdown
 			sidebarUI={sidebarUI}
 			forDetails={forDetails}
 			className={className}
 			items={items}
 			value={item}
 			defaultItem={!item ? 'epic' : undefined}
-			onChange={onChange}
-			multiple={multiple}
+			onChange={onChange as any}
 			values={values}
-			showButtonOnly
 			taskStatusClassName={taskStatusClassName}
-			isEpic
+			isVersion={false}
 		>
 			{children}
-		</StatusDropdown>
+		</MultipleStatusDropdown>
 	);
 }
 

--- a/apps/web/core/components/tasks/task-status.tsx
+++ b/apps/web/core/components/tasks/task-status.tsx
@@ -274,7 +274,7 @@ export function EpicPropertiesDropdown({
 			items={items}
 			value={item}
 			defaultItem={!item ? 'epic' : undefined}
-			onChange={onChange as any}
+			onChange={onChange}
 			values={values}
 			taskStatusClassName={taskStatusClassName}
 			isVersion={false}
@@ -319,7 +319,7 @@ export function TaskPropertiesDropdown({
 			items={items}
 			value={item}
 			defaultItem={!item ? 'priority' : undefined}
-			onChange={onChange as any}
+			onChange={onChange}
 			multiple={multiple}
 			isMultiple={isMultiple}
 			values={values as any}
@@ -759,7 +759,7 @@ export function StatusDropdown<T extends TStatusItem>({
 			};
 
 			return (
-				<div className="relative w-full outline-none cursor-pointer">
+				<div className="relative w-full cursor-pointer outline-none">
 					<TaskStatus
 						showIcon={showIcon}
 						{...item}
@@ -776,7 +776,7 @@ export function StatusDropdown<T extends TStatusItem>({
 					{isSelected && issueType !== 'issue' && (
 						<button
 							onClick={handleRemove}
-							className="absolute w-4 h-4 -translate-y-1/2 bg-transparent bg-white rounded right-1 top-1/2 dark:bg-black"
+							className="absolute right-1 top-1/2 w-4 h-4 bg-transparent bg-white rounded -translate-y-1/2 dark:bg-black"
 						>
 							<XMarkIcon
 								className="text-dark dark:text-white"

--- a/apps/web/core/constants/config/constants.tsx
+++ b/apps/web/core/constants/config/constants.tsx
@@ -6,6 +6,7 @@ import { BG, CN, DE, ES, FR, IS, IT, NL, PL, PT, RU, SA, US } from 'country-flag
 import { EManualTimeReasons } from '@/core/types/generics/enums/timer';
 import { EInviteStatus } from '@/core/types/generics/enums/invite';
 import { Shield, User2, UserCog } from 'lucide-react';
+import { TStatusItem } from '@/core/types/interfaces/task/task-card';
 
 export const BREAKPOINTS = {
 	MOBILE: 768
@@ -905,3 +906,14 @@ export const sizeOption = [
 		name: '100+'
 	}
 ];
+
+/**
+ * Default state for the issues filter.
+ * Extracted as a constant to avoid recreating the object on every render.
+ */
+export const DEFAULT_ISSUES_STATE: TStatusItem = {
+	name: 'Issues',
+	icon: null,
+	bgColor: '',
+	value: ''
+};

--- a/apps/web/core/constants/config/constants.tsx
+++ b/apps/web/core/constants/config/constants.tsx
@@ -392,6 +392,7 @@ export enum ActivityFilters {
 }
 
 export enum KanbanTabs {
+	ALL = 'ALL',
 	TODAY = 'TODAY',
 	YESTERDAY = 'YESTERDAY',
 	TOMORROW = 'TOMORROW'

--- a/apps/web/core/hooks/tasks/use-kanban-filters.ts
+++ b/apps/web/core/hooks/tasks/use-kanban-filters.ts
@@ -43,7 +43,15 @@ export function useKanbanFilters(tasks: TTask[], isDataLoading: boolean) {
 			return [];
 		}
 
-		return applyAllFilters(tasks, { search: searchTasks, priority, issueValue: issues.value, sizes, labels, epics, employee });
+		return applyAllFilters(tasks, {
+			search: searchTasks,
+			priority,
+			issueValue: issues.value,
+			sizes,
+			labels,
+			epics,
+			employee
+		});
 	}, [tasks, isDataLoading, searchTasks, priority, issues.value, sizes, labels, epics, employee]);
 
 	return {
@@ -51,6 +59,7 @@ export function useKanbanFilters(tasks: TTask[], isDataLoading: boolean) {
 		// Filter state (read)
 		searchTasks,
 		issues,
+		epics,
 		// Filter state (write)
 		setSearchTasks,
 		setPriority,
@@ -63,4 +72,3 @@ export function useKanbanFilters(tasks: TTask[], isDataLoading: boolean) {
 
 /** Return type of useKanbanFilters for external typing */
 export type TKanbanFilters = ReturnType<typeof useKanbanFilters>;
-

--- a/apps/web/core/hooks/tasks/use-kanban-filters.ts
+++ b/apps/web/core/hooks/tasks/use-kanban-filters.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState, useMemo, useCallback } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { TStatusItem } from '@/core/types/interfaces/task/task-card';
+import { TTask } from '@/core/types/schemas/task/task.schema';
+import { applyAllFilters } from '@/core/lib/utils';
+import { DEFAULT_ISSUES_STATE } from '@/core/constants/config/constants';
+
+// ==================== HOOK ====================
+
+/**
+ * Hook that manages kanban filter state and applies filters to tasks.
+ *
+ * Extracted from useKanban to separate filtering concerns from board/column management.
+ * This hook owns:
+ * - Filter state (search, priority, sizes, labels, epics, issues, employee)
+ * - Filter application logic (single-pass filtering with useMemo)
+ *
+ * @param tasks - The raw task list to filter
+ * @param isDataLoading - Whether the upstream data is still loading
+ * @returns Filtered tasks and all filter state setters
+ */
+export function useKanbanFilters(tasks: TTask[], isDataLoading: boolean) {
+	// ==================== FILTER STATE ====================
+	const [searchTasks, setSearchTasks] = useState('');
+	const [labels, setLabels] = useState<string[]>([]);
+	const [epics, setEpics] = useState<string[]>([]);
+	const [issues, setIssues] = useState<TStatusItem>(DEFAULT_ISSUES_STATE);
+	const [priority, setPriority] = useState<string[]>([]);
+	const [sizes, setSizes] = useState<string[]>([]);
+	const employee = useSearchParams().get('employee');
+
+	// ==================== STABLE SETTER REFERENCES ====================
+	// React setState is already stable, but we wrap setIssues for type safety
+	const handleSetIssues = useCallback((updater: TStatusItem | ((prev: TStatusItem) => TStatusItem)) => {
+		setIssues(updater);
+	}, []);
+
+	// ==================== FILTERED TASKS ====================
+	const filteredTasks = useMemo(() => {
+		if (isDataLoading) {
+			return [];
+		}
+
+		return applyAllFilters(tasks, { search: searchTasks, priority, issueValue: issues.value, sizes, labels, epics, employee });
+	}, [tasks, isDataLoading, searchTasks, priority, issues.value, sizes, labels, epics, employee]);
+
+	return {
+		filteredTasks,
+		// Filter state (read)
+		searchTasks,
+		issues,
+		// Filter state (write)
+		setSearchTasks,
+		setPriority,
+		setLabels,
+		setSizes,
+		setIssues: handleSetIssues,
+		setEpics
+	};
+}
+
+/** Return type of useKanbanFilters for external typing */
+export type TKanbanFilters = ReturnType<typeof useKanbanFilters>;
+

--- a/apps/web/core/hooks/tasks/use-kanban-filters.ts
+++ b/apps/web/core/hooks/tasks/use-kanban-filters.ts
@@ -7,7 +7,6 @@ import { TTask } from '@/core/types/schemas/task/task.schema';
 import { applyAllFilters } from '@/core/lib/utils';
 import { DEFAULT_ISSUES_STATE } from '@/core/constants/config/constants';
 
-// ==================== HOOK ====================
 
 /**
  * Hook that manages kanban filter state and applies filters to tasks.
@@ -22,7 +21,6 @@ import { DEFAULT_ISSUES_STATE } from '@/core/constants/config/constants';
  * @returns Filtered tasks and all filter state setters
  */
 export function useKanbanFilters(tasks: TTask[], isDataLoading: boolean) {
-	// ==================== FILTER STATE ====================
 	const [searchTasks, setSearchTasks] = useState('');
 	const [labels, setLabels] = useState<string[]>([]);
 	const [epics, setEpics] = useState<string[]>([]);
@@ -31,13 +29,11 @@ export function useKanbanFilters(tasks: TTask[], isDataLoading: boolean) {
 	const [sizes, setSizes] = useState<string[]>([]);
 	const employee = useSearchParams().get('employee');
 
-	// ==================== STABLE SETTER REFERENCES ====================
 	// React setState is already stable, but we wrap setIssues for type safety
 	const handleSetIssues = useCallback((updater: TStatusItem | ((prev: TStatusItem) => TStatusItem)) => {
 		setIssues(updater);
 	}, []);
 
-	// ==================== FILTERED TASKS ====================
 	const filteredTasks = useMemo(() => {
 		if (isDataLoading) {
 			return [];

--- a/apps/web/core/hooks/tasks/use-kanban.ts
+++ b/apps/web/core/hooks/tasks/use-kanban.ts
@@ -1,37 +1,91 @@
-import { kanbanBoardState } from '@/core/stores/integrations/kanban';
 import { useTaskStatusesQuery } from '../tasks/use-task-statuses-query';
 import { useEditTaskStatus } from '../tasks/use-edit-task-status';
-import { useAtom } from 'jotai';
 import { useEffect, useState, useMemo, useCallback, useOptimistic, startTransition } from 'react';
-import { useSearchParams } from 'next/navigation';
 import { useUpdateTask, useTeamTasksQuery } from '../organizations';
-import { TStatusItem } from '@/core/types/interfaces/task/task-card';
 import { TTaskStatus } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
+import { useKanbanFilters } from './use-kanban-filters';
 
 export interface IKanban {
 	[key: string]: TTask[];
 }
 
+/**
+ * Builds a kanban board by grouping tasks by their status.
+ * Pure function — no side effects, easily testable.
+ */
+function buildKanbanBoard(filteredTasks: TTask[], taskStatuses: TTaskStatus[]): IKanban {
+	const board: IKanban = {};
+	for (const status of taskStatuses) {
+		const key = status.name ?? '';
+		board[key] = filteredTasks.filter((task) => task.taskStatusId === status.id);
+	}
+	return board;
+}
+
+/**
+ * Main Kanban board hook.
+ *
+ * Responsibilities:
+ * - Board construction (grouping filtered tasks by status into columns via useMemo)
+ * - Local board state for drag/drop mutations (useState, synced from computed board)
+ * - Column management with optimistic updates (collapse/expand, reorder)
+ * - Task status updates (drag & drop between columns)
+ * - Adding new tasks to the board
+ *
+ * Filtering logic is delegated to `useKanbanFilters`.
+ * No global state (Jotai atom removed) — board state is local to the hook instance.
+ */
 export function useKanban() {
-	const [loading, setLoading] = useState<boolean>(true);
-	const [searchTasks, setSearchTasks] = useState('');
-	const [labels, setLabels] = useState<string[]>([]);
-	const [epics, setEpics] = useState<string[]>([]);
-	const [issues, setIssues] = useState<TStatusItem>({
-		name: 'Issues',
-		icon: null,
-		bgColor: '',
-		value: ''
-	});
-	const [kanbanBoard, setKanbanBoard] = useAtom(kanbanBoardState);
 	const { taskStatuses, getTaskStatusesLoading, setTaskStatuses } = useTaskStatusesQuery();
 	const { editTaskStatus } = useEditTaskStatus();
 	const { updateTask } = useUpdateTask();
-	const { tasks: newTask, tasksFetching } = useTeamTasksQuery();
-	const [priority, setPriority] = useState<string[]>([]);
-	const [sizes, setSizes] = useState<string[]>([]);
-	const employee = useSearchParams().get('employee');
+	const { tasks: newTask } = useTeamTasksQuery();
+
+	// ==================== FILTERING (delegated) ====================
+	// IMPORTANT: Only use `getTaskStatusesLoading` (React Query's `isLoading` = isPending && isFetching).
+	// This is true ONLY on the initial load when no cached data exists, and stays false during
+	// background refetches. Using `tasksFetching` (isFetching) here would cause the board to
+	// flash empty on every refetch because isFetching goes true→false→true→false during
+	// the loadTeamTasksData() → refetch() cycle, while Jotai sync is still pending.
+	const isDataLoading = getTaskStatusesLoading;
+	const {
+		filteredTasks,
+		searchTasks,
+		issues,
+		setSearchTasks,
+		setPriority,
+		setLabels,
+		setSizes,
+		setIssues,
+		setEpics
+	} = useKanbanFilters(newTask, isDataLoading);
+
+	// ==================== BOARD CONSTRUCTION (derived state) ====================
+
+	// Computed board: the "source of truth" derived from filtered tasks + statuses.
+	// useMemo → synchronous, no intermediate empty-render, no race condition.
+	const computedBoard = useMemo<IKanban>(() => {
+		if (isDataLoading) return {};
+		return buildKanbanBoard(filteredTasks, taskStatuses);
+	}, [filteredTasks, taskStatuses, isDataLoading]);
+
+	// Drag/drop override: only set when user performs a drag/drop operation.
+	// null = use computedBoard (server truth), non-null = use optimistic drag/drop state.
+	// This avoids the useState+useEffect sync pattern that caused a one-render delay
+	// where data={} was returned before the useEffect could sync.
+	const [dragDropOverride, setDragDropOverride] = useState<IKanban | null>(null);
+
+	// Reset drag/drop override when server data changes (new computedBoard).
+	// After server confirms the drag/drop, computedBoard updates → override clears.
+	useEffect(() => {
+		setDragDropOverride(null);
+	}, [computedBoard]);
+
+	// The board to render: use drag/drop override if active, otherwise computed board.
+	const kanbanBoard = dragDropOverride ?? computedBoard;
+
+	// ==================== OPTIMISTIC COLUMN STATE ====================
 
 	// Optimistic state for column collapse/expand operations only
 	const [optimisticColumnStates, setOptimisticColumnStates] = useOptimistic(
@@ -60,109 +114,6 @@ export function useKanban() {
 			return status;
 		});
 	}, [taskStatuses, optimisticColumnStates]);
-
-	// Memoized filter functions for better performance
-	const filterBySearch = useCallback(
-		(task: TTask) => {
-			return task.title.toLowerCase().includes(searchTasks.toLowerCase());
-		},
-		[searchTasks]
-	);
-
-	const filterByPriority = useCallback(
-		(task: TTask) => {
-			return priority.length ? priority.includes(task.priority as string) : true;
-		},
-		[priority]
-	);
-
-	const filterByIssue = useCallback(
-		(task: TTask) => {
-			return issues.value ? task.issueType === issues.value : true;
-		},
-		[issues.value]
-	);
-
-	const filterBySize = useCallback(
-		(task: TTask) => {
-			return sizes.length ? sizes.includes(task.size as string) : true;
-		},
-		[sizes]
-	);
-
-	const filterByLabels = useCallback(
-		(task: TTask) => {
-			return labels.length ? labels.some((label) => task.tags?.some((tag) => tag.name === label)) : true;
-		},
-		[labels]
-	);
-
-	const filterByEpics = useCallback(
-		(task: TTask) => {
-			return epics.length ? epics.includes(task.id) : true;
-		},
-		[epics]
-	);
-
-	const filterByEmployee = useCallback(
-		(task: TTask) => {
-			if (employee) {
-				return task.members?.map((el) => el.fullName).includes(employee as string);
-			}
-			return true;
-		},
-		[employee]
-	);
-
-	// Memoized filtered tasks to prevent unnecessary recalculations
-	const filteredTasks = useMemo(() => {
-		if (getTaskStatusesLoading || tasksFetching) {
-			return [];
-		}
-
-		return newTask
-			.filter(filterBySearch)
-			.filter(filterByPriority)
-			.filter(filterByIssue)
-			.filter(filterBySize)
-			.filter(filterByLabels)
-			.filter(filterByEpics)
-			.filter(filterByEmployee);
-	}, [
-		newTask,
-		filterBySearch,
-		filterByPriority,
-		filterByIssue,
-		filterBySize,
-		filterByLabels,
-		filterByEpics,
-		filterByEmployee,
-		getTaskStatusesLoading,
-		tasksFetching
-	]);
-
-	useEffect(() => {
-		if (!getTaskStatusesLoading && !tasksFetching) {
-			setLoading(true);
-			let kanban = {};
-			const getTasksByStatus = (status: string | undefined) => {
-				return filteredTasks.filter((task: TTask) => {
-					return task.taskStatusId === status;
-				});
-			};
-
-			// Use the base taskStatuses for kanban board construction to avoid infinite loops
-			taskStatuses.map((taskStatus: TTaskStatus) => {
-				kanban = {
-					...kanban,
-					[taskStatus.name ? taskStatus.name : '']: getTasksByStatus(taskStatus.id)
-				};
-			});
-			setKanbanBoard(kanban);
-			setLoading(false);
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [getTaskStatusesLoading, tasksFetching, filteredTasks, taskStatuses]);
 
 	/**
 	 * collapse or show kanban column with optimistic updates
@@ -309,17 +260,33 @@ export function useKanban() {
 		},
 		[setOptimisticColumnStates, taskStatuses, editTaskStatus, setTaskStatuses]
 	);
-	const addNewTask = (task: TTask, status: string) => {
-		const updatedBoard = {
-			...kanbanBoard,
-			[status]: [...kanbanBoard[status], task]
-		};
-		setKanbanBoard(() => updatedBoard);
-	};
+	// Wrapper for drag/drop board updates — sets the override so the UI
+	// reflects the optimistic state until server data catches up.
+	const updateKanbanBoard = useCallback(
+		(updater: IKanban | ((prev: IKanban) => IKanban)) => {
+			setDragDropOverride((prev) => {
+				const current = prev ?? computedBoard;
+				return typeof updater === 'function' ? updater(current) : updater;
+			});
+		},
+		[computedBoard]
+	);
+
+	const addNewTask = useCallback(
+		(task: TTask, status: string) => {
+			updateKanbanBoard((prev) => ({
+				...prev,
+				[status]: [...(prev[status] ?? []), task]
+			}));
+		},
+		[updateKanbanBoard]
+	);
+
 	return {
 		data: kanbanBoard as IKanban,
-		isLoading: loading,
+		isLoading: isDataLoading,
 		columns: optimisticTaskStatuses, // Use memoized optimistic state for instant UI updates
+		taskStatuses, // Raw statuses for status ID lookup (e.g., drag/drop status resolution)
 		searchTasks,
 		issues,
 		setPriority,
@@ -327,7 +294,7 @@ export function useKanban() {
 		setSizes,
 		setIssues,
 		setEpics,
-		updateKanbanBoard: setKanbanBoard,
+		updateKanbanBoard,
 		updateTaskStatus: updateTask,
 		toggleColumn,
 		isColumnCollapse,

--- a/apps/web/core/hooks/tasks/use-kanban.ts
+++ b/apps/web/core/hooks/tasks/use-kanban.ts
@@ -28,8 +28,6 @@ export function useKanban() {
 	const { updateTask } = useUpdateTask();
 	const { tasks: newTask } = useTeamTasksQuery();
 
-	// ==================== FILTERING (delegated) ====================
-	// IMPORTANT: Only use `getTaskStatusesLoading` (React Query's `isLoading` = isPending && isFetching).
 	// This is true ONLY on the initial load when no cached data exists, and stays false during
 	// background refetches. Using `tasksFetching` (isFetching) here would cause the board to
 	// flash empty on every refetch because isFetching goes true→false→true→false during
@@ -48,7 +46,6 @@ export function useKanban() {
 		setEpics
 	} = useKanbanFilters(newTask, isDataLoading);
 
-	// ==================== BOARD CONSTRUCTION (derived state) ====================
 
 	// Computed board: the "source of truth" derived from filtered tasks + statuses.
 	// useMemo → synchronous, no intermediate empty-render, no race condition.
@@ -72,7 +69,6 @@ export function useKanban() {
 	// The board to render: use drag/drop override if active, otherwise computed board.
 	const kanbanBoard = dragDropOverride ?? computedBoard;
 
-	// ==================== OPTIMISTIC COLUMN STATE ====================
 
 	// Optimistic state for column collapse/expand operations only
 	const [optimisticColumnStates, setOptimisticColumnStates] = useOptimistic(

--- a/apps/web/core/hooks/tasks/use-kanban.ts
+++ b/apps/web/core/hooks/tasks/use-kanban.ts
@@ -5,23 +5,9 @@ import { useUpdateTask, useTeamTasksQuery } from '../organizations';
 import { TTaskStatus } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { useKanbanFilters } from './use-kanban-filters';
+import { IKanban } from '@/core/types/interfaces/task/task';
+import { buildKanbanBoard } from '@/core/lib/utils';
 
-export interface IKanban {
-	[key: string]: TTask[];
-}
-
-/**
- * Builds a kanban board by grouping tasks by their status.
- * Pure function — no side effects, easily testable.
- */
-function buildKanbanBoard(filteredTasks: TTask[], taskStatuses: TTaskStatus[]): IKanban {
-	const board: IKanban = {};
-	for (const status of taskStatuses) {
-		const key = status.name ?? '';
-		board[key] = filteredTasks.filter((task) => task.taskStatusId === status.id);
-	}
-	return board;
-}
 
 /**
  * Main Kanban board hook.
@@ -53,6 +39,7 @@ export function useKanban() {
 		filteredTasks,
 		searchTasks,
 		issues,
+		epics,
 		setSearchTasks,
 		setPriority,
 		setLabels,
@@ -289,6 +276,7 @@ export function useKanban() {
 		taskStatuses, // Raw statuses for status ID lookup (e.g., drag/drop status resolution)
 		searchTasks,
 		issues,
+		epics,
 		setPriority,
 		setLabels,
 		setSizes,

--- a/apps/web/core/lib/utils/index.ts
+++ b/apps/web/core/lib/utils/index.ts
@@ -4,3 +4,4 @@ export * from './scroll-to-element';
 export * from './queue';
 export * from './wait';
 export * from './http';
+export * from './kanban'

--- a/apps/web/core/lib/utils/kanban.ts
+++ b/apps/web/core/lib/utils/kanban.ts
@@ -2,25 +2,25 @@ import { IKanban, KanbanFilterCriteria } from "@/core/types/interfaces/task/task
 import { TTaskStatus } from "@/core/types/schemas";
 import { TTask } from "@/core/types/schemas/task/task.schema";
 
-export const matchesSearch = (task: TTask, search: string): boolean =>
+const matchesSearch = (task: TTask, search: string): boolean =>
 	task.title.toLowerCase().includes(search.toLowerCase());
 
-export const matchesPriority = (task: TTask, priority: string[]): boolean =>
+const matchesPriority = (task: TTask, priority: string[]): boolean =>
 	priority.length === 0 || priority.includes(task.priority as string);
 
-export const matchesIssue = (task: TTask, issueValue: string | undefined): boolean =>
+const matchesIssue = (task: TTask, issueValue: string | undefined): boolean =>
 	!issueValue || task.issueType === issueValue;
 
-export const matchesSize = (task: TTask, sizes: string[]): boolean =>
+const matchesSize = (task: TTask, sizes: string[]): boolean =>
 	sizes.length === 0 || sizes.includes(task.size as string);
 
-export const matchesLabels = (task: TTask, labels: string[]): boolean =>
+const matchesLabels = (task: TTask, labels: string[]): boolean =>
 	labels.length === 0 || labels.some((label) => task.tags?.some((tag) => tag.name === label));
 
-export const matchesEpics = (task: TTask, epics: string[]): boolean =>
+const matchesEpics = (task: TTask, epics: string[]): boolean =>
 	epics.length === 0 || epics.includes(task.id);
 
-export const matchesEmployee = (task: TTask, employee: string | null): boolean =>
+const matchesEmployee = (task: TTask, employee: string | null): boolean =>
 	!employee || (task.members?.map((el) => el.fullName).includes(employee) ?? false);
 
 

--- a/apps/web/core/lib/utils/kanban.ts
+++ b/apps/web/core/lib/utils/kanban.ts
@@ -1,0 +1,47 @@
+
+// ==================== PURE FILTER FUNCTIONS ====================
+// These are pure functions (no hooks, no side effects) for testability and reusability.
+
+import { KanbanFilterCriteria } from "@/core/types/interfaces/task/task";
+import { TTask } from "@/core/types/schemas/task/task.schema";
+
+export const matchesSearch = (task: TTask, search: string): boolean =>
+	task.title.toLowerCase().includes(search.toLowerCase());
+
+export const matchesPriority = (task: TTask, priority: string[]): boolean =>
+	priority.length === 0 || priority.includes(task.priority as string);
+
+export const matchesIssue = (task: TTask, issueValue: string | undefined): boolean =>
+	!issueValue || task.issueType === issueValue;
+
+export const matchesSize = (task: TTask, sizes: string[]): boolean =>
+	sizes.length === 0 || sizes.includes(task.size as string);
+
+export const matchesLabels = (task: TTask, labels: string[]): boolean =>
+	labels.length === 0 || labels.some((label) => task.tags?.some((tag) => tag.name === label));
+
+export const matchesEpics = (task: TTask, epics: string[]): boolean =>
+	epics.length === 0 || epics.includes(task.id);
+
+export const matchesEmployee = (task: TTask, employee: string | null): boolean =>
+	!employee || (task.members?.map((el) => el.fullName).includes(employee) ?? false);
+
+
+/**
+ * Applies all kanban filters to a list of tasks in a single pass.
+ * Single-pass filtering is more performant than chaining .filter() calls
+ * because it avoids creating intermediate arrays.
+ */
+export function applyAllFilters(tasks: TTask[], criteria: KanbanFilterCriteria): TTask[] {
+	const { search, priority, issueValue, sizes, labels, epics, employee } = criteria;
+	return tasks.filter(
+		(task) =>
+			matchesSearch(task, search) &&
+			matchesPriority(task, priority) &&
+			matchesIssue(task, issueValue) &&
+			matchesSize(task, sizes) &&
+			matchesLabels(task, labels) &&
+			matchesEpics(task, epics) &&
+			matchesEmployee(task, employee)
+	);
+}

--- a/apps/web/core/lib/utils/kanban.ts
+++ b/apps/web/core/lib/utils/kanban.ts
@@ -2,7 +2,8 @@
 // ==================== PURE FILTER FUNCTIONS ====================
 // These are pure functions (no hooks, no side effects) for testability and reusability.
 
-import { KanbanFilterCriteria } from "@/core/types/interfaces/task/task";
+import { IKanban, KanbanFilterCriteria } from "@/core/types/interfaces/task/task";
+import { TTaskStatus } from "@/core/types/schemas";
 import { TTask } from "@/core/types/schemas/task/task.schema";
 
 export const matchesSearch = (task: TTask, search: string): boolean =>
@@ -44,4 +45,17 @@ export function applyAllFilters(tasks: TTask[], criteria: KanbanFilterCriteria):
 			matchesEpics(task, epics) &&
 			matchesEmployee(task, employee)
 	);
+}
+
+/**
+ * Builds a kanban board by grouping tasks by their status.
+ * Pure function — no side effects, easily testable.
+ */
+export function buildKanbanBoard(filteredTasks: TTask[], taskStatuses: TTaskStatus[]): IKanban {
+	const board: IKanban = {};
+	for (const status of taskStatuses) {
+		const key = status.name ?? '';
+		board[key] = filteredTasks.filter((task) => task.taskStatusId === status.id);
+	}
+	return board;
 }

--- a/apps/web/core/lib/utils/kanban.ts
+++ b/apps/web/core/lib/utils/kanban.ts
@@ -1,7 +1,3 @@
-
-// ==================== PURE FILTER FUNCTIONS ====================
-// These are pure functions (no hooks, no side effects) for testability and reusability.
-
 import { IKanban, KanbanFilterCriteria } from "@/core/types/interfaces/task/task";
 import { TTaskStatus } from "@/core/types/schemas";
 import { TTask } from "@/core/types/schemas/task/task.schema";

--- a/apps/web/core/stores/integrations/index.ts
+++ b/apps/web/core/stores/integrations/index.ts
@@ -2,4 +2,3 @@ export * from './integration';
 export * from './integration-github';
 export * from './integration-tenant';
 export * from './integration-types';
-export * from './kanban';

--- a/apps/web/core/stores/integrations/kanban.ts
+++ b/apps/web/core/stores/integrations/kanban.ts
@@ -1,4 +1,0 @@
-import { atom } from 'jotai';
-import { IKanban } from '@/core/hooks/tasks/use-kanban';
-
-export const kanbanBoardState = atom<IKanban>({});

--- a/apps/web/core/types/interfaces/task/task.ts
+++ b/apps/web/core/types/interfaces/task/task.ts
@@ -84,3 +84,14 @@ export interface ICreateTask {
 	tenantId: string;
 	projectId?: string | null;
 }
+
+/** Filter criteria passed to applyAllFilters */
+export interface KanbanFilterCriteria {
+	search: string;
+	priority: string[];
+	issueValue: string | undefined;
+	sizes: string[];
+	labels: string[];
+	epics: string[];
+	employee: string | null;
+}

--- a/apps/web/core/types/interfaces/task/task.ts
+++ b/apps/web/core/types/interfaces/task/task.ts
@@ -1,4 +1,5 @@
 import { ETaskPriority, ETaskSize, ETaskStatusName, EIssueType } from '../../generics/enums/task';
+import { TTask } from '../../schemas/task/task.schema';
 import { IBasePerTenantAndOrganizationEntityModel, ID, ITaggable } from '../common/base-interfaces';
 import { IEmployee } from '../organization/employee';
 import { IRelationalOrganizationProject } from '../project/organization-project';
@@ -8,6 +9,7 @@ import { ITaskLinkedIssue } from './task-linked-issue';
 import { ITaskPriority } from './task-priority';
 import { ITaskSize } from './task-size';
 import { ITaskStatus } from './task-status/task-status';
+import { TTaskStatus } from '../../schemas';
 
 export interface IBaseTaskProperties extends IBasePerTenantAndOrganizationEntityModel {
 	title: string;
@@ -94,4 +96,35 @@ export interface KanbanFilterCriteria {
 	labels: string[];
 	epics: string[];
 	employee: string | null;
+}
+
+/**
+ * Props for KanbanView — all data & operations received from parent.
+ * No internal hook calls → pure prop-driven component.
+ */
+export interface KanbanViewProps {
+	/** Board data: tasks grouped by status column name */
+	kanbanBoardTasks: IKanban;
+	/** Whether board data is still loading */
+	isLoading: boolean;
+	/** Task status columns with optimistic state applied */
+	kanbanColumns: TTaskStatus[];
+	/** All task statuses (for status ID lookup during drag/drop) */
+	taskStatuses: TTaskStatus[];
+	/** Setter to update the board after drag/drop operations */
+	updateKanbanBoard: (board: IKanban | ((prev: IKanban) => IKanban)) => void;
+	/** API call to update a task's status on the server */
+	updateTaskStatus: (task: TTask) => void;
+	/** Check if a column is collapsed */
+	isColumnCollapse: (column: string) => boolean | undefined;
+	/** API call to reorder a column */
+	reorderStatus: (itemStatus: string, index: number) => Promise<void>;
+	/** Add a new task to the board */
+	addNewTask: (task: TTask, status: string) => void;
+	/** Toggle column collapse/expand */
+	toggleColumn: (column: string, status: boolean) => Promise<void>;
+}
+
+export interface IKanban {
+	[key: string]: TTask[];
 }


### PR DESCRIPTION
# [ETP-226](https://evertech.atlassian.net/browse/ETP-226): Refactor useKanban Extract Filtering Logic to Selectors

## Description

The `useKanban` hook (~340 lines) was a monolith mixing three distinct concerns: filtering engine (7 filter functions), board construction, and UI state management (column collapse/expand, drag & drop, optimistic updates). This made it hard to maintain and extend — adding a new filter meant touching the same file as drag & drop logic.

This PR separates those concerns:

- **Filtering** → extracted to a dedicated `useKanbanFilters` hook
- **Pure filter functions** → moved to `core/lib/utils/kanban.ts` (testable, no React dependency)
- **Board construction** → `buildKanbanBoard()` pure function, also in `kanban.ts`
- **Global Jotai atom removed** → board state is now local to the hook (no shared mutable state)
- **KanbanView** → made fully prop-driven (no internal `useKanban()` call)
- **Date tab filters** (All / Today / Yesterday / Tomorrow) → now functional, default tab set to "All"

The hook went from ~340 lines down to ~295 lines with clearer separation of responsibilities.

## What Was Changed

### Major Changes

- **New `useKanbanFilters` hook** (`core/hooks/tasks/use-kanban-filters.ts`): owns all filter state (`search`, `priority`, `labels`, `sizes`, `epics`, `issues`, `employee`) and returns `filteredTasks` via a single-pass `useMemo`
- **New `core/lib/utils/kanban.ts`**: 7 pure filter functions (`matchesSearch`, `matchesPriority`, `matchesIssue`, `matchesSize`, `matchesLabels`, `matchesEpics`, `matchesEmployee`), `applyAllFilters()` single-pass filter, and `buildKanbanBoard()` pure function
- **Removed Jotai `kanbanBoardState` atom** (`core/stores/integrations/kanban.ts` deleted): board state is now derived via `useMemo` inside `useKanban` — no more global mutable atom
- **`useKanban` simplified**: consumes `useKanbanFilters`, builds the board with `useMemo`, uses a `dragDropOverride` pattern for optimistic drag & drop state instead of `useState` + `useEffect` sync
- **`KanbanView` is now prop-driven**: receives all data and callbacks via `KanbanViewProps` interface — no internal hook instance, single source of truth from `page.tsx`
- **New TypeScript interfaces** (`core/types/interfaces/task/task.ts`): `IKanban`, `KanbanViewProps`, `KanbanFilterCriteria` — moved from inline definitions to shared types

### Minor Changes

- **`DEFAULT_ISSUES_STATE`** moved to `core/constants/config/constants.tsx`
- **`KanbanTabs` enum** added to constants (`ALL`, `TODAY`, `YESTERDAY`, `TOMORROW`)
- **Date tab default** changed from `TODAY` to `ALL` (so the board shows all tasks on load)
- **`filteredBoard`** in `page.tsx` filters `data` by active date tab and is passed to `KanbanView`
- **`isDataLoading`** simplified to use only `getTaskStatusesLoading` (React Query's `isLoading` = `isPending && isFetching`, only true on initial load — prevents the board from flashing empty during background refetches)
- Removed unused imports and cleaned up `search-bar.tsx` and `task-status.tsx`

## How to Test This PR

1. Run the app with `yarn web:dev`
2. Open `http://localhost:3030/en/kanban`
3. Check the following:

**Board loading:**
- The kanban board loads and displays tasks in their respective columns
- No blank screen or infinite loading state

**Date tabs (All | Today | Yesterday | Tomorrow):**
- "All" tab (default): all tasks visible in columns
- "Today" tab: only tasks created today are shown (columns may be empty if no tasks were created today — this is expected)
- "Yesterday" / "Tomorrow": same behavior filtered by date
- Switching back to "All" restores all tasks

**Sidebar filters:**
- Search by task name works
- Priority filter works
- Labels filter works
- Issue type filter works
- Epic filter works
- Size filter works
- Employee filter (via URL `?employee=Name`) works
- Clearing a filter restores the tasks

**Drag & drop:**
- Drag a task from one column to another — task moves and status updates
- Drag a task within the same column — reorders correctly
- After drag & drop, the board stays consistent (no flash or data loss)

**Column operations:**
- Collapse a column — column collapses immediately (optimistic update)
- Expand a column — column expands immediately
- Reorder columns via drag — columns reorder

## Screenshots (if needed)

No visual changes — this is a pure refactoring PR. The UI behavior is identical to before.

## Related Issues

- Closes [ETP-226](https://evertech.atlassian.net/browse/ETP-226)

## Type of Change

- [ ] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [x] Refactoring (restructures code without changing external behavior)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## Affected Files

| File | Change |
|------|--------|
| `core/hooks/tasks/use-kanban.ts` | Simplified: delegates filtering to `useKanbanFilters`, uses `useMemo` + `dragDropOverride` pattern |
| `core/hooks/tasks/use-kanban-filters.ts` | **New**: filter state management + single-pass filtering |
| `core/lib/utils/kanban.ts` | **New**: pure filter functions + `buildKanbanBoard()` |
| `core/lib/utils/index.ts` | Re-exports `kanban.ts` |
| `core/types/interfaces/task/task.ts` | Added `IKanban`, `KanbanViewProps`, `KanbanFilterCriteria` |
| `core/constants/config/constants.tsx` | Added `KanbanTabs` enum, `DEFAULT_ISSUES_STATE` |
| `core/stores/integrations/kanban.ts` | **Deleted**: global `kanbanBoardState` atom removed |
| `core/stores/integrations/index.ts` | Removed re-export of deleted store |
| `app/[locale]/(main)/kanban/page.tsx` | Single `useKanban()` instance, date tab filtering via `filteredBoard`, passes props to `KanbanView` |
| `core/components/pages/kanban/team-members-kanban-view.tsx` | Prop-driven via `KanbanViewProps`, no internal hook call |
| `core/components/pages/kanban/search-bar.tsx` | Cleaned up imports |
| `core/components/tasks/task-status.tsx` | Cleaned up imports |

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer

- **No visual regression**: the board renders exactly the same. Only the internal architecture changed.
- **`dragDropOverride` pattern**: replaces the old `useState(computedBoard)` + `useEffect` sync that caused a one-render delay where `data={}` was returned before the effect could sync. Now: `kanbanBoard = dragDropOverride ?? computedBoard` — synchronous, no empty flash.
- **`isDataLoading` uses `getTaskStatusesLoading` only** (not `tasksFetching`): React Query's `isLoading` = `isPending && isFetching` is `true` only on initial load with no cache. Using `isFetching` would cause the board to disappear during background refetches.
- **Pre-existing: `columns` state in `KanbanView`** (line 30-40) uses `useState` initialized from props at mount. It does not re-sync when `kanbanBoardTasks` changes. This is not introduced by this PR — it's a pre-existing pattern. It works because column metadata (names, icons, colors) don't change between renders, only the tasks inside each column do (via `items[column.name]`).
- **Pre-existing: Jotai sync delay**: tasks arrive from React Query → sync to Jotai atom via `useEffect` → consumed by the hook. There is a brief moment (~1-2 renders) where columns are empty before Jotai catches up. This is inherent to the current architecture, not introduced by this PR.
- **Date filtering uses `createdAt`**: the Today/Yesterday/Tomorrow tabs filter tasks by their `createdAt` date. If this should be `updatedAt` or `dueDate` instead, that's a separate discussion.


[ETP-226]: https://evertech.atlassian.net/browse/ETP-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ETP-226]: https://evertech.atlassian.net/browse/ETP-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Kanban board to separate filtering from board/UI logic, remove global state, and make the view prop-driven. Aligns with ETP-226; simpler code, testable filters, steadier loading, and “All” is now the default date tab.

- **Refactors**
  - Introduced useKanbanFilters for all filter state and single-pass filtering via applyAllFilters.
  - Added pure utils in core/lib/utils/kanban.ts (applyAllFilters, buildKanbanBoard), now const-based for consistency.
  - Removed Jotai kanbanBoardState; board is derived with useMemo and an optimistic dragDropOverride.
  - Made KanbanView fully prop-driven; page passes columns, taskStatuses, and board handlers.
  - Added KanbanTabs.ALL and DEFAULT_ISSUES_STATE; improved tabs and compact h-8 controls; search bar accepts className; Epic dropdown uses MultipleStatusDropdown with defaultValues; dropdown onChange supports string|string[]; minor style cleanups and deepscan fixes.

- **Migration**
  - Update KanbanView usage to pass: kanbanBoardTasks, kanbanColumns, taskStatuses, updateKanbanBoard, updateTaskStatus, isColumnCollapse, reorderStatus, addNewTask, toggleColumn.
  - Remove references to the deleted Jotai kanban store; import shared types from core/types/interfaces/task/task.
  - “All” loads by default for date tabs; no other action required.

<sup>Written for commit 723a652af95ea173e4bf69b16a0b7add7eb6be36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "All" tab to filter and display all tasks in the Kanban board.

* **Improvements**
  * Enhanced Kanban board header and controls with improved styling and layout.
  * Improved search functionality with better styling flexibility.
  * Enhanced task status dropdown to support more flexible selection handling.
  * Better visual organization of filters and controls for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->