### PR TITLE
ci: gate legacy DigitalOcean deploy behind DO_ENABLED (main)

### DIFF
--- a/.github/workflows/chatgpt.deploy-do-dev.yml
+++ b/.github/workflows/chatgpt.deploy-do-dev.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   deploy-chatgpt-dev:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    if: ${{ vars.DO_ENABLED == 'true' }}
 
     environment: dev
 

--- a/.github/workflows/chatgpt.deploy-do-prod.yml
+++ b/.github/workflows/chatgpt.deploy-do-prod.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   deploy-chatgpt-prod:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    if: ${{ vars.DO_ENABLED == 'true' }}
 
     environment: prod
 

--- a/.github/workflows/chatgpt.deploy-do-stage.yml
+++ b/.github/workflows/chatgpt.deploy-do-stage.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   deploy-chatgpt-stage:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    if: ${{ vars.DO_ENABLED == 'true' }}
 
     environment: stage
 

--- a/.github/workflows/chatgpt.docker-build-publish-dev.yml
+++ b/.github/workflows/chatgpt.docker-build-publish-dev.yml
@@ -53,14 +53,17 @@ jobs:
             NODE_ENV=development
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-teams-chatgpt-dev:latest
 

--- a/.github/workflows/chatgpt.docker-build-publish-prod.yml
+++ b/.github/workflows/chatgpt.docker-build-publish-prod.yml
@@ -53,14 +53,17 @@ jobs:
             NODE_ENV=production
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-teams-chatgpt-prod:latest
 

--- a/.github/workflows/chatgpt.docker-build-publish-stage.yml
+++ b/.github/workflows/chatgpt.docker-build-publish-stage.yml
@@ -53,14 +53,17 @@ jobs:
             NODE_ENV=staging
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-teams-chatgpt-stage:latest
 

--- a/.github/workflows/deploy-api-do-dev.yml
+++ b/.github/workflows/deploy-api-do-dev.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   deploy-api-dev:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    if: ${{ vars.DO_ENABLED == 'true' }}
 
     environment: dev
 

--- a/.github/workflows/deploy-api-do-prod.yml
+++ b/.github/workflows/deploy-api-do-prod.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   deploy-api-prod:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    if: ${{ vars.DO_ENABLED == 'true' }}
 
     environment: prod
 

--- a/.github/workflows/deploy-api-do-stage.yml
+++ b/.github/workflows/deploy-api-do-stage.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   deploy-api-stage:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    if: ${{ vars.DO_ENABLED == 'true' }}
 
     environment: stage
 

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   deploy-demo:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    if: ${{ vars.DO_ENABLED == 'true' }}
 
     environment: dev
 

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   deploy-prod:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    if: ${{ vars.DO_ENABLED == 'true' }}
 
     environment: prod
 

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   deploy-stage:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    if: ${{ vars.DO_ENABLED == 'true' }}
 
     environment: stage
 

--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -90,14 +90,17 @@ jobs:
           docker push everco/ever-teams-webapp-dev:latest
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-teams-webapp-dev:latest
 

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -90,14 +90,17 @@ jobs:
           docker push everco/ever-teams-webapp:latest
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-teams-webapp:latest
 

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -90,14 +90,17 @@ jobs:
           docker push everco/ever-teams-webapp-stage:latest
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-teams-webapp-stage:latest
 


### PR DESCRIPTION
Gates the ungated legacy DigitalOcean deploy content behind `vars.DO_ENABLED` on **main**, mirroring the pattern already merged on `develop` and `stage`.

DO is retired (`vars.DO_ENABLED` unset), so these jobs/steps currently FAIL on self-hosted ARC (`kubectl: command not found` / DO 403). With the gate they SKIP (green) instead.

- **Job-level gate** (9 files): `chatgpt.deploy-do-{dev,prod,stage}`, `deploy-api-do-{dev,prod,stage}`, `deploy-do-{dev,prod,stage}` — `if: ${{ vars.DO_ENABLED == 'true' }}` on the single deploy job.
- **Step-level gate** (6 files): `chatgpt.docker-build-publish-{dev,prod,stage}`, `docker-build-publish-{dev,prod,stage}` — only the 3 DO steps (Install doctl / DO registry login / Push to DO Registry). Build + DockerHub + GHCR steps stay ungated and keep running.

No content removed (no-removal rule). Diff is exactly 27 added `if:` lines, zero deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated legacy DigitalOcean deploy jobs and registry steps behind `vars.DO_ENABLED` on `main` so retired DO paths skip instead of failing on ARC. Mirrors `develop` and `stage`; non-DO builds and pushes are unchanged.

- **Bug Fixes**
  - Added job-level gate to 9 DO deploy workflows (`if: ${{ vars.DO_ENABLED == 'true' }}`).
  - Gated DO-specific steps (install `doctl`, DO registry login, DO push) in 6 build/publish workflows; DockerHub and GHCR steps remain active.
  - When `vars.DO_ENABLED` is unset, DO jobs/steps now skip (green) instead of failing on ARC.

<sup>Written for commit 891519b37d751beebc963be688be0d68fa5ba1b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

