### PR TITLE
feat(tasks): virtualize task list with TanStack Virtual to fix ETP-218

### DIFF
--- a/apps/web/core/components/layouts/default-layout/main-layout.tsx
+++ b/apps/web/core/components/layouts/default-layout/main-layout.tsx
@@ -214,6 +214,7 @@ export function MainLayout({
 								>
 									{headerHeight && (
 										<div
+											data-layout="main-scroll-offset"
 											className="w-full"
 											style={{
 												height: `${headerHeight + (mainHeaderSlot ? -30 : 0)}px`

--- a/apps/web/core/components/pages/profile/user-profile-tasks.tsx
+++ b/apps/web/core/components/pages/profile/user-profile-tasks.tsx
@@ -6,7 +6,6 @@ import { ComponentProps, memo, Suspense, useCallback, useEffect, useMemo, useSta
 import { cn } from '@/core/lib/helpers';
 import { ITEMS_LENGTH_TO_VIRTUALIZED } from '@/core/constants/config/constants';
 import { useTaskFilterCache } from '@/core/hooks/common/use-memoized-cache';
-import { useEnhancedVirtualization } from '@/core/hooks/common/use-tanstack-virtual';
 import { UserProfilePlans } from '@/core/components/users/user-profile-plans';
 import { EmptyPlans } from '@/core/components/daily-plan';
 import { TUser } from '@/core/types/schemas';
@@ -143,16 +142,14 @@ export const UserProfileTask = memo(
 					</div>
 				)}
 
-				{tabFiltered.tab !== 'dailyplan' &&
-					(useVirtualization && otherTasks.length > ITEMS_LENGTH_TO_VIRTUALIZED ? (
-						<TanStackVirtualizedTaskList
-							tasks={otherTasks as TTask[]}
-							tabFiltered={tabFiltered}
-							profile={profile}
-						/>
-					) : (
-						<TaskList slicedItems={otherTasks as TTask[]} tabFiltered={tabFiltered} profile={profile} />
-					))}
+				{tabFiltered.tab !== 'dailyplan' && (
+					<TaskList
+						enableVirtualization={useVirtualization || otherTasks.length > ITEMS_LENGTH_TO_VIRTUALIZED}
+						items={otherTasks as TTask[]}
+						tabFiltered={tabFiltered}
+						profile={profile}
+					/>
+				)}
 			</div>
 		);
 	}
@@ -188,17 +185,21 @@ const DeferredTaskCard = memo((props: ComponentProps<typeof LazyTaskCard>) => {
 
 	return <LazyTaskCard {...props} />;
 });
+DeferredTaskCard.displayName = 'DeferredTaskCard';
 
+const LIST_GAP = 16;
 // Optimized TaskList component to prevent unnecessary re-renders
 const TaskList = memo(
 	({
-		slicedItems,
+		items,
 		tabFiltered,
-		profile
+		profile,
+		enableVirtualization
 	}: {
-		slicedItems: TTask[];
+		items: TTask[];
 		tabFiltered: I_TaskFilter;
 		profile: I_UserProfilePage;
+		enableVirtualization?: boolean;
 	}) => {
 		// Track the offset element height dynamically
 		const [scrollMargin, setScrollMargin] = useState(0);
@@ -208,13 +209,13 @@ const TaskList = memo(
 
 		const isAuthUser = useMemo(() => profile.isAuthUser, [profile.isAuthUser]);
 
-		const LIST_GAP = 16;
 		// Virtualizer with options
 		const virtualiser = useWindowVirtualizer({
-			count: slicedItems?.length ?? 0,
-			estimateSize: () => 175 + LIST_GAP,
+			count: items?.length ?? 0,
+			estimateSize: () => 112 + LIST_GAP,
 			overscan: 4,
-			scrollMargin
+			scrollMargin,
+			enabled: enableVirtualization
 		});
 
 		useEffect(() => {
@@ -249,7 +250,7 @@ const TaskList = memo(
 			tabFiltered.tab === 'worked' &&
 			(profile.member?.employee?.isTrackingTime || (profile.isAuthUser && profile.activeUserTeamTask));
 
-		if (slicedItems.length === 0) {
+		if (items.length === 0) {
 			// Only show EmptyPlans for task-related tabs, not for dailyplan or stats
 			if (tabFiltered.tab === 'stats' || tabFiltered.tab === 'dailyplan') {
 				return null;
@@ -274,7 +275,7 @@ const TaskList = memo(
 				}}
 			>
 				{virtualiser.getVirtualItems().map((virtualItem) => {
-					const task = slicedItems[virtualItem.index];
+					const task = items[virtualItem.index];
 					return (
 						<li
 							key={virtualItem.key}
@@ -308,111 +309,3 @@ const TaskList = memo(
 );
 
 TaskList.displayName = 'TaskList';
-
-// TanStack Virtualized TaskList for large datasets
-const TanStackVirtualizedTaskList = memo(
-	({ tasks, tabFiltered, profile }: { tasks: TTask[]; tabFiltered: I_TaskFilter; profile: I_UserProfilePage }) => {
-		const containerHeight = 600; // Adjust based on your layout
-		const itemHeight = 120; // Approximate height of each TaskCard
-
-		const virtualizationResult = useEnhancedVirtualization(tasks, {
-			containerHeight,
-			itemHeight,
-			enabled: true,
-			useWindow: false, // Simplified: always use container virtualization for consistency
-			cacheSize: 50,
-			overscanMultiplier: 2
-		});
-
-		// Memoize computed values
-		const viewType = useMemo(() => (tabFiltered.tab === 'unassigned' ? 'unassign' : 'default'), [tabFiltered.tab]);
-
-		const isAuthUser = useMemo(() => profile.isAuthUser, [profile.isAuthUser]);
-		const getTaskBadgeClassName = useCallback(
-			(issueType: string) =>
-				cn(
-					issueType === 'Bug' ? '!px-[0.3312rem] py-[0.2875rem]' : '!px-[0.375rem] py-[0.375rem]',
-					'rounded-sm'
-				),
-			[]
-		);
-
-		// Extract repeated JSX into a separate function to adhere to DRY principle
-		const renderVirtualItem = useCallback(
-			(virtualItem: any) => (
-				<div
-					key={virtualItem.key}
-					style={{
-						position: 'absolute',
-						top: 0,
-						left: 0,
-						width: '100%',
-						height: `${virtualItem.size}px`,
-						transform: `translateY(${virtualItem.start}px)`
-					}}
-				>
-					<div className="px-1 pb-4">
-						<LazyTaskCard
-							task={virtualItem.item}
-							isAuthUser={isAuthUser}
-							activeAuthTask={false}
-							viewType={viewType}
-							profile={profile}
-							taskBadgeClassName={getTaskBadgeClassName(virtualItem.item.issueType || '')}
-							taskTitleClassName="mt-[0.0625rem]"
-						/>
-					</div>
-				</div>
-			),
-			[isAuthUser, viewType, profile, getTaskBadgeClassName]
-		);
-
-		const { virtualItems, isScrolling } = virtualizationResult;
-
-		// Simplified: always use container virtualization since useWindow is false
-		const parentRef = 'parentRef' in virtualizationResult ? virtualizationResult.parentRef : null;
-		const containerStyle =
-			'containerStyle' in virtualizationResult
-				? virtualizationResult.containerStyle
-				: { height: containerHeight, overflow: 'auto' as const };
-		const innerStyle =
-			'innerStyle' in virtualizationResult
-				? virtualizationResult.innerStyle
-				: { height: virtualizationResult.totalSize, width: '100%', position: 'relative' as const };
-
-		// Handle empty state
-		if (tasks.length === 0) {
-			// Only show EmptyPlans for task-related tabs, not for dailyplan or stats
-			if (tabFiltered.tab === 'stats' || tabFiltered.tab === 'dailyplan') {
-				return null;
-			}
-
-			// Don't show EmptyPlans if there's an active task displayed above
-			const hasActiveTask =
-				tabFiltered.tab === 'worked' &&
-				(profile.member?.employee?.isTrackingTime || (profile.isAuthUser && profile.activeUserTeamTask));
-
-			if (hasActiveTask) {
-				return null; // Active task is already shown, no need for empty state
-			}
-
-			// Show appropriate empty state based on tab
-			const planMode = tabFiltered.tab === 'worked' ? 'Today Tasks' : 'All Tasks';
-			return <EmptyPlans planMode={planMode} />;
-		}
-
-		// Simplified container virtualization rendering
-		return (
-			<div style={containerStyle} ref={parentRef} className="custom-scrollbar">
-				<div style={innerStyle}>{virtualItems.map(renderVirtualItem)}</div>
-				{isScrolling && (
-					<div className="absolute top-2 right-2 px-2 py-1 text-xs text-white rounded-sm bg-black/50">
-						Scrolling...
-					</div>
-				)}
-			</div>
-		);
-	}
-);
-
-TanStackVirtualizedTaskList.displayName = 'TanStackVirtualizedTaskList';

--- a/apps/web/core/components/pages/profile/user-profile-tasks.tsx
+++ b/apps/web/core/components/pages/profile/user-profile-tasks.tsx
@@ -224,9 +224,9 @@ const TaskList = memo(
 
 		const isAuthUser = useMemo(() => profile.isAuthUser, [profile.isAuthUser]);
 
-		// Virtualizer with options
+		// Virtualizer with options - use 0 if items is null
 		const virtualiser = useWindowVirtualizer({
-			count: items.length,
+			count: items?.length ?? 0,
 			estimateSize: () => 112 + LIST_GAP,
 			overscan: 4,
 			scrollMargin,
@@ -260,7 +260,7 @@ const TaskList = memo(
 			[]
 		);
 
-		// Logical inconsistency - Don't show EmptyPlans if there's an active task being displayed
+		// Early return if items is null/undefined or empty
 		const hasActiveTask =
 			tabFiltered.tab === 'worked' &&
 			(profile.member?.employee?.isTrackingTime || (profile.isAuthUser && profile.activeUserTeamTask));

--- a/apps/web/core/components/pages/profile/user-profile-tasks.tsx
+++ b/apps/web/core/components/pages/profile/user-profile-tasks.tsx
@@ -29,7 +29,7 @@ type Props = {
  * @returns A component that displays a user's profile page.
  */
 export const UserProfileTask = memo(
-	({ profile, paginateTasks, tabFiltered, useVirtualization = false, user, employeeId }: Props) => {
+	({ profile, tabFiltered, useVirtualization = false, user, employeeId }: Props) => {
 		const t = useTranslations();
 		// Get current timer seconds
 		const { time, timerStatus } = useLiveTimerStatus();
@@ -86,12 +86,12 @@ export const UserProfileTask = memo(
 		]);
 
 		return (
-			<div className="flex flex-col w-full h-full mt-5">
+			<div className="flex flex-col mt-5 w-full h-full">
 				{tabFiltered.tab === 'worked' &&
 					(profile.member?.employee?.isTrackingTime || (profile.isAuthUser && timerStatus?.running)) &&
 					otherTasks.length > 0 && (
 						/* Displaying the current time. */
-						<div className="flex items-center mb-3 gap-x-2 w-fit">
+						<div className="flex gap-x-2 items-center mb-3 w-fit">
 							<Text className="font-normal">{t('common.NOW')}</Text>
 							<Divider className="flex-1" />
 							<div className="flex items-center space-x-4">
@@ -155,25 +155,40 @@ export const UserProfileTask = memo(
 	}
 );
 /**
+ * Cache to track which tasks have already been rendered.
+ * Prevents showing skeleton for tasks that were already displayed.
+ */
+const renderedTasksCache = new Set<string>();
+
+/**
  * Deferred TaskCard — shows a skeleton on FIRST frame,
  * then swaps to the real card on the NEXT frame.
  *
  * Why? Because the virtualizer mounts new items during scroll.
  * If TaskCard is heavy (50-100ms), the user sees a freeze.
  * With this wrapper, they see a skeleton instantly → no freeze.
+ *
+ * Cache optimization: Once a task has been rendered, it won't show
+ * the skeleton again when scrolling back to it. This prevents flickering.
  */
 const DeferredTaskCard = memo((props: ComponentProps<typeof LazyTaskCard>) => {
-	const [isReady, setIsReady] = useState(false);
+	const taskId = props.task?.id;
+	const wasRendered = taskId ? renderedTasksCache.has(taskId) : false;
+	const [isReady, setIsReady] = useState(wasRendered);
 
 	useEffect(() => {
+		// Skip animation frame if task was already rendered or task is null
+		if (wasRendered || !taskId) return;
+
 		// Schedule the real render for the NEXT animation frame
 		//    This lets the browser paint the placeholder FIRST
 		const frameId = requestAnimationFrame(() => {
 			setIsReady(true);
+			renderedTasksCache.add(taskId);
 		});
 
 		return () => cancelAnimationFrame(frameId);
-	}, []);
+	}, [taskId, wasRendered]);
 
 	if (!isReady) {
 		return (

--- a/apps/web/core/components/pages/profile/user-profile-tasks.tsx
+++ b/apps/web/core/components/pages/profile/user-profile-tasks.tsx
@@ -271,7 +271,7 @@ const TaskList = memo(
 				<ul className="flex flex-col gap-4">
 					{items?.map((task) => {
 						return (
-							<li key={task?.id}>
+							<li key={task.id}>
 								<LazyTaskCard
 									task={task}
 									isAuthUser={isAuthUser}

--- a/apps/web/core/components/pages/profile/user-profile-tasks.tsx
+++ b/apps/web/core/components/pages/profile/user-profile-tasks.tsx
@@ -169,7 +169,7 @@ const DeferredTaskCard = memo((props: ComponentProps<typeof LazyTaskCard>) => {
 	const [isReady, setIsReady] = useState(false);
 
 	useEffect(() => {
-		// ⭐ Schedule the real render for the NEXT animation frame
+		// Schedule the real render for the NEXT animation frame
 		//    This lets the browser paint the placeholder FIRST
 		const frameId = requestAnimationFrame(() => {
 			setIsReady(true);

--- a/apps/web/core/components/pages/profile/user-profile-tasks.tsx
+++ b/apps/web/core/components/pages/profile/user-profile-tasks.tsx
@@ -271,7 +271,7 @@ const TaskList = memo(
 				<ul className="flex flex-col gap-4">
 					{items?.map((task) => {
 						return (
-							<li>
+							<li key={task?.id}>
 								<LazyTaskCard
 									task={task}
 									isAuthUser={isAuthUser}

--- a/apps/web/core/components/pages/profile/user-profile-tasks.tsx
+++ b/apps/web/core/components/pages/profile/user-profile-tasks.tsx
@@ -2,10 +2,9 @@ import { I_UserProfilePage, useLiveTimerStatus } from '@/core/hooks';
 import { Divider, Text } from '@/core/components';
 import { I_TaskFilter } from './task-filters';
 import { useTranslations } from 'next-intl';
-import { memo, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { ComponentProps, memo, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { cn } from '@/core/lib/helpers';
 import { ITEMS_LENGTH_TO_VIRTUALIZED } from '@/core/constants/config/constants';
-import { useScrollPagination } from '@/core/hooks/common/use-pagination';
 import { useTaskFilterCache } from '@/core/hooks/common/use-memoized-cache';
 import { useEnhancedVirtualization } from '@/core/hooks/common/use-tanstack-virtual';
 import { UserProfilePlans } from '@/core/components/users/user-profile-plans';
@@ -14,6 +13,8 @@ import { TUser } from '@/core/types/schemas';
 import { TTask } from '@/core/types/schemas/task/task.schema';
 import { LazyActivityCalendar, LazyTaskCard } from '@/core/components/optimized-components';
 import { ActivityCalendarSkeleton } from '../../common/skeleton/activity-calendar-skeleton';
+import { useWindowVirtualizer } from '@tanstack/react-virtual';
+import { TaskCardSkeleton } from '../../common/skeleton/profile-component-skeletons';
 
 type Props = {
 	tabFiltered: I_TaskFilter;
@@ -30,8 +31,6 @@ type Props = {
  */
 export const UserProfileTask = memo(
 	({ profile, paginateTasks, tabFiltered, useVirtualization = false, user, employeeId }: Props) => {
-		const [scrollableContainer, setScrollableContainer] = useState<HTMLDivElement | null>(null);
-
 		const t = useTranslations();
 		// Get current timer seconds
 		const { time, timerStatus } = useLiveTimerStatus();
@@ -86,51 +85,6 @@ export const UserProfileTask = memo(
 			deferredProfile.member?.running,
 			deferredProfile.activeUserTeamTask?.id
 		]);
-
-		const { slicedItems: rawSlicedItems } = useScrollPagination({
-			enabled: !!paginateTasks && !useVirtualization,
-			items: otherTasks,
-			scrollableElement: scrollableContainer,
-			defaultItemsPerPage: 20
-		});
-
-		// FIXED Additional deduplication at slicedItems level to prevent duplicate keys
-		// This ensures no duplicate tasks reach the rendering phase
-		const slicedItems = useMemo(() => {
-			return rawSlicedItems.reduce(
-				(acc, task) => {
-					if (!acc.find((t) => t.id === task.id)) {
-						acc.push(task);
-					}
-					return acc;
-				},
-				[] as typeof rawSlicedItems
-			);
-		}, [rawSlicedItems]);
-
-		// Optimized scroll container setup with useCallback
-		const setupScrollContainer = useCallback(() => {
-			const scrollable = document.querySelector<HTMLDivElement>('div.custom-scrollbar');
-			if (scrollable && scrollable !== scrollableContainer) {
-				setScrollableContainer(scrollable);
-			}
-		}, [scrollableContainer]);
-
-		useEffect(() => {
-			setupScrollContainer();
-
-			// Setup ResizeObserver for dynamic container detection
-			const resizeObserver = new ResizeObserver(() => {
-				setupScrollContainer();
-			});
-
-			const targetElement = document.body;
-			resizeObserver.observe(targetElement);
-
-			return () => {
-				resizeObserver.disconnect();
-			};
-		}, [setupScrollContainer]);
 
 		return (
 			<div className="flex flex-col w-full h-full mt-5">
@@ -197,12 +151,43 @@ export const UserProfileTask = memo(
 							profile={profile}
 						/>
 					) : (
-						<TaskList slicedItems={slicedItems as TTask[]} tabFiltered={tabFiltered} profile={profile} />
+						<TaskList slicedItems={otherTasks as TTask[]} tabFiltered={tabFiltered} profile={profile} />
 					))}
 			</div>
 		);
 	}
 );
+/**
+ * Deferred TaskCard — shows a skeleton on FIRST frame,
+ * then swaps to the real card on the NEXT frame.
+ *
+ * Why? Because the virtualizer mounts new items during scroll.
+ * If TaskCard is heavy (50-100ms), the user sees a freeze.
+ * With this wrapper, they see a skeleton instantly → no freeze.
+ */
+const DeferredTaskCard = memo((props: ComponentProps<typeof LazyTaskCard>) => {
+	const [isReady, setIsReady] = useState(false);
+
+	useEffect(() => {
+		// ⭐ Schedule the real render for the NEXT animation frame
+		//    This lets the browser paint the placeholder FIRST
+		const frameId = requestAnimationFrame(() => {
+			setIsReady(true);
+		});
+
+		return () => cancelAnimationFrame(frameId);
+	}, []);
+
+	if (!isReady) {
+		return (
+			<div className="min-h-28">
+				<TaskCardSkeleton />
+			</div>
+		);
+	}
+
+	return <LazyTaskCard {...props} />;
+});
 
 // Optimized TaskList component to prevent unnecessary re-renders
 const TaskList = memo(
@@ -215,10 +200,39 @@ const TaskList = memo(
 		tabFiltered: I_TaskFilter;
 		profile: I_UserProfilePage;
 	}) => {
+		// Track the offset element height dynamically
+		const [scrollMargin, setScrollMargin] = useState(0);
+
 		// Memoize computed values to prevent recalculation
 		const viewType = useMemo(() => (tabFiltered.tab === 'unassigned' ? 'unassign' : 'default'), [tabFiltered.tab]);
 
 		const isAuthUser = useMemo(() => profile.isAuthUser, [profile.isAuthUser]);
+
+		const LIST_GAP = 16;
+		// Virtualizer with options
+		const virtualiser = useWindowVirtualizer({
+			count: slicedItems?.length ?? 0,
+			estimateSize: () => 175 + LIST_GAP,
+			overscan: 4,
+			scrollMargin
+		});
+
+		useEffect(() => {
+			const offsetEl = document.querySelector<HTMLElement>('[data-layout="main-scroll-offset"]');
+			if (!offsetEl) return;
+
+			const observer = new ResizeObserver((entries) => {
+				for (const entry of entries) {
+					setScrollMargin(entry.contentRect.height);
+				}
+			});
+
+			// Set initial value
+			setScrollMargin(offsetEl.getBoundingClientRect().height);
+			observer.observe(offsetEl);
+
+			return () => observer.disconnect();
+		}, []);
 
 		// Memoize the task badge class calculation
 		const getTaskBadgeClassName = useCallback(
@@ -252,20 +266,42 @@ const TaskList = memo(
 		}
 
 		return (
-			<ul className="flex flex-col gap-4">
-				{slicedItems.map((task) => (
-					<li key={task.id}>
-						<LazyTaskCard
-							task={task}
-							isAuthUser={isAuthUser}
-							activeAuthTask={false}
-							viewType={viewType}
-							profile={profile}
-							taskBadgeClassName={getTaskBadgeClassName(task.issueType || '')}
-							taskTitleClassName="mt-[0.0625rem]"
-						/>
-					</li>
-				))}
+			<ul
+				style={{
+					height: `${virtualiser.getTotalSize()}px`,
+					width: '100%',
+					position: 'relative'
+				}}
+			>
+				{virtualiser.getVirtualItems().map((virtualItem) => {
+					const task = slicedItems[virtualItem.index];
+					return (
+						<li
+							key={virtualItem.key}
+							data-index={virtualItem.index}
+							ref={virtualiser.measureElement}
+							style={{
+								position: 'absolute',
+								top: 0,
+								left: 0,
+								width: '100%',
+								transform: `translateY(${virtualItem.start - scrollMargin}px)`,
+								boxSizing: 'border-box',
+								paddingBottom: `${LIST_GAP}px`
+							}}
+						>
+							<DeferredTaskCard
+								task={task}
+								isAuthUser={isAuthUser}
+								activeAuthTask={false}
+								viewType={viewType}
+								profile={profile}
+								taskBadgeClassName={getTaskBadgeClassName(task.issueType || '')}
+								taskTitleClassName="mt-[0.0625rem]"
+							/>
+						</li>
+					);
+				})}
 			</ul>
 		);
 	}

--- a/apps/web/core/components/pages/profile/user-profile-tasks.tsx
+++ b/apps/web/core/components/pages/profile/user-profile-tasks.tsx
@@ -226,7 +226,7 @@ const TaskList = memo(
 
 		// Virtualizer with options
 		const virtualiser = useWindowVirtualizer({
-			count: items?.length ?? 0,
+			count: items.length,
 			estimateSize: () => 112 + LIST_GAP,
 			overscan: 4,
 			scrollMargin,
@@ -265,7 +265,7 @@ const TaskList = memo(
 			tabFiltered.tab === 'worked' &&
 			(profile.member?.employee?.isTrackingTime || (profile.isAuthUser && profile.activeUserTeamTask));
 
-		if (items.length === 0) {
+		if (!items || items.length === 0) {
 			// Only show EmptyPlans for task-related tabs, not for dailyplan or stats
 			if (tabFiltered.tab === 'stats' || tabFiltered.tab === 'dailyplan') {
 				return null;
@@ -284,7 +284,7 @@ const TaskList = memo(
 		if (!enableVirtualization) {
 			return (
 				<ul className="flex flex-col gap-4">
-					{items?.map((task) => {
+					{items.map((task) => {
 						return (
 							<li key={task.id}>
 								<LazyTaskCard

--- a/apps/web/core/components/pages/profile/user-profile-tasks.tsx
+++ b/apps/web/core/components/pages/profile/user-profile-tasks.tsx
@@ -266,6 +266,27 @@ const TaskList = memo(
 			return <EmptyPlans planMode={planMode} />;
 		}
 
+		if (!enableVirtualization) {
+			return (
+				<ul className="flex flex-col gap-4">
+					{items?.map((task) => {
+						return (
+							<li>
+								<LazyTaskCard
+									task={task}
+									isAuthUser={isAuthUser}
+									activeAuthTask={false}
+									viewType={viewType}
+									profile={profile}
+									taskBadgeClassName={getTaskBadgeClassName(task.issueType || '')}
+									taskTitleClassName="mt-[0.0625rem]"
+								/>
+							</li>
+						);
+					})}
+				</ul>
+			);
+		}
 		return (
 			<ul
 				style={{


### PR DESCRIPTION
# feat(tasks): virtualize task list with TanStack Virtual to fix ETP-218

## Description

Fixes **ETP-218** — Task list display was limited to 20 items, even though
all tasks were already loaded client-side.

## What Was Changed

### Minor Changes

- **Created a virtualized task list** using `useWindowVirtualizer` in
  window scroll mode (no custom scroll container needed)
- **Dynamic measurement** via `measureElement` — supports variable-height
  TaskCards without hardcoding heights
- **Gap management** via `paddingBottom` (CSS `gap` is incompatible with
  absolute positioning used by virtualizers)

## Related Issues

Please list related issues, tasks or discussions:

Example:
>
> - Closes [ETP-218](https://evertech.atlassian.net/browse/ETP-218)

## Type of Change

- [x] Bug fix (fixes a problem)
- [x] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

> `DeferredTaskCard` is a **temporary workaround** to mask the expensive
> mount cost of `TaskCard` during scroll. It works, but it's a band-aid.
>
> A follow-up PR should **optimize `TaskCard` internals** (lazy dropdowns,
> memoization, fewer re-renders) so we can remove `DeferredTaskCard`
> entirely.

## Reviewers Suggested

- `@ndekocode` for integration review


[ETP-218]: https://evertech.atlassian.net/browse/ETP-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Virtualized the profile task list with TanStack Virtual to render all tasks and keep scrolling smooth. Fixes ETP-218 so Unassigned and other tabs no longer stop at 20 items.

- **Bug Fixes**
  - Removed the 20-item pagination cap and now use stable task.id keys. All loaded tasks render without key warnings.
  - Resolved additional DeepScan issues in the task list code.

- **New Features**
  - useWindowVirtualizer with an enable/disable toggle; auto-enables past a threshold and falls back to a plain list when off.
  - Dynamic measurement via measureElement and header-aware scrollMargin using MainLayout’s data-layout="main-scroll-offset"; spacing kept via paddingBottom.
  - DeferredTaskCard shows a skeleton on first frame and caches rendered task IDs to prevent flicker when scrolling back; removed the unused paginateTasks prop.

<sup>Written for commit 6e356f54afde6901de04892a6ec06c0df8886ac5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified list rendering with an optional virtualization mode for smoother, more efficient scrolling on large task lists.
  * List API now accepts full item arrays rather than pre-sliced pages.
  * Improved empty-state behavior across tabs and active-item contexts.
  * Lightweight skeleton placeholders appear briefly before full task content to reduce perceived latency.

* **Layout**
  * Header spacer now includes a data attribute for more accurate scroll offset and layout stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->