### PR TITLE
fix(timesheet): display task title instead of label in manual time dropdown

### DIFF
--- a/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
+++ b/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
@@ -503,7 +503,7 @@ export function AddManualTimeModal(props: Readonly<IAddManualTimeModalProps>) {
 								className="w-full text-sm border-gray-300 dark:border-slate-600 dark:text-white"
 								options={team ? selectedTeamTasks : activeTeamTasks}
 								renderOption={(task: TTask) => {
-									return task?.title ?? task.label ?? '(no-title)';
+									return task?.title ?? task?.label ?? '(no-title)';
 								}}
 								onChange={(value) => {
 									// CustomSelect returns the ID directly when valueKey="id"

--- a/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
+++ b/apps/web/core/components/features/manual-time/add-manual-time-modal.tsx
@@ -502,6 +502,9 @@ export function AddManualTimeModal(props: Readonly<IAddManualTimeModalProps>) {
 								ariaLabel="task"
 								className="w-full text-sm border-gray-300 dark:border-slate-600 dark:text-white"
 								options={team ? selectedTeamTasks : activeTeamTasks}
+								renderOption={(task: TTask) => {
+									return task?.title ?? task.label ?? '(no-title)';
+								}}
 								onChange={(value) => {
 									// CustomSelect returns the ID directly when valueKey="id"
 									if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
# Fix task dropdown displaying label instead of title in Add Manual Time modal

## Description

In the "Add Manual Time" modal, the task dropdown was showing the 
internal `label` instead of the human-readable `title`. Added a `renderOption` prop to control what's displayed solve the issue.

## Related Issues

> - Closes [ETP-217](https://evertech.atlassian.net/browse/ETP-217)

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Reviewers Suggested

- `@ndekocode` for integration review


[ETP-217]: https://evertech.atlassian.net/browse/ETP-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show task titles in the Add Manual Time modal dropdown instead of internal labels, so users pick tasks by name. Aligns with ETP-217.

- **Bug Fixes**
  - Use renderOption to display task?.title with fallback to label or '(no-title)'; add optional chaining to handle undefined tasks safely.

<sup>Written for commit 23a4dd1cdff7e2fa3f855992118700d1fa0011a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task option display in the manual time entry modal to show task titles with fallback options for tasks without titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->