### PR TITLE
Add self-hosted ever-k8s deploy (parallel to DigitalOcean)

### DIFF
--- a/.deploy/ever-k8s/README.md
+++ b/.deploy/ever-k8s/README.md
@@ -1,0 +1,10 @@
+# `.deploy/ever-k8s/` — self-hosted Kubernetes deploy
+
+Deploys Ever Teams to a **self-hosted `ever-k8s`** cluster (bare-metal / Proxmox homelab), **in parallel**
+to the DigitalOcean deploy in `.deploy/k8s/` (which is unchanged). Managed by **Argo CD** (GitOps).
+
+**Phase 1 (current):** the stateless `apps/web` Next.js app, pointing at the hosted Gauzy API
+(`https://api.ever.team`). Exposed publicly via a Cloudflare Tunnel. No in-cluster DB/Redis/S3 required.
+
+**Phase 2 (later):** run the Gauzy API + PostgreSQL + Redis (Valkey) + object storage (MinIO) in-cluster;
+the web image must be **rebuilt** with the in-cluster `NEXT_PUBLIC_GAUZY_API_SERVER_URL` (build-time arg).

--- a/.deploy/ever-k8s/ever-teams-web.yaml
+++ b/.deploy/ever-k8s/ever-teams-web.yaml
@@ -1,0 +1,78 @@
+# Ever Teams — self-hosted deploy for the `ever-k8s` cluster (Proxmox homelab).
+# Managed by Argo CD (Application watches this directory). PARALLEL to the DigitalOcean deploy — DO is untouched.
+# Phase 1: stateless web app -> hosted Gauzy API (api.ever.team). No Postgres/Redis/S3 needed here.
+# Phase 2 (later): point NEXT_PUBLIC_GAUZY_API_SERVER_URL at an in-cluster Gauzy API (requires an image rebuild,
+# since NEXT_PUBLIC_* is baked at build time).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: ever-teams
+  labels:
+    app: ever-teams-web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ever-teams-web
+  template:
+    metadata:
+      labels:
+        app: ever-teams-web
+    spec:
+      containers:
+        - name: web
+          image: ghcr.io/ever-co/ever-teams-webapp:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3030
+          env:
+            - name: PORT
+              value: "3030"
+            - name: GAUZY_API_SERVER_URL
+              value: "https://api.ever.team/api"
+            - name: NEXT_PUBLIC_GAUZY_API_SERVER_URL
+              value: "https://api.ever.team"
+          readinessProbe:
+            httpGet: { path: /api/health, port: 3030 }
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet: { path: /api/health, port: 3030 }
+            initialDelaySeconds: 40
+            periodSeconds: 20
+          resources:
+            requests: { cpu: 200m, memory: 512Mi }
+            limits: { cpu: "1", memory: 1Gi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: ever-teams
+spec:
+  selector:
+    app: ever-teams-web
+  ports:
+    - port: 80
+      targetPort: 3030
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  namespace: ever-teams
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: teams-lab.ever.team
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web
+                port:
+                  number: 80


### PR DESCRIPTION
Adds `.deploy/ever-k8s/` — a GitOps (Argo CD) deploy of the Ever Teams web app to a self-hosted `ever-k8s` cluster, **in parallel** with the existing DigitalOcean deploy (unchanged). Phase 1 points at the hosted Gauzy API (`api.ever.team`) and is exposed via Cloudflare Tunnel. See `.deploy/ever-k8s/README.md`.

Signed-off-by: Ruslan Konviser <evereq@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.deploy/ever-k8s/` to deploy the Ever Teams web app to a self-hosted `ever-k8s` cluster via Argo CD, running in parallel with the existing DigitalOcean deploy. Phase 1 points the web app at the hosted Gauzy API and exposes it via Cloudflare Tunnel.

- **New Features**
  - Argo CD-managed Deployment, Service, and Ingress in the `ever-teams` namespace.
  - 2 replicas of `ghcr.io/ever-co/ever-teams-webapp:latest` with health probes and resource limits.
  - Ingress on `teams-lab.ever.team` (`nginx`), port 80 to container port 3030.
  - Env configured for `https://api.ever.team` (`GAUZY_API_SERVER_URL` and `NEXT_PUBLIC_GAUZY_API_SERVER_URL`); no in-cluster DB/Redis/S3.
  - README outlines Phase 2 (run API + PostgreSQL + Redis/Valkey + MinIO in-cluster; rebuild web image with updated URL).

<sup>Written for commit 491d6d706d97e0c2028c205e0fdd439fc252e9ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new self-hosted deployment path for the app.
  * Introduced a Kubernetes setup that runs the web app with health checks, resource settings, and public ingress access.
  * Documented a phased rollout path from a web-only setup to a full in-cluster stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->