### PR TITLE
fix(timesheet): correct date filter boundaries and section group label

### DIFF
--- a/apps/web/core/components/pages/timesheet/table-time-sheet.tsx
+++ b/apps/web/core/components/pages/timesheet/table-time-sheet.tsx
@@ -60,6 +60,8 @@ import {
 	DropdownMenuSeparator
 } from '@/core/components/common/dropdown-menu';
 import { CaretDownIcon, CaretUpIcon } from '@radix-ui/react-icons';
+import { ETimeFrequency } from '@/core/types/generics/enums/date';
+import moment from 'moment';
 
 export function DataTableTimeSheet({ data, user }: { data?: GroupedTimesheet[]; user?: TUser | null }) {
 	const accordionRef = React.useRef(null);
@@ -154,6 +156,11 @@ export function DataTableTimeSheet({ data, user }: { data?: GroupedTimesheet[]; 
 			/>
 			<div className="rounded-md">
 				{data?.map((plan, index) => {
+					console.log(plan.date);
+					const groupTitle =
+						timesheetGroupByDays === ETimeFrequency.MONTHLY
+							? moment(plan.date).format('MMM YYYY')
+							: formatDate(plan.date);
 					return (
 						<div key={index}>
 							<div
@@ -165,7 +172,7 @@ export function DataTableTimeSheet({ data, user }: { data?: GroupedTimesheet[]; 
 							>
 								<div className="flex gap-x-3">
 									{timesheetGroupByDays === 'Weekly' && <span>Week {index + 1}</span>}
-									<span>{formatDate(plan.date)}</span>
+									<span>{groupTitle}</span>
 								</div>
 								<TotalDurationByDate timesheetLog={plan.tasks} createdAt={formatDate(plan.date)} />
 							</div>

--- a/apps/web/core/components/pages/timesheet/table-time-sheet.tsx
+++ b/apps/web/core/components/pages/timesheet/table-time-sheet.tsx
@@ -156,7 +156,6 @@ export function DataTableTimeSheet({ data, user }: { data?: GroupedTimesheet[]; 
 			/>
 			<div className="rounded-md">
 				{data?.map((plan, index) => {
-					console.log(plan.date);
 					const groupTitle =
 						timesheetGroupByDays === ETimeFrequency.MONTHLY
 							? moment(plan.date).format('MMM YYYY')

--- a/apps/web/core/lib/helpers/format-date-range.ts
+++ b/apps/web/core/lib/helpers/format-date-range.ts
@@ -22,18 +22,9 @@ export function formatStartAndEndDateRange(
 	startOfDay.setUTCHours(0, 0, 0, 0);
 	const start = startOfDay.toISOString();
 
-	// Format end date to end of day (23:59:59.999Z) if it's the same day as start date
-	// or to beginning of day if it's a different day
+	// Format end date to end of day (23:59:59.999Z)
 	const endOfDay = new Date(endDateObj);
-	const isSameDay = startOfDay.toDateString() === endOfDay.toDateString();
-
-	if (isSameDay) {
-		// Set to end of day to include the entire day
-		endOfDay.setUTCHours(23, 59, 59, 999);
-	} else {
-		// Set to beginning of day for different days
-		endOfDay.setUTCHours(0, 0, 0, 0);
-	}
+	endOfDay.setUTCHours(23, 59, 59, 999);
 	const end = endOfDay.toISOString();
 
 	return { start, end };

--- a/apps/web/core/services/client/api/timesheets/time-log.service.ts
+++ b/apps/web/core/services/client/api/timesheets/time-log.service.ts
@@ -367,10 +367,10 @@ class TimeLogService extends APIService {
 	}
 
 	private dateToStartOfDay(dateInput: Date | string) {
-		const endOfDay = new Date(dateInput);
-		endOfDay.setUTCHours(0, 0, 0, 0);
+		const startOfDay = new Date(dateInput);
+		startOfDay.setUTCHours(0, 0, 0, 0);
 
-		return endOfDay;
+		return startOfDay;
 	}
 }
 

--- a/apps/web/core/services/client/api/timesheets/time-log.service.ts
+++ b/apps/web/core/services/client/api/timesheets/time-log.service.ts
@@ -30,11 +30,15 @@ import {
 
 class TimeLogService extends APIService {
 	getTimeLimitsReport = async (params: TGetTimeLimitReport): Promise<TTimeLimitReportList[]> => {
-		const query = qs.stringify({
-			...params,
-			tenantId: this.tenantId,
-			organizationId: this.organizationId
-		});
+		const convertedParams = { ...params, tenantId: this.tenantId, organizationId: this.organizationId };
+		if (params.endDate) {
+			convertedParams.endDate = this.dateToEndOfDay(params.endDate);
+		}
+		if (params.startDate) {
+			convertedParams.startDate = this.dateToStartOfDay(params.startDate);
+		}
+
+		const query = qs.stringify(convertedParams);
 
 		try {
 			const response = await this.get<TTimeLimitReportList[]>(`/timesheet/time-log/time-limit?${query}`);
@@ -64,17 +68,22 @@ class TimeLogService extends APIService {
 	 * @throws ValidationError if response data doesn't match schema
 	 */
 	getTimerLogsDailyReport = async (params: TGetTimerLogsDailyReportRequest): Promise<TTimeLogReportDaily[]> => {
+		const convertedParams = {
+			...params,
+			tenantId: this.tenantId,
+			organizationId: this.organizationId,
+			'activityLevel[start]': '0',
+			'activityLevel[end]': '100',
+			timeZone: params.timeZone || getDefaultTimezone()
+		};
+		if (params.endDate) {
+			convertedParams.endDate = this.dateToEndOfDay(params.endDate);
+		}
+		if (params.startDate) {
+			convertedParams.startDate = this.dateToStartOfDay(params.startDate);
+		}
 		try {
-			const queryParams = {
-				'activityLevel[start]': '0',
-				'activityLevel[end]': '100',
-				tenantId: this.tenantId,
-				organizationId: this.organizationId,
-				timeZone: params.timeZone || getDefaultTimezone(),
-				...params
-			};
-
-			const query = qs.stringify(queryParams);
+			const query = qs.stringify(convertedParams);
 
 			const response = await this.get<TTimeLogReportDaily[]>(`/timesheet/time-log/report/daily?${query}`);
 
@@ -349,6 +358,20 @@ class TimeLogService extends APIService {
 			tenantId: this.tenantId
 		});
 	};
+
+	private dateToEndOfDay(dateInput: Date | string) {
+		const endOfDay = new Date(dateInput);
+		endOfDay.setUTCHours(23, 59, 59, 999);
+
+		return endOfDay;
+	}
+
+	private dateToStartOfDay(dateInput: Date | string) {
+		const endOfDay = new Date(dateInput);
+		endOfDay.setUTCHours(0, 0, 0, 0);
+
+		return endOfDay;
+	}
 }
 
 export const timeLogService = new TimeLogService(GAUZY_API_BASE_SERVER_URL.value);


### PR DESCRIPTION
# fix(timesheet): correct date filter boundaries and section group label

## Description

1. **Date filter returned incorrect results** — `startDate` and `endDate` 
   were sent without explicit UTC normalization, causing off-by-one issues 
   depending on the user's timezone. Tasks at the edges of the date range 
   were either missing or incorrectly included.

2. **Section group label showed the first day of the month** (e.g. 
   `Sun 01 Feb 2026`) instead of the **month name** (e.g. `Feb 2026`).

## What Was Changed

### Minor Changes

- Normalize `startDate` to **UTC 00:00:00.000** and `endDate` to 
  **UTC 23:59:59.999** before sending GET requests
- Fix section group header to display **formatted month + year** 
  instead of the raw start-of-month date

## Related Issues

- Closes [ETP-221](https://evertech.atlassian.net/browse/ETP-221)

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Reviewers Suggested

- `@ndekocode` for integration review


[ETP-221]: https://evertech.atlassian.net/browse/ETP-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes timesheet date filtering by sending UTC-normalized day boundaries to prevent edge records from being missed, and updates monthly group headers to show clear month-year labels. Addresses ETP-221.

- **Bug Fixes**
  - Normalize startDate (UTC 00:00) and endDate (UTC 23:59:59.999) across API queries and the date-range helper.
  - Show month-year (e.g., "Feb 2026") for monthly group labels in the timesheet table.

<sup>Written for commit 23ae1575089f11fa662b4e44af401c81136543e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced timesheet display with improved date grouping that adapts formatting based on view type (monthly or daily).
  * Strengthened date boundary handling in time log services with consistent end-of-day normalization and comprehensive parameter validation for more accurate data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->