### PR TITLE
feat(chat-panel): add resizable chat panel with toggle support

### DIFF
--- a/apps/web/core/components/features/chat-panel/atoms/chat-panel-open.atom.ts
+++ b/apps/web/core/components/features/chat-panel/atoms/chat-panel-open.atom.ts
@@ -1,0 +1,10 @@
+import { atomWithStorage } from 'jotai/utils';
+
+/**
+ * Persists the chat panel open/closed state in localStorage.
+ * This way, the user's preference survives page refreshes.
+ */
+export const chatPanelOpenAtom = atomWithStorage<boolean>(
+	'chat-panel-open',
+	false // closed by default
+);

--- a/apps/web/core/components/features/chat-panel/components/chat-panel-layout.tsx
+++ b/apps/web/core/components/features/chat-panel/components/chat-panel-layout.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/core/components/common/resizable';
+import { cn } from '@/core/lib/helpers';
+import type { PropsWithChildren } from 'react';
+import { CHAT_PANEL_CONSTRAINTS } from '../constants/chat-panel-constraints.constant';
+import { ChatPanelContext } from '../contexts/chat-panel.context';
+import { useChatPanel } from '../hooks/use-chat-panel';
+
+export function ChatPanelLayout({ children }: PropsWithChildren) {
+	const chatPanel = useChatPanel();
+
+	return (
+		// Provide chat controls to the entire subtree (children included)
+		<ChatPanelContext.Provider value={chatPanel}>
+			<div
+				className="relative flex h-full w-full"
+				style={
+					{
+						'--chat-panel-width': `${chatPanel.sizePixels}px`
+					} as React.CSSProperties
+				}
+			>
+				<ResizablePanelGroup direction="horizontal" autoSaveId="chat-content-layout" className="h-full w-full">
+					{/* ── PANEL 1 : Chat ──────────────────────────────────────── */}
+					<ResizablePanel
+						ref={chatPanel.panelRef}
+						order={1}
+						defaultSize={CHAT_PANEL_CONSTRAINTS.defaultSize}
+						minSize={CHAT_PANEL_CONSTRAINTS.minSize}
+						maxSize={CHAT_PANEL_CONSTRAINTS.maxSize}
+						collapsedSize={CHAT_PANEL_CONSTRAINTS.collapsedSize}
+						collapsible
+						onCollapse={chatPanel.closePanel}
+						onExpand={chatPanel.openPanel}
+						onResize={chatPanel.handleResize}
+						className={cn('bg-muted/30 border-r', 'z-60 relative')}
+					>
+						<div ref={chatPanel.chatPanelDomRef} className="flex h-full flex-col p-4 bg-dark">
+							<p className="text-sm font-semibold">Chat</p>
+						</div>
+					</ResizablePanel>
+
+					{/* ── HANDLE ──────────────────────────────────────────────── */}
+					<ResizableHandle withHandle className="z-100 relative" />
+
+					{/* ── PANEL 2 : Page Content ───────────────────────────────── */}
+					<ResizablePanel
+						order={2}
+						defaultSize={100 - CHAT_PANEL_CONSTRAINTS.defaultSize}
+						minSize={50}
+						className="overflow-auto"
+					>
+						{children}
+					</ResizablePanel>
+				</ResizablePanelGroup>
+			</div>
+		</ChatPanelContext.Provider>
+	);
+}

--- a/apps/web/core/components/features/chat-panel/constants/chat-panel-constraints.constant.ts
+++ b/apps/web/core/components/features/chat-panel/constants/chat-panel-constraints.constant.ts
@@ -1,0 +1,12 @@
+/**
+ * CHAT_PANEL_CONSTRAINTS
+ *
+ * Sizing rules for the chat panel (expressed in % of SidebarInset width,
+ * NOT the full viewport — the sidebar width is excluded).
+ */
+export const CHAT_PANEL_CONSTRAINTS = {
+	defaultSize: 30, // 30% of the content area when open
+	minSize: 20, // cannot be squeezed below 20%
+	maxSize: 50, // cannot take more than half the content area
+	collapsedSize: 0 // fully hidden when collapsed
+} as const;

--- a/apps/web/core/components/features/chat-panel/contexts/chat-panel.context.tsx
+++ b/apps/web/core/components/features/chat-panel/contexts/chat-panel.context.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+/**
+ * ChatPanelContext — Exposes chat panel controls to any child component
+ */
+interface ChatPanelContextValue {
+	isOpen: boolean;
+	togglePanel: () => void;
+	openPanel: () => void;
+	closePanel: () => void;
+}
+
+export const ChatPanelContext = createContext<ChatPanelContextValue | null>(null);
+
+export function useChatPanelContext() {
+	const ctx = useContext(ChatPanelContext);
+	if (!ctx) {
+		throw new Error('useChatPanelContext must be used inside LayoutShell');
+	}
+	return ctx;
+}

