### PR TITLE
Fix: resolve z-index overlap between team size dropdown and team color field

### DIFF
--- a/apps/web/core/components/teams/team-size-popover.tsx
+++ b/apps/web/core/components/teams/team-size-popover.tsx
@@ -124,7 +124,7 @@ const TeamSize = ({
 							<PopoverPanel
 								ref={panelRef}
 								anchor="bottom end"
-								className="mt-5 bg-light--theme-light dark:bg-dark--theme-light border p-3 rounded-xl shadow-xlcard flex flex-col gap-3"
+								className="z-50 mt-5 bg-light--theme-light dark:bg-dark--theme-light border p-3 rounded-xl shadow-xlcard flex flex-col gap-3"
 							>
 								<div className="text-lg text-[#7E7991] dark:text-gray-400 font-[500]">
 									{t('form.SELECT_TEAM_SIZE')}


### PR DESCRIPTION
## Description

This PR fixes a visual bug in the Team Settings page (`Paramètres généraux`) where the "Team Color" form elements were overlapping and bleeding through the "Team Size" dropdown menu (popover). 
The issue occurred because the team size popover lacked a designated `z-index` while the team color field below it had a `z-10` utility class. 
### Changes made
- Added the `z-50` utility class to the `PopoverPanel` component in `apps/web/core/components/teams/team-size-popover.tsx` to establish a higher stacking context and ensure the popover always renders in the foreground.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code improvement without functional changes)
## Related Issue
Fixes #4346 
## How Has This Been Tested?
- [x] Navigated to Team Settings -> General Settings.
- [x] Clicked on the "Team Size" input to open the popover.
- [x] Verified that the dropdown menu fully covers the "Team Color" field and its icons without any visual overlap.
## Screenshots (if applicable)
*("Before")*
<img width="1920" height="995" alt="Screenshot 2026-05-13 135536" src="https://github.com/user-attachments/assets/d71c562d-3461-4312-9c39-f9b325a66d88" />

*("After")*
<img width="1920" height="994" alt="Screenshot 2026-05-13 141939" src="https://github.com/user-attachments/assets/744b13f1-cdbe-463b-847a-6bd744f4ad46" />


## ⚠️⚠️⚠️ Reviewers Suggested

- @evereq 
- @NdekoCode 
- @Innocent-Akim



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a z-index issue so the Team Size dropdown appears above the Team Color field in Team Settings. Removes the visual overlap and bleed-through.

- **Bug Fixes**
  - Added `z-50` to the `PopoverPanel` in `apps/web/core/components/teams/team-size-popover.tsx` to ensure the popover stacks above nearby fields.

<sup>Written for commit 75869ca326fb4c078147c4cfcfa4aa6cded3fdae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual stacking order of the team size popover to prevent it from being hidden behind other elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-co/ever-teams/pull/4347)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->