### PR TITLE
fix(ci): install .NET SDK on Windows runners so Azure Trusted Signing can run

### DIFF
--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -550,6 +550,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Web Server App
         shell: cmd
         run: 'yarn build:web-server:windows:release:gh:x64'
@@ -760,6 +769,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Web Server App
         shell: cmd


### PR DESCRIPTION
Azure Trusted Signing shells out to `Invoke-TrustedSigning`, which installs the `sign` **dotnet global tool** at sign time. The self-hosted Windows runners have **no .NET SDK**, so that install fails and signing never happens.

Evidence from the live run (ever-gauzy stage-apps, `release-windows`):

```
Invoke-TrustedSigning -Endpoint https://eus.codesigning.azure.net/ -CertificateProfileName *** -CodeSigningAccountName ever ...
    Installing package: Microsoft.Trusted.Signing.Client 1.0.95
    Installing package: sign 0.9.1-beta.24469.1
https://aka.ms/dotnet/sdk-not-found
Failed to install package: sign 0.9.1-beta.24469.1
```

NuGet itself is reachable (`Found existing package source: https://www.nuget.org/api/v2/`) — the only thing missing is the SDK. Note the signing **configuration is already correct**: the command above carries our real endpoint, account and certificate profile.

**Fix:** add `actions/setup-dotnet@v4` (8.0.x) immediately before the Build step of each Windows job — one step per job. Provisioning it in the workflow rather than on the host keeps the requirement in Git, applies to every runner, and is trivially reversible.

Verified: exactly one step per `release-windows`/`release-windows-arm64` job, all workflows still parse as valid YAML.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs the .NET SDK on Windows CI runners so Azure Trusted Signing can run. Previously `Invoke-TrustedSigning` failed with "sdk-not-found" when installing the `sign` tool and signing was skipped; with the SDK installed, signing now proceeds in Windows release jobs.

• Adds `actions/setup-dotnet@v4` with `dotnet-version: 8.0.x` immediately before the Build step in both Windows jobs (`release-windows`, `release-windows-arm64`).
• No changes to signing configuration or secrets; only CI environment updates on Windows runners.
• No runner image migration required; the requirement lives in Git.

<sup>Written for commit ab4cb6e9f21cc3a2938713b381baf1721359abef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

