### PR TITLE
feat(desktop): support Azure Artifact Signing for Windows (gated)

### DIFF
--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -558,6 +558,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: "${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}"
@@ -756,6 +764,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: "${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}"

--- a/.scripts/bump-version-electron.js
+++ b/.scripts/bump-version-electron.js
@@ -136,11 +136,28 @@ module.exports.serverweb = async (isProd) => {
 		// WIN_CSC_KEY_PASSWORD env in CI (electron-builder signs automatically when they are set).
 		if (process.env.WINDOWS_PUBLISHER_NAME) {
 			package.build.win = package.build.win || {};
-			package.build.win.signtoolOptions = {
-				...(package.build.win.signtoolOptions || {}),
-				publisherName: process.env.WINDOWS_PUBLISHER_NAME,
-				rfc3161TimeStampServer: 'http://timestamp.digicert.com'
-			};
+			// Preferred path: Azure Artifact Signing (formerly Trusted Signing). Engaged only when a
+			// certificate profile name is supplied, i.e. Azure identity validation has completed and a
+			// profile exists. electron-builder authenticates with AZURE_TENANT_ID / AZURE_CLIENT_ID /
+			// AZURE_CLIENT_SECRET from the environment (DefaultAzureCredential).
+			if (process.env.AZURE_CERT_PROFILE_NAME) {
+				package.build.win.azureSignOptions = {
+					...(package.build.win.azureSignOptions || {}),
+					publisherName: process.env.WINDOWS_PUBLISHER_NAME,
+					endpoint: process.env.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/',
+					codeSigningAccountName: process.env.AZURE_CODE_SIGNING_ACCOUNT || 'ever',
+					certificateProfileName: process.env.AZURE_CERT_PROFILE_NAME
+				};
+				// Azure signing supersedes the PFX/signtool path; keep exactly one signer configured.
+				delete package.build.win.signtoolOptions;
+			} else {
+				// Fallback: PFX via WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD (signtool).
+				package.build.win.signtoolOptions = {
+					...(package.build.win.signtoolOptions || {}),
+					publisherName: process.env.WINDOWS_PUBLISHER_NAME,
+					rfc3161TimeStampServer: 'http://timestamp.digicert.com'
+				};
+			}
 		}
 
 		fs.writeFileSync('./apps/server-web/package.json', JSON.stringify(package, null, 2));


### PR DESCRIPTION
Follow-up to #4412. Adds the **Azure Artifact Signing** (formerly Trusted Signing) path next to the existing PFX signer for `apps/server-web`, so Windows signing flips to a publicly-trusted, Microsoft-rooted certificate the moment a certificate profile exists — with no further code change.

## Behaviour (all three states verified)

| Env | Result |
|---|---|
| no `WINDOWS_PUBLISHER_NAME` | no signer block — today's state (interim self-signed cert, verification off) |
| `WINDOWS_PUBLISHER_NAME` only | `signtoolOptions` — PFX path via `WIN_CSC_LINK` |
| `+ AZURE_CERT_PROFILE_NAME` | `azureSignOptions`, `signtoolOptions` removed (exactly one signer) |

## Changes
- `.scripts/bump-version-electron.js` — emits `win.azureSignOptions` when `AZURE_CERT_PROFILE_NAME` is set.
- `.github/workflows/desktop-server-web.apps.yml` — pass `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`/`AZURE_CERT_PROFILE_NAME` to both windows jobs, plus repo `vars` for account/endpoint (defaults `ever` / `https://eus.codesigning.azure.net/`). electron-builder authenticates via DefaultAzureCredential.

## Azure state (verified live)
Subscription `Ever`, account `ever` (East US, SKU Basic), endpoint `https://eus.codesigning.azure.net/`, provisioning Succeeded. The CI principal now holds **Artifact Signing Certificate Profile Signer** — note Azure **Owner does NOT** grant this (Owner has `dataActions: []`; signing is a data-plane action).

Remaining prerequisite: Azure **identity validation → certificate profile** (portal, business verification). Until then this path stays dormant and builds are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Azure Artifact Signing for Windows builds in `apps/server-web`. When an Azure certificate profile is configured, signing switches to a Microsoft-rooted cert with no code changes.

- **New Features**
  - Emit `win.azureSignOptions` in `.scripts/bump-version-electron.js` when `AZURE_CERT_PROFILE_NAME` is set and remove `signtoolOptions` to keep a single signer; otherwise use the existing PFX path, or no signer if `WINDOWS_PUBLISHER_NAME` is unset.
  - Update CI to pass `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_CERT_PROFILE_NAME`, and optional `AZURE_CODE_SIGNING_ACCOUNT`/`AZURE_CODE_SIGNING_ENDPOINT` (defaults `ever` / `https://eus.codesigning.azure.net/`) to Windows jobs; `electron-builder` uses DefaultAzureCredential.

<sup>Written for commit 1c52aaac382bc7a36aef9744d1f765162cf4695f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release & Distribution**
  * Windows releases can now use Azure Artifact Signing for improved certificate-based signing.
  * Existing PFX-based signing remains available as a fallback when Azure signing is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->