### PR TITLE
fix(i18n): translate hardcoded sidebar strings into all 13 locales

### DIFF
--- a/apps/web/core/components/features/layouts/header/create-default-action.tsx
+++ b/apps/web/core/components/features/layouts/header/create-default-action.tsx
@@ -80,7 +80,7 @@ export const DefaultCreateAction = ({ publicTeam }: { publicTeam?: boolean }) =>
 								fill="currentColor"
 							/>
 						</svg>
-						Quick Create
+						{t('sidebar.QUICK_CREATE')}
 					</Button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent

--- a/apps/web/core/components/layouts/app-sidebar.tsx
+++ b/apps/web/core/components/layouts/app-sidebar.tsx
@@ -153,14 +153,14 @@ export function AppSidebar({ publicTeam, ...props }: AppSidebarProps) {
 		],
 		home: [
 			{
-				title: 'Home',
+				title: t('sidebar.HOME'),
 				url: '/',
 				selectable: true,
 				icon: HomeIcon,
 				label: 'home'
 			},
 			{
-				title: 'Inbox',
+				title: t('sidebar.INBOX'),
 				url: '/inbox',
 				selectable: true,
 				icon: InboxIcon,
@@ -176,12 +176,12 @@ export function AppSidebar({ publicTeam, ...props }: AppSidebarProps) {
 				label: 'dashboard',
 				items: [
 					{
-						title: 'Team Dashboard',
+						title: t('sidebar.TEAM_DASHBOARD'),
 						url: `/dashboard/team-dashboard/${user?.id}?name=${encodeURIComponent(username || '')}`,
 						label: 'team dashboard'
 					},
 					{
-						title: 'Apps & URLs',
+						title: t('sidebar.APPS_AND_URLS'),
 						url: `/dashboard/app-url/${user?.id}?name=${encodeURIComponent(username || '')}`,
 						label: 'apps-urls'
 					}

--- a/apps/web/core/components/layouts/default-layout/header/sidebar-command-form.tsx
+++ b/apps/web/core/components/layouts/default-layout/header/sidebar-command-form.tsx
@@ -1,23 +1,25 @@
 import type React from 'react';
 
+import { useTranslations } from 'next-intl';
 import { Label } from '@/core/components/common/label';
 import { SidebarGroup, SidebarGroupContent, SidebarInput } from '@/core/components/common/sidebar';
 import { CommandIcon } from '../../../icons';
 
 export function SidebarCommandForm({ ...props }: React.ComponentProps<'form'>) {
+	const t = useTranslations();
 	return (
 		<>
 			<form {...props}>
 				<SidebarGroup className="py-0 mt-2">
 					<SidebarGroupContent className="relative inline-flex">
 						<Label htmlFor="command" className="sr-only">
-							Command
+							{t('sidebar.COMMAND')}
 						</Label>
 						<SidebarInput
 							id="command"
-							placeholder="Enter a command..."
+							placeholder={t('placeholders.ENTER_A_COMMAND')}
 							className="pl-8 file:text-foreground placeholder:text-gray-500 dark:placeholder:text-muted-foreground/70 flex rounded-md border px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-hidden file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive h-fit ps-9 pe-9  w-fit min-w-32 max-w-[98.5%] bg-[#eaeef4] dark:bg-dark--theme-light border-gray-200 dark:border-gray-700"
-							aria-label="Command"
+							aria-label={t('sidebar.COMMAND')}
 						/>
 
 						<div className="absolute inset-y-0 flex items-center justify-center text-gray-500 pointer-events-none start-0 ps-2 dark:text-muted-foreground/70 peer-disabled:opacity-50">

--- a/apps/web/core/components/layouts/nav-main.tsx
+++ b/apps/web/core/components/layouts/nav-main.tsx
@@ -17,6 +17,7 @@ import {
 	useSidebar
 } from '@/core/components/common/sidebar';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { activeMenuIndexState, activeSubMenuIndexState, openMenusState } from '@/core/stores/common/menu';
 import { ReactNode } from 'react';
 
@@ -37,6 +38,7 @@ export function NavMain({
 		}[];
 	}[];
 }>) {
+	const t = useTranslations();
 	const { state } = useSidebar();
 	const [openMenus, setOpenMenus] = useAtom(openMenusState);
 	const [activeMenuIndex, setActiveMenuIndex] = useAtom(activeMenuIndexState);
@@ -103,7 +105,7 @@ export function NavMain({
 	};
 	return (
 		<SidebarGroup>
-			<SidebarGroupLabel>Platform</SidebarGroupLabel>
+			<SidebarGroupLabel>{t('sidebar.PLATFORM')}</SidebarGroupLabel>
 			<SidebarMenu
 				className={cn('w-full max-w-[230px]', state === 'collapsed' ? 'items-center gap-y-2' : '', 'gap-y-1')}
 			>

--- a/apps/web/core/components/layouts/sidebar-opt-in-form.tsx
+++ b/apps/web/core/components/layouts/sidebar-opt-in-form.tsx
@@ -91,7 +91,7 @@ export function SidebarOptInForm() {
 									<FormControl>
 										<SidebarInput
 											type="email"
-											placeholder="Email"
+											placeholder={t('common.EMAIL')}
 											className="border-gray-200 placeholder:text-xs dark:bg-gray-800 dark:border-gray-700"
 											{...field}
 										/>
@@ -105,7 +105,7 @@ export function SidebarOptInForm() {
 							className="w-full shadow-none bg-sidebar-primary text-sidebar-primary-foreground"
 							size="sm"
 						>
-							{isLoading ? 'Subscribing...' : 'Subscribe'}
+							{isLoading ? t('common.SUBSCRIBING') : t('common.SUBSCRIBE')}
 						</Button>
 					</CardContent>
 				</form>

--- a/apps/web/locales/ar.json
+++ b/apps/web/locales/ar.json
@@ -19,6 +19,9 @@
 		"ADD_TIME_ENTRY": "إضافة إدخال وقت",
 		"OPT_IN_UPDATES": "اشترك لتلقي التحديثات والأخبار حول {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "اشترك في النشرة الإخبارية",
+		"SUBSCRIBE": "اشترك",
+		"SUBSCRIBING": "جارٍ الاشتراك...",
+		"EMAIL": "البريد الإلكتروني",
 		"VIEW_PROJECT": "عرض المشروع",
 		"SHARE_PROJECT": "مشاركة المشروع",
 		"DELETE_PROJECT": "حذف المشروع",
@@ -453,6 +456,11 @@
 	"sidebar": {
 		"DASHBOARD": "لوحة التحكم",
 		"FORYOU": "عام",
+		"QUICK_CREATE": "إنشاء سريع",
+		"COMMAND": "أمر",
+		"PLATFORM": "المنصة",
+		"TEAM_DASHBOARD": "لوحة تحكم الفريق",
+		"APPS_AND_URLS": "التطبيقات والروابط",
 		"HOME": "الصفحة الرئيسية",
 		"INBOX": "الوارد",
 		"PROJECTS": "المشاريع",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "كلمات المرور غير متطابقة"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "اضغط إدخال للتحقق"
+		"ENTER_TO_VALIDATE": "اضغط إدخال للتحقق",
+		"ENTER_A_COMMAND": "أدخل أمرًا..."
 	},
 	"team": {
 		"BACK_LABEL": "العودة إلى الفريق",

--- a/apps/web/locales/bg.json
+++ b/apps/web/locales/bg.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "Табло",
 		"FORYOU": "Общи",
+		"QUICK_CREATE": "Бързо създаване",
+		"COMMAND": "Команда",
+		"PLATFORM": "Платформа",
+		"TEAM_DASHBOARD": "Табло на екипа",
+		"APPS_AND_URLS": "Приложения и URL адреси",
 		"HOME": "Начало",
 		"INBOX": "Входящи",
 		"PROJECTS": "Проекти",
@@ -44,6 +49,9 @@
 		"ADD_TIME_ENTRY": "Добавяне на запис на време",
 		"OPT_IN_UPDATES": "Абонирайте се за актуализации и новини за {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "Абонирайте се за нашия бюлетин",
+		"SUBSCRIBE": "Абонирайте се",
+		"SUBSCRIBING": "Абониране...",
+		"EMAIL": "Имейл",
 		"VIEW_PROJECT": "Преглед на проекта",
 		"SHARE_PROJECT": "Споделяне на проекта",
 		"DELETE_PROJECT": "Изтриване на проекта",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "Паролите не съвпадат"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "Натиснете Enter за валидиране"
+		"ENTER_TO_VALIDATE": "Натиснете Enter за валидиране",
+		"ENTER_A_COMMAND": "Въведете команда..."
 	},
 	"team": {
 		"BACK_LABEL": "Обратно към отбора",

--- a/apps/web/locales/de.json
+++ b/apps/web/locales/de.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "Dashboard",
 		"FORYOU": "Allgemein",
+		"QUICK_CREATE": "Schnellerstellung",
+		"COMMAND": "Befehl",
+		"PLATFORM": "Plattform",
+		"TEAM_DASHBOARD": "Team Dashboard",
+		"APPS_AND_URLS": "Apps & URLs",
 		"HOME": "Startseite",
 		"INBOX": "Posteingang",
 		"PROJECTS": "Projekte",
@@ -44,6 +49,9 @@
 		"ADD_TIME_ENTRY": "Zeiteintrag hinzufügen",
 		"OPT_IN_UPDATES": "Abonnieren Sie Updates und Nachrichten zu {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "Abonnieren Sie unseren Newsletter",
+		"SUBSCRIBE": "Abonnieren",
+		"SUBSCRIBING": "Abonnieren...",
+		"EMAIL": "E-Mail",
 		"VIEW_PROJECT": "Projekt anzeigen",
 		"SHARE_PROJECT": "Projekt teilen",
 		"DELETE_PROJECT": "Projekt löschen",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "Passwörter stimmen nicht überein"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "Enter drücken, um zu validieren"
+		"ENTER_TO_VALIDATE": "Enter drücken, um zu validieren",
+		"ENTER_A_COMMAND": "Befehl eingeben..."
 	},
 	"team": {
 		"BACK_LABEL": "Zurück zum Team",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "Dashboard",
 		"FORYOU": "General",
+		"QUICK_CREATE": "Quick Create",
+		"COMMAND": "Command",
+		"PLATFORM": "Platform",
+		"TEAM_DASHBOARD": "Team Dashboard",
+		"APPS_AND_URLS": "Apps & URLs",
 		"HOME": "Home",
 		"INBOX": "Inbox",
 		"PROJECTS": "Projects",
@@ -64,6 +69,9 @@
 		"ADD_TIME_ENTRY": "Add Time Entry",
 		"OPT_IN_UPDATES": "Opt-in to receive updates and news about {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "Subscribe to our newsletter",
+		"SUBSCRIBE": "Subscribe",
+		"SUBSCRIBING": "Subscribing...",
+		"EMAIL": "Email",
 		"VIEW_PROJECT": "View Project",
 		"SHARE_PROJECT": "Share Project",
 		"DELETE_PROJECT": "Delete Project",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "Passwords do not match"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "Press Enter to validate"
+		"ENTER_TO_VALIDATE": "Press Enter to validate",
+		"ENTER_A_COMMAND": "Enter a command..."
 	},
 	"team": {
 		"BACK_LABEL": "Back to Team",

--- a/apps/web/locales/es.json
+++ b/apps/web/locales/es.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "Tablero",
 		"FORYOU": "General",
+		"QUICK_CREATE": "Creación rápida",
+		"COMMAND": "Comando",
+		"PLATFORM": "Plataforma",
+		"TEAM_DASHBOARD": "Panel del Equipo",
+		"APPS_AND_URLS": "Aplicaciones y URLs",
 		"HOME": "Inicio",
 		"INBOX": "Bandeja de entrada",
 		"PROJECTS": "Proyectos",
@@ -40,6 +45,9 @@
 		"ADD_TIME_ENTRY": "Agregar entrada de tiempo",
 		"OPT_IN_UPDATES": "Opta por recibir actualizaciones y noticias sobre {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "Suscríbete a nuestro boletín",
+		"SUBSCRIBE": "Suscribirse",
+		"SUBSCRIBING": "Suscribiendo...",
+		"EMAIL": "Correo electrónico",
 		"VIEW_PROJECT": "Ver proyecto",
 		"SHARE_PROJECT": "Compartir proyecto",
 		"DELETE_PROJECT": "Eliminar proyecto",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "Las contraseñas no coinciden"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "Presione Enter para validar"
+		"ENTER_TO_VALIDATE": "Presione Enter para validar",
+		"ENTER_A_COMMAND": "Escribe un comando..."
 	},
 	"team": {
 		"BACK_LABEL": "Volver al equipo",

--- a/apps/web/locales/fr.json
+++ b/apps/web/locales/fr.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "Tableau de bord",
 		"FORYOU": "Général",
+		"QUICK_CREATE": "Création rapide",
+		"COMMAND": "Commande",
+		"PLATFORM": "Plateforme",
+		"TEAM_DASHBOARD": "Tableau de bord d'équipe",
+		"APPS_AND_URLS": "Applications et URL",
 		"HOME": "Accueil",
 		"INBOX": "Boîte de réception",
 		"PROJECTS": "Projets",
@@ -44,6 +49,9 @@
 		"ADD_TIME_ENTRY": "Ajouter une entrée de temps",
 		"OPT_IN_UPDATES": "Acceptez de recevoir des mises à jour et des nouvelles sur {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "Abonnez-vous à notre newsletter",
+		"SUBSCRIBE": "S'abonner",
+		"SUBSCRIBING": "Abonnement en cours...",
+		"EMAIL": "E-mail",
 		"VIEW_PROJECT": "Voir le projet",
 		"SHARE_PROJECT": "Partager le projet",
 		"DELETE_PROJECT": "Supprimer le projet",
@@ -1235,7 +1243,8 @@
 		}
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "Appuyez sur Entrée pour valider"
+		"ENTER_TO_VALIDATE": "Appuyez sur Entrée pour valider",
+		"ENTER_A_COMMAND": "Saisir une commande..."
 	},
 	"links": {
 		"common": {

--- a/apps/web/locales/he.json
+++ b/apps/web/locales/he.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "לוח מחוונים",
 		"FORYOU": "כללי",
+		"QUICK_CREATE": "יצירה מהירה",
+		"COMMAND": "פקודה",
+		"PLATFORM": "פלטפורמה",
+		"TEAM_DASHBOARD": "לוח מחוונים של הצוות",
+		"APPS_AND_URLS": "אפליקציות וכתובות URL",
 		"HOME": "בית",
 		"INBOX": "דואר נכנס",
 		"PROJECTS": "פרויקטים",
@@ -44,6 +49,9 @@
 		"ADD_TIME_ENTRY": "הוסף כניסת זמן",
 		"OPT_IN_UPDATES": "בחר לקבל עדכונים וחדשות על {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "הירשם לניוזלטר שלנו",
+		"SUBSCRIBE": "הירשם",
+		"SUBSCRIBING": "נרשם...",
+		"EMAIL": "אימייל",
 		"VIEW_PROJECT": "צפה בפרויקט",
 		"SHARE_PROJECT": "שתף פרויקט",
 		"DELETE_PROJECT": "מחק פרויקט",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "הסיסמאות אינן תואמות"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "לחץ Enter כדי לאמת"
+		"ENTER_TO_VALIDATE": "לחץ Enter כדי לאמת",
+		"ENTER_A_COMMAND": "הזן פקודה..."
 	},
 	"team": {
 		"BACK_LABEL": "חזור לצוות",

--- a/apps/web/locales/it.json
+++ b/apps/web/locales/it.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "Cruscotto",
 		"FORYOU": "Generale",
+		"QUICK_CREATE": "Creazione rapida",
+		"COMMAND": "Comando",
+		"PLATFORM": "Piattaforma",
+		"TEAM_DASHBOARD": "Dashboard del Team",
+		"APPS_AND_URLS": "App e URL",
 		"HOME": "Home",
 		"INBOX": "Posta in arrivo",
 		"PROJECTS": "Progetti",
@@ -44,6 +49,9 @@
 		"ADD_TIME_ENTRY": "Aggiungi voce di tempo",
 		"OPT_IN_UPDATES": "Acconsenti a ricevere aggiornamenti e notizie su {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "Iscriviti alla nostra newsletter",
+		"SUBSCRIBE": "Iscriviti",
+		"SUBSCRIBING": "Iscrizione in corso...",
+		"EMAIL": "Email",
 		"VIEW_PROJECT": "Visualizza progetto",
 		"SHARE_PROJECT": "Condividi progetto",
 		"DELETE_PROJECT": "Elimina progetto",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "Le password non corrispondono"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "Premi Invio per convalidare"
+		"ENTER_TO_VALIDATE": "Premi Invio per convalidare",
+		"ENTER_A_COMMAND": "Inserisci un comando..."
 	},
 	"team": {
 		"BACK_LABEL": "Torna al Team",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "Dashboard",
 		"FORYOU": "Algemeen",
+		"QUICK_CREATE": "Snel aanmaken",
+		"COMMAND": "Opdracht",
+		"PLATFORM": "Platform",
+		"TEAM_DASHBOARD": "Team Dashboard",
+		"APPS_AND_URLS": "Apps & URL's",
 		"HOME": "Startpagina",
 		"INBOX": "Postvak IN",
 		"PROJECTS": "Projecten",
@@ -44,6 +49,9 @@
 		"ADD_TIME_ENTRY": "Tijdinvoer toevoegen",
 		"OPT_IN_UPDATES": "Kies ervoor om updates en nieuws over {appName} te ontvangen.",
 		"SUBSCRIBE_NEWSLETTER": "Abonneer je op onze nieuwsbrief",
+		"SUBSCRIBE": "Abonneren",
+		"SUBSCRIBING": "Bezig met abonneren...",
+		"EMAIL": "E-mail",
 		"VIEW_PROJECT": "Project bekijken",
 		"SHARE_PROJECT": "Project delen",
 		"DELETE_PROJECT": "Project verwijderen",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "Wachtwoorden komen niet overeen"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "Druk op Enter om te valideren"
+		"ENTER_TO_VALIDATE": "Druk op Enter om te valideren",
+		"ENTER_A_COMMAND": "Voer een opdracht in..."
 	},
 	"team": {
 		"BACK_LABEL": "Terug naar team",

--- a/apps/web/locales/pl.json
+++ b/apps/web/locales/pl.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "Pulpit",
 		"FORYOU": "Ogólne",
+		"QUICK_CREATE": "Szybkie tworzenie",
+		"COMMAND": "Polecenie",
+		"PLATFORM": "Platforma",
+		"TEAM_DASHBOARD": "Panel Zespołu",
+		"APPS_AND_URLS": "Aplikacje i adresy URL",
 		"HOME": "Strona główna",
 		"INBOX": "Skrzynka odbiorcza",
 		"PROJECTS": "Projekty",
@@ -44,6 +49,9 @@
 		"ADD_TIME_ENTRY": "Dodaj wpis czasu",
 		"OPT_IN_UPDATES": "Zgódź się na otrzymywanie aktualizacji i wiadomości o {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "Zapisz się na nasz newsletter",
+		"SUBSCRIBE": "Subskrybuj",
+		"SUBSCRIBING": "Subskrybowanie...",
+		"EMAIL": "E-mail",
 		"VIEW_PROJECT": "Wyświetl projekt",
 		"SHARE_PROJECT": "Udostępnij projekt",
 		"DELETE_PROJECT": "Usuń projekt",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "Hasła nie są zgodne"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "Naciśnij Enter, aby potwierdzić"
+		"ENTER_TO_VALIDATE": "Naciśnij Enter, aby potwierdzić",
+		"ENTER_A_COMMAND": "Wpisz polecenie..."
 	},
 	"team": {
 		"BACK_LABEL": "Powrót do Zespołu",

--- a/apps/web/locales/pt.json
+++ b/apps/web/locales/pt.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "Painel",
 		"FORYOU": "Geral",
+		"QUICK_CREATE": "Criação rápida",
+		"COMMAND": "Comando",
+		"PLATFORM": "Plataforma",
+		"TEAM_DASHBOARD": "Dashboard da Equipe",
+		"APPS_AND_URLS": "Apps e URLs",
 		"HOME": "Início",
 		"INBOX": "Caixa de entrada",
 		"PROJECTS": "Projetos",
@@ -44,6 +49,9 @@
 		"ADD_TIME_ENTRY": "Adicionar Entrada de Tempo",
 		"OPT_IN_UPDATES": "Concorde em receber atualizações e notícias sobre {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "Inscreva-se na nossa newsletter",
+		"SUBSCRIBE": "Inscrever-se",
+		"SUBSCRIBING": "Inscrevendo...",
+		"EMAIL": "E-mail",
 		"VIEW_PROJECT": "Ver Projeto",
 		"SHARE_PROJECT": "Compartilhar Projeto",
 		"DELETE_PROJECT": "Excluir Projeto",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "As senhas não coincidem"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "Pressione Enter para validar"
+		"ENTER_TO_VALIDATE": "Pressione Enter para validar",
+		"ENTER_A_COMMAND": "Digite um comando..."
 	},
 	"team": {
 		"BACK_LABEL": "Voltar para a Equipe",

--- a/apps/web/locales/ru.json
+++ b/apps/web/locales/ru.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "Панель управления",
 		"FORYOU": "Общие",
+		"QUICK_CREATE": "Быстрое создание",
+		"COMMAND": "Команда",
+		"PLATFORM": "Платформа",
+		"TEAM_DASHBOARD": "Панель команды",
+		"APPS_AND_URLS": "Приложения и URL-адреса",
 		"HOME": "Главная",
 		"INBOX": "Входящие",
 		"PROJECTS": "Проекты",
@@ -44,6 +49,9 @@
 		"ADD_TIME_ENTRY": "Добавить запись времени",
 		"OPT_IN_UPDATES": "Согласитесь получать обновления и новости о {appName}.",
 		"SUBSCRIBE_NEWSLETTER": "Подпишитесь на нашу рассылку",
+		"SUBSCRIBE": "Подписаться",
+		"SUBSCRIBING": "Подписка...",
+		"EMAIL": "Эл. почта",
 		"VIEW_PROJECT": "Просмотр проекта",
 		"SHARE_PROJECT": "Поделиться проектом",
 		"DELETE_PROJECT": "Удалить проект",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "Пароли не совпадают"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "Нажмите Enter для подтверждения"
+		"ENTER_TO_VALIDATE": "Нажмите Enter для подтверждения",
+		"ENTER_A_COMMAND": "Введите команду..."
 	},
 	"team": {
 		"BACK_LABEL": "Вернуться в Команду",

--- a/apps/web/locales/zh.json
+++ b/apps/web/locales/zh.json
@@ -3,6 +3,11 @@
 	"sidebar": {
 		"DASHBOARD": "仪表板",
 		"FORYOU": "常规",
+		"QUICK_CREATE": "快速创建",
+		"COMMAND": "命令",
+		"PLATFORM": "平台",
+		"TEAM_DASHBOARD": "团队仪表板",
+		"APPS_AND_URLS": "应用和网址",
 		"HOME": "主页",
 		"INBOX": "收件箱",
 		"PROJECTS": "项目",
@@ -40,6 +45,9 @@
 		"ADD_TIME_ENTRY": "添加时间条目",
 		"OPT_IN_UPDATES": "选择接收关于 {appName} 的更新和新闻。",
 		"SUBSCRIBE_NEWSLETTER": "订阅我们的新闻通讯",
+		"SUBSCRIBE": "订阅",
+		"SUBSCRIBING": "订阅中...",
+		"EMAIL": "电子邮箱",
 		"VIEW_PROJECT": "查看项目",
 		"SHARE_PROJECT": "分享项目",
 		"DELETE_PROJECT": "删除项目",
@@ -1227,7 +1235,8 @@
 		"PASSWORDS_DO_NOT_MATCH": "密码不匹配"
 	},
 	"placeholders": {
-		"ENTER_TO_VALIDATE": "按Enter键验证"
+		"ENTER_TO_VALIDATE": "按Enter键验证",
+		"ENTER_A_COMMAND": "输入命令..."
 	},
 	"team": {
 		"BACK_LABEL": "返回团队",


### PR DESCRIPTION
Sidebar labels were hardcoded in English and stayed untranslated when switching language (e.g. Home, Inbox, Platform still showing in English while the rest of the UI was localized).

- Wire Home/Inbox to existing sidebar.HOME / sidebar.INBOX keys
- Add and wire sidebar.QUICK_CREATE, COMMAND, PLATFORM, TEAM_DASHBOARD, APPS_AND_URLS keys
- Add and wire placeholders.ENTER_A_COMMAND
- Add and wire common.SUBSCRIBE, SUBSCRIBING, EMAIL (opt-in form)
- Add useTranslations to nav-main and sidebar-command-form
- Provide translations for en, ar, bg, de, es, fr, he, it, nl, pl, pt, ru, zh (TEAM_DASHBOARD/EMAIL reuse existing localized value

# 🚀 Pull Request Title

_A short and clear title that describes what this PR does._

Example:
> Add Retry, Cache, and Logging Features to API Service

## Description

Please describe **what you did**, and **why**.

- What problem or feature does this PR address?
- What changes were made?
- Why are these changes useful?

Example:
> This PR adds advanced features to the API request system:
>
> - Retry failed requests with exponential delay
> - Cache GET responses with TTL
> - Log all requests and responses
> - Allow cancelling requests
>
> These features improve reliability, performance, and debugging.

## What Was Changed

### Major Changes

Example:
> Here are the major changes in that his PR adds
>
> - New `CookieManagement` class for cookie handling
> - Cancel requests using `AbortController`
> - Automatically inject tenant and organization headers

### Minor Changes

Example:
> Here are the minor changes in that his PR adds
>
> - Update `tast-status`  component style
> - Work on the theme toggler
> - Remove unused imports

## How to Test This PR

Please explain clearly how to test the changes locally:

Example:
>
> 1. Run the app with `yarn web:dev`
> 2. Open the browser at `http://localhost:3030`
> 3. Try navigating to a page that uses API calls (e.g., `/tasks`)
> 4. Check:
   >
   > - Logs in the console
   > - Retry works on failed requests
   > - Cache works on repeated GET requests
   > - Errors are handled properly
   > - Cancelling navigation cancels requests
   > - Remove unused imports

> If this PR affects UI:
>
> - Include before and after screenshots
> - Explain any design or UX changes

## Screenshots (if needed)

| Before           | After            |
| ---------------- | ---------------- |
| (Add screenshot) | (Add screenshot) |

> You can also add videos or logs here.

### Previous screenshots

Please add here videos or images of the previous status

### Current screenshots

Please add here videos or images of the current (new) status

## Related Issues

Please list related issues, tasks or discussions:

Example:
>
> - Closes #12343434344
> - Related to #567834232

## Type of Change

- [ ] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

Please confirm you did the following before asking for review:

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

_Add here any context, help, or known issues for the person reviewing:_

- Example: “The retry logic uses `setTimeout` for now – may need refinement.”
- Example: “PostHog is disabled in dev, enable it in `.env` to test logs.”

## ⚠️⚠️⚠️ Reviewers Suggested

- `@evereq` for architecture validation
- `@ndekocode` for integration review
- `@Innocent-Akim` for auth and cookie handling and assistance
- `@AnicetFantomas` and `@Sergemuhundu` for mobile app and some web issues
- `@Cedric921` and `@GloireMutaliko21` for complex issues


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix untranslated sidebar and opt‑in form labels by wiring them to i18n and adding missing keys. All 13 locales now show the correct translations for Home, Inbox, Platform, Quick Create, and command inputs.

- **Bug Fixes**
  - Replaced hardcoded labels/placeholders with `next-intl` keys in the sidebar, command form, and opt‑in form (Home, Inbox, Platform, Quick Create, command label/placeholder, email/subscribe).
  - Added keys: `sidebar.QUICK_CREATE`, `sidebar.COMMAND`, `sidebar.PLATFORM`, `sidebar.TEAM_DASHBOARD`, `sidebar.APPS_AND_URLS`, `placeholders.ENTER_A_COMMAND`, `common.SUBSCRIBE`, `common.SUBSCRIBING`, `common.EMAIL`; wired `sidebar.HOME` and `sidebar.INBOX`.
  - Implemented `useTranslations` in `nav-main` and `sidebar-command-form`; provided translations for `en`, `ar`, `bg`, `de`, `es`, `fr`, `he`, `it`, `nl`, `pl`, `pt`, `ru`, `zh`.

<sup>Written for commit 099e1e6b205b9c6b907516042a633b54bbf22a2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added translated labels for sidebar navigation, Quick Create, commands, platform sections, and dashboard links.
  * Localized command input labels and placeholders.
  * Added translated subscription form labels, including email, Subscribe, and Subscribing states, across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->