### PR TITLE
fix(docker): copy @ever-teams/toolkit-types manifest in web Dockerfile

### DIFF
--- a/.deploy/web/Dockerfile
+++ b/.deploy/web/Dockerfile
@@ -133,6 +133,9 @@ ARG VERDACCIO_TOKEN
 COPY package.json yarn.lock ./
 
 COPY packages/constants/package.json packages/constants/package.json
+# constants/utils/services depend on @ever-teams/toolkit-types, so its manifest
+# must be present for the workspace-aware `yarn install --frozen-lockfile` below.
+COPY packages/toolkit-types/package.json packages/toolkit-types/package.json
 COPY packages/types/package.json packages/types/package.json
 COPY packages/utils/package.json packages/utils/package.json
 COPY packages/ui/package.json packages/ui/package.json


### PR DESCRIPTION
Follow-up to #4363. The web Dockerfile copied an outdated subset of workspace manifests; constants/utils/services now depend on @ever-teams/toolkit-types, so its package.json must be present for the workspace-aware `yarn install --frozen-lockfile` step. Without it the Docker image build on develop failed (couldn't find @ever-teams/toolkit-types on the npm registry). 

Verified locally: full turbo build is green; this only affects the container's partial-manifest copy. The Docker Build Dev workflow (develop push) will validate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix web Docker image build by copying the `@ever-teams/toolkit-types` package manifest into the workspace manifest layer. Ensures `yarn install --frozen-lockfile` resolves the workspace dep (used by constants/utils/services) and doesn’t fall back to the npm registry.

<sup>Written for commit ec705e5a46e0309e94eb26c6972f71e2d7278b17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to improve workspace-level dependency resolution. The build process now ensures that all workspace package manifests are properly included during installation, enhancing reliability and consistency when managing multi-package project structures with frozen-lockfile installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->