### PR TITLE
fix(ci): give the Bump step the Windows signing config (Azure signing was silently inert)

### DIFF
--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -491,6 +491,11 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverweb(true))
         env:
+          # Windows signing config must be visible to the BUMP step: this script writes build.win.azureSignOptions into package.json, which electron-builder reads later.
+          WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           PROJECT_REPO: "https://github.com/ever-co/ever-teams.git"
           DESKTOP_WEB_SERVER_APP_NAME: "ever-teams-web-server"
           DESKTOP_WEB_SERVER_REPO_NAME: "ever-teams-web-server"
@@ -701,6 +706,11 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverweb(true))
         env:
+          # Windows signing config must be visible to the BUMP step: this script writes build.win.azureSignOptions into package.json, which electron-builder reads later.
+          WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           PROJECT_REPO: "https://github.com/ever-co/ever-teams.git"
           DESKTOP_WEB_SERVER_APP_NAME: "ever-teams-web-server"
           DESKTOP_WEB_SERVER_REPO_NAME: "ever-teams-web-server"


### PR DESCRIPTION
**Bug in the wiring I added in #4414.** The bump script writes `build.win.azureSignOptions` into `apps/server-web/package.json`; electron-builder reads that file later. But I had put the signing config env on the **Build** step only — so the **Bump** step never saw `AZURE_CERT_PROFILE_NAME`/`WINDOWS_PUBLISHER_NAME` and never wrote `azureSignOptions`.

**Impact:** the build would silently fall back to the `WIN_CSC_LINK` PFX path — i.e. sign with the **interim self-signed cert** — while a green build looked like Azure signing was live. `publisherName` would never be written either, so update verification stayed off.

**Fix:** add `WINDOWS_PUBLISHER_NAME`, `AZURE_CERT_PROFILE_NAME`, `AZURE_CODE_SIGNING_ACCOUNT`, `AZURE_CODE_SIGNING_ENDPOINT` to the Bump step of `release-windows` and `release-windows-arm64`. Azure *credentials* stay on the Build step, where electron-builder authenticates.

Verified programmatically: every `release-windows*` job now has bump-step config **and** build-step credentials.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Azure code signing by exposing Windows signing config to the Bump step. Previously only the Build step had these envs, so the bump script skipped writing `build.win.azureSignOptions` and `publisherName` to `apps/server-web/package.json`, causing fallback to `WIN_CSC_LINK` (self-signed PFX) and disabling `electron-updater` verification. Now the Bump step writes the config, and `electron-builder` uses it later.

- In `.github/workflows/desktop-server-web.apps.yml`, the Bump step for `release-windows` and `release-windows-arm64` now exports: `WINDOWS_PUBLISHER_NAME`, `AZURE_CERT_PROFILE_NAME`, `AZURE_CODE_SIGNING_ACCOUNT`, `AZURE_CODE_SIGNING_ENDPOINT`.
- Azure credentials (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`) remain only on the Build step. No other workflow logic changes or migrations.

<sup>Written for commit 6ae524690716a05fb6936d11050c7a0e6a6d6350. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows release packaging by adding signing configuration for both x64 and ARM64 builds.
  * Enabled publisher and cloud-based signing settings during version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->