### PR TITLE
ci(verdaccio): route dev+stage web build through internal Verdaccio VIP (not prod)

### DIFF
--- a/.deploy/web/Dockerfile
+++ b/.deploy/web/Dockerfile
@@ -148,9 +148,16 @@ COPY apps/web/package.json ./apps/web/package.json
 # Set working directory to the web app
 WORKDIR /app/apps/web
 
-# Configure private registry if token is provided
-RUN if [ -n "$VERDACCIO_TOKEN" ]; then \
-	echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> /app/.npmrc; \
+# Configure the npm registry: prefer the internal Verdaccio cache (VERDACCIO_REGISTRY build-arg, anonymous),
+# else the legacy packages.ever.co token path. Empty (e.g. a fork) → public npm. The yarn.lock rewrite is
+# best-effort (non-fatal) so a path mismatch degrades to public downloads rather than breaking the build.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+		echo "registry=${VERDACCIO_REGISTRY}" >> /app/.npmrc && \
+		printf 'registry "%s"\n' "${VERDACCIO_REGISTRY}" >> /app/.yarnrc && \
+		{ sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" /app/yarn.lock 2>/dev/null || true; }; \
+	elif [ -n "$VERDACCIO_TOKEN" ]; then \
+		echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> /app/.npmrc; \
 	fi
 
 # --- STEP 2: Install deps in deterministic and cacheable way ---

--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -59,6 +59,7 @@ jobs:
           build-args: |
             NODE_ENV=development
             VERDACCIO_TOKEN=${{ secrets.VERDACCIO_TOKEN }}
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NEXT_PUBLIC_DEMO=true
             API_BASE_URL=${{ vars.API_BASE_URL }}
             CLIENT_BASE_URL=${{ vars.CLIENT_BASE_URL }}

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -59,6 +59,7 @@ jobs:
           build-args: |
             NODE_ENV=production
             VERDACCIO_TOKEN=${{ secrets.VERDACCIO_TOKEN }}
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NEXT_PUBLIC_DEMO=false
             API_BASE_URL=${{ vars.API_BASE_URL }}
             CLIENT_BASE_URL=${{ vars.CLIENT_BASE_URL }}


### PR DESCRIPTION
Adds backward-compatible `VERDACCIO_REGISTRY` support to `.deploy/web/Dockerfile` (internal VIP when set, else legacy packages.ever.co token, else public npm — fork-safe) and passes `VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}` in the dev+stage build workflows. Prod untouched. yarn.lock rewrite is non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route dev and stage web Docker builds through an internal Verdaccio VIP when available, with fallbacks to the legacy `packages.ever.co` token or public npm. Production builds are unchanged.

- **Refactors**
  - Add `VERDACCIO_REGISTRY` to `.deploy/web/Dockerfile`; prefer it for npm/yarn registry and best-effort `yarn.lock` rewrite; fallback to `VERDACCIO_TOKEN`, else public.
  - Pass `VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}` in dev and stage workflows; forks build without it.

<sup>Written for commit bc6d526c5051345fc8489d63700cc70c7f9a3c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container builds to support configurable internal package registries.
  * Build workflows now pass the internal registry setting through development and staging image builds.
  * Retained compatibility with the existing token-based package configuration.
  * Package lockfile registry references are updated automatically when the internal registry is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->