### PR TITLE
ci: replace dead ubicloud x64 labels with self-hosted ARC vars (main)

### DIFF
--- a/.github/workflows/chatgpt.deploy-do-dev.yml
+++ b/.github/workflows/chatgpt.deploy-do-dev.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   deploy-chatgpt-dev:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev
 

--- a/.github/workflows/chatgpt.deploy-do-prod.yml
+++ b/.github/workflows/chatgpt.deploy-do-prod.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   deploy-chatgpt-prod:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
 

--- a/.github/workflows/chatgpt.deploy-do-stage.yml
+++ b/.github/workflows/chatgpt.deploy-do-stage.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   deploy-chatgpt-stage:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage
 

--- a/.github/workflows/chatgpt.docker-build-publish-dev.yml
+++ b/.github/workflows/chatgpt.docker-build-publish-dev.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev
 

--- a/.github/workflows/chatgpt.docker-build-publish-prod.yml
+++ b/.github/workflows/chatgpt.docker-build-publish-prod.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
 

--- a/.github/workflows/chatgpt.docker-build-publish-stage.yml
+++ b/.github/workflows/chatgpt.docker-build-publish-stage.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage
 

--- a/.github/workflows/deploy-api-do-dev.yml
+++ b/.github/workflows/deploy-api-do-dev.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   deploy-api-dev:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev
 

--- a/.github/workflows/deploy-api-do-prod.yml
+++ b/.github/workflows/deploy-api-do-prod.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   deploy-api-prod:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
 

--- a/.github/workflows/deploy-api-do-stage.yml
+++ b/.github/workflows/deploy-api-do-stage.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   deploy-api-stage:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage
 

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-demo:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev
 

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-prod:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
 

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-stage:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage
 

--- a/.github/workflows/deploy-render-dev.yml
+++ b/.github/workflows/deploy-render-dev.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-render:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev
 

--- a/.github/workflows/deploy-vercel-dev.yml
+++ b/.github/workflows/deploy-vercel-dev.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev
 

--- a/.github/workflows/deploy-vercel-prod.yml
+++ b/.github/workflows/deploy-vercel-prod.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
 

--- a/.github/workflows/deploy-vercel-stage.yml
+++ b/.github/workflows/deploy-vercel-stage.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage
 

--- a/.github/workflows/desktop-server-api.apps.yml
+++ b/.github/workflows/desktop-server-api.apps.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubicloud-standard-8]
+        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubicloud-standard-8]
+        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/desktop.apps.yml
+++ b/.github/workflows/desktop.apps.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubicloud-standard-8]
+        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ever-teams-webapp:
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev
 

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ever-teams-webapp:
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
 

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ever-teams-webapp:
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage
 

--- a/.github/workflows/extensions.dev.yml
+++ b/.github/workflows/extensions.dev.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev
     

--- a/.github/workflows/extensions.prod.yml
+++ b/.github/workflows/extensions.prod.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
     

--- a/.github/workflows/knip-cleanup.yml
+++ b/.github/workflows/knip-cleanup.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   knip-review:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/mobile.apps.android.yml
+++ b/.github/workflows/mobile.apps.android.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
 

--- a/.github/workflows/mobile.apps.ios.yml
+++ b/.github/workflows/mobile.apps.ios.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
 

--- a/.github/workflows/mobile.apps.stage.android.yml
+++ b/.github/workflows/mobile.apps.stage.android.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage
 

--- a/.github/workflows/mobile.apps.stage.ios.yml
+++ b/.github/workflows/mobile.apps.stage.ios.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage
 

--- a/.github/workflows/mobile.before-merge.yml
+++ b/.github/workflows/mobile.before-merge.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     permissions:
       pull-requests: write

--- a/.github/workflows/mobile.dev.yml
+++ b/.github/workflows/mobile.dev.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev
 

--- a/.github/workflows/mobile.prod.yml
+++ b/.github/workflows/mobile.prod.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
 

--- a/.github/workflows/mobile.stage.yml
+++ b/.github/workflows/mobile.stage.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage
 

--- a/.github/workflows/release.apps.yml
+++ b/.github/workflows/release.apps.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubicloud-standard-2]
+        os: ["${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubicloud-standard-2]
+        os: ["${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/release.prod.yml
+++ b/.github/workflows/release.prod.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubicloud-standard-2]
+        os: ["${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/release.sdk.prod.yml
+++ b/.github/workflows/release.sdk.prod.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Version and SDK Publish with Changesets
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     permissions:
       contents: write # for changelog/version PRs

--- a/.github/workflows/release.stage.yml
+++ b/.github/workflows/release.stage.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubicloud-standard-2]
+        os: ["${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   spellcheck:
     name: Cspell
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - uses: streetsidesoftware/cspell-action@v2

--- a/.github/workflows/web.before-merge.yml
+++ b/.github/workflows/web.before-merge.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Replaces the 40 dead third-party `ubicloud-standard-{2,4,8}` x64 runner labels on `main` with our self-hosted ARC runner vars, mirroring exactly what `develop` already uses per file:

- `runs-on: ubicloud-standard-{2,4,8}` -> `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}`
- desktop*.apps.yml matrix `os: [ubicloud-standard-8]` -> `os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]`
- release.*.yml matrix `os: [ubicloud-standard-2]` -> `os: ["${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}"]`

Untouched: `ubicloud-*-arm` legs, macOS/Windows/self-hosted desktop legs, DO_ENABLED-gated steps. All 40 files YAML-validated. Surgical CI-only fix — no branch cascade (stage/main are forked from develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all x64 `ubicloud-standard-{2,4,8}` GitHub Actions runner labels on `main` with self-hosted ARC vars (`${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` and `RUNNER_LINUX_X64_8`) to restore CI and match `develop`. ARM, macOS, Windows, and self-hosted desktop legs are unchanged.

<sup>Written for commit 66bef1f851d8bcba4c75dcc141f0a980de99d5e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