--- a/apps/web/core/components/features/chat-panel/hooks/use-chat-panel.ts
+++ b/apps/web/core/components/features/chat-panel/hooks/use-chat-panel.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useAtom } from 'jotai';
+import { useCallback, useRef, useState } from 'react';
+import type { ImperativePanelHandle } from 'react-resizable-panels';
+import { chatPanelOpenAtom } from '../atoms/chat-panel-open.atom';
+import { CHAT_PANEL_CONSTRAINTS } from '../constants/chat-panel-constraints.constant';
+
+/**
+ * useChatPanel — Manages the imperative API of the chat ResizablePanel
+ */
+export function useChatPanel() {
+	/**
+	 * A ref on the wrapper div of the chat panel DOM node
+	 */
+	const chatPanelDomRef = useRef<HTMLDivElement>(null);
+	const panelRef = useRef<ImperativePanelHandle>(null);
+
+	const [isOpen, setIsOpen] = useAtom(chatPanelOpenAtom);
+	const [sizePercent, setSizePercent] = useState<number>(0);
+	const [sizePixels, setSizePixels] = useState<number>(0);
+
+	const openPanel = useCallback(() => {
+		console.log(panelRef.current);
+		panelRef.current?.expand();
+		setIsOpen(true);
+		setSizePixels(CHAT_PANEL_CONSTRAINTS.defaultSize);
+	}, [setIsOpen]);
+
+	const closePanel = useCallback(() => {
+		console.log(panelRef.current);
+		panelRef.current?.collapse();
+		setIsOpen(false);
+		setSizePixels(0);
+	}, [setIsOpen]);
+
+	const togglePanel = useCallback(() => {
+		console.log(panelRef.current?.getSize());
+		if (isOpen) {
+			closePanel();
+		} else {
+			openPanel();
+		}
+	}, [isOpen, openPanel, closePanel]);
+
+	const handleResize = useCallback((percentage: number) => {
+		setSizePercent(percentage);
+
+		if (chatPanelDomRef.current) {
+			const { width } = chatPanelDomRef.current.getBoundingClientRect();
+			setSizePixels(width);
+		}
+	}, []);
+
+	return {
+		panelRef,
+		isOpen,
+		togglePanel,
+		openPanel,
+		closePanel,
+		chatPanelDomRef,
+		sizePercent,
+		sizePixels,
+		setSizePixels,
+		handleResize
+	};
+}

--- a/apps/web/core/components/layouts/default-layout/global-header.tsx
+++ b/apps/web/core/components/layouts/default-layout/global-header.tsx
@@ -24,12 +24,12 @@ const GlobalHeader = forwardRef(
 			<div
 				ref={ref as LegacyRef<HTMLDivElement>}
 				className={cn(
-					'fixed flex flex-col top-0 left-0 right-0 z-50 bg-white border-b min-h-fit shrink-0 h-max bg-background ',
-					`!lg:pl-[${state === 'expanded' ? '--sidebar-width' : '--sidebar-width-icon'}]`,
-					`!lg:pl-[var(${state === 'expanded' ? '--sidebar-width' : '--sidebar-width-icon'})]`
+					'fixed flex flex-col top-0 left-0 right-0 z-50 bg-white border-b min-h-fit shrink-0 h-max bg-background '
 				)}
 				style={{
-					paddingLeft: `var(${state === 'expanded' ? '--sidebar-width' : '--sidebar-width-icon'})`
+					paddingLeft: `calc(var(${
+						state === 'expanded' ? '--sidebar-width' : '--sidebar-width-icon'
+					}) + var(--chat-panel-width, 0px))`
 				}}
 			>
 				<header

--- a/apps/web/core/components/layouts/default-layout/layout-shell.tsx
+++ b/apps/web/core/components/layouts/default-layout/layout-shell.tsx
@@ -8,6 +8,7 @@ import AppContainer from './app-container';
 import { LayoutShellContext } from './layout-shell-context';
 import { publicState } from '@/core/stores';
 import { useAtomValue } from 'jotai';
+import { ChatPanelLayout } from '@/core/components/features/chat-panel/components/chat-panel-layout';
 
 /**
  * LayoutShell — Persistent layout wrapper that survives page navigations.
@@ -39,11 +40,10 @@ export function LayoutShell({ children }: PropsWithChildren) {
 
 					{/* Content area — children will be PageLayout from each page */}
 					<SidebarInset className="relative flex-1 overflow-x-hidden !h-full !w-full">
-						{children}
+						<ChatPanelLayout>{children}</ChatPanelLayout>
 					</SidebarInset>
 				</SidebarProvider>
 			</AppContainer>
 		</LayoutShellContext.Provider>
 	);
 }
-


### PR DESCRIPTION
- Add ChatPanelLayout to orchestrate chat/content split
- Add ChatPanelContext to expose size, isOpen and controls
- Fix z-index to ensure handle renders above sidebar


## Reviewers

- `@evereq` for architecture validation
- `@ndekocode` for integration review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a resizable, collapsible chat panel to the global layout with toggle controls and persisted open state. The header and content now adjust to the panel width for a consistent layout.

- **New Features**
  - Introduced `ChatPanelLayout` using `ResizablePanelGroup` to split chat and content; sizes controlled by `CHAT_PANEL_CONSTRAINTS`.
  - Exposed controls via `ChatPanelContext` and `useChatPanelContext()` (`isOpen`, `togglePanel`, `openPanel`, `closePanel`); state persists with `chatPanelOpenAtom`.
  - Enabled app-wide by wrapping pages in `LayoutShell` with `ChatPanelLayout`; `GlobalHeader` now includes `--chat-panel-width` in its left padding.

- **Bug Fixes**
  - Raised z-index so the resizable handle renders above the sidebar.

<sup>Written for commit 46c084cd59320cb315cb59c99d5cbe69aad098ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

