### PR TITLE
ci: gate 'Free disk space' step to github-hosted only (self-hosted ARC fix) [main]

### DIFF
--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Free disk space
+        if: runner.environment == 'github-hosted'
         run: |
             df -h /
             sudo swapoff -a

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Free disk space
+        if: runner.environment == 'github-hosted'
         run: |
             df -h /
             sudo swapoff -a

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Free disk space
+        if: runner.environment == 'github-hosted'
         run: |
             df -h /
             sudo swapoff -a

--- a/.github/workflows/web.before-merge.yml
+++ b/.github/workflows/web.before-merge.yml
@@ -33,6 +33,7 @@ jobs:
         run: echo "Workflow was skipped" && exit 0
 
       - name: Free disk space
+        if: runner.environment == 'github-hosted'
         run: |
             df -h /
             sudo swapoff -a


### PR DESCRIPTION
Gates the ARC-incompatible **Free disk space** step so it only runs on GitHub-hosted runners.

That shell step assumes a GitHub-hosted layout (`~/work/_temp`, `$AGENT_TOOLSDIRECTORY`, etc.) and **fails on our self-hosted ARC runners** (`find: '/home/runner/work/_temp': No such file or directory` -> aborts the Docker build). Adding `if: runner.environment == 'github-hosted'` bypasses it on self-hosted runners while keeping it intact for GitHub-hosted (no-removal rule: gate, don't delete).

Files gated (this branch, `main`):
- `.github/workflows/docker-build-publish-dev.yml`
- `.github/workflows/docker-build-publish-prod.yml`
- `.github/workflows/docker-build-publish-stage.yml`
- `.github/workflows/web.before-merge.yml`

Surgical: only one `if:` line added per file; nothing else changed. (`develop` already carries this gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the "Free disk space" CI step to GitHub-hosted runners to stop failures on self-hosted ARC. Skips the step on self-hosted to prevent Docker build aborts, while keeping it on GitHub-hosted.

- **Bug Fixes**
  - Added `if: runner.environment == 'github-hosted'` to the step in 4 workflows (docker build/publish dev, stage, prod; web.before-merge).
  - Resolves missing-path errors on self-hosted runners that aborted builds.

<sup>Written for commit 481dd6eb3c8bc0a2374e63195322674c5173bd07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

