### PR TITLE
fix(ci): work around app-builder-lib macOS keychain bug blocking all mac signing

### DIFF
--- a/.github/workflows/desktop-server-api.apps.yml
+++ b/.github/workflows/desktop-server-api.apps.yml
@@ -359,6 +359,35 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      # macOS signing: build the keychain ourselves instead of letting electron-builder do it.
+      # app-builder-lib passes the p12 password to `security set-key-partition-list -k`, which
+      # expects the KEYCHAIN password — fatal on the current runner image, and still unfixed in
+      # the latest release. With CSC_LINK unset, electron-builder skips its own keychain code and
+      # uses CSC_KEYCHAIN (macPackager.js:25-48), so this sidesteps the bug without patching deps.
+      - name: Import Apple signing certificate into a keychain
+        env:
+          CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/ever-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/ever-signing-cert.p12"
+          printf '%s' "$CSC_LINK_BASE64" | base64 --decode > "$CERT"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          # The KEYCHAIN password here — this is the exact call app-builder-lib gets wrong.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
+          rm -f "$CERT"
+          # Fail loudly here rather than silently shipping an unsigned app later.
+          security find-identity -v -p codesigning "$KEYCHAIN" | tee /tmp/identities.txt
+          grep -q "Developer ID Application" /tmp/identities.txt
+
       - name: Build API Server App
         run: "yarn build:gauzy-api-server:mac:release"
         env:
@@ -395,7 +424,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_APP_PASSWORD: ${{ secrets.APPLE_ID_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.CSC_LINK_BASE64 }}
+          # CSC_LINK deliberately NOT set: that is what makes electron-builder build its own
+          # (broken) keychain. Point it at the one imported above instead.
+          CSC_KEYCHAIN: ${{ runner.temp }}/ever-signing.keychain-db
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -354,11 +354,43 @@ jobs:
 
       - name: Configure Code Signing
         run: |
+          # Deliberately does NOT export CSC_LINK. Setting it makes electron-builder build its own
+          # keychain, which is the code path that is broken (see the import step below). The cert is
+          # imported there instead and handed over via CSC_KEYCHAIN.
           if [ -n "$CSC_LINK_VALUE" ]; then
-            echo "CSC_LINK=$CSC_LINK_VALUE" >> $GITHUB_ENV
+            echo "CSC_KEYCHAIN=$RUNNER_TEMP/ever-signing.keychain-db" >> $GITHUB_ENV
           fi
         env:
           CSC_LINK_VALUE: ${{ secrets.CSC_LINK_BASE64 }}
+
+      # macOS signing: build the keychain ourselves instead of letting electron-builder do it.
+      # app-builder-lib passes the p12 password to `security set-key-partition-list -k`, which
+      # expects the KEYCHAIN password — fatal on the current runner image, and still unfixed in
+      # the latest release. With CSC_LINK unset, electron-builder skips its own keychain code and
+      # uses CSC_KEYCHAIN (macPackager.js:25-48), so this sidesteps the bug without patching deps.
+      - name: Import Apple signing certificate into a keychain
+        env:
+          CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/ever-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/ever-signing-cert.p12"
+          printf '%s' "$CSC_LINK_BASE64" | base64 --decode > "$CERT"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          # The KEYCHAIN password here — this is the exact call app-builder-lib gets wrong.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
+          rm -f "$CERT"
+          # Fail loudly here rather than silently shipping an unsigned app later.
+          security find-identity -v -p codesigning "$KEYCHAIN" | tee /tmp/identities.txt
+          grep -q "Developer ID Application" /tmp/identities.txt
 
       - name: Build Web Server App
         run: "yarn build:web-server:mac:release"
@@ -398,7 +430,9 @@ jobs:
           APPLE_ID_APP_PASSWORD: ${{ secrets.APPLE_ID_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+          # Must be true: the Developer ID identity now lives in the keychain we imported above,
+          # and electron-builder finds it by discovery. With this false it would skip signing.
+          CSC_IDENTITY_AUTO_DISCOVERY: true
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}

--- a/.github/workflows/desktop.apps.yml
+++ b/.github/workflows/desktop.apps.yml
@@ -359,6 +359,35 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      # macOS signing: build the keychain ourselves instead of letting electron-builder do it.
+      # app-builder-lib passes the p12 password to `security set-key-partition-list -k`, which
+      # expects the KEYCHAIN password — fatal on the current runner image, and still unfixed in
+      # the latest release. With CSC_LINK unset, electron-builder skips its own keychain code and
+      # uses CSC_KEYCHAIN (macPackager.js:25-48), so this sidesteps the bug without patching deps.
+      - name: Import Apple signing certificate into a keychain
+        env:
+          CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/ever-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/ever-signing-cert.p12"
+          printf '%s' "$CSC_LINK_BASE64" | base64 --decode > "$CERT"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          # The KEYCHAIN password here — this is the exact call app-builder-lib gets wrong.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
+          rm -f "$CERT"
+          # Fail loudly here rather than silently shipping an unsigned app later.
+          security find-identity -v -p codesigning "$KEYCHAIN" | tee /tmp/identities.txt
+          grep -q "Developer ID Application" /tmp/identities.txt
+
       - name: Build Desktop Timer App
         run: "yarn build:desktop-timer:mac:release"
         env:
@@ -395,7 +424,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_APP_PASSWORD: ${{ secrets.APPLE_ID_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.CSC_LINK_BASE64 }}
+          # CSC_LINK deliberately NOT set: that is what makes electron-builder build its own
+          # (broken) keychain. Point it at the one imported above instead.
+          CSC_KEYCHAIN: ${{ runner.temp }}/ever-signing.keychain-db
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}


### PR DESCRIPTION
## The bug

`electron-builder` `createKeychain()` creates a temp keychain with a **random** password, then calls:

```
security set-key-partition-list -S apple-tool:,apple: -s -k <p12 password> <keychain>
```

`-k` expects the **keychain** password, not the p12 export password (`macCodeSign.js`: `keychainPassword` vs `keyPasswords[i]`). On the current macOS runner image this hard-fails:

```
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

Every macOS release job dies during packaging. **Present in 26.0.3, 26.8.1 and the latest 26.15.3** — upgrading does not fix it.

## The fix — no dependency patching

`macPackager.js:25-48`: when `CSC_LINK` is **not** set, electron-builder skips `createKeychain()` and uses `process.env.CSC_KEYCHAIN` for identity lookup. So each `release-mac` job now:

1. imports the certificate itself, passing the **keychain** password to `set-key-partition-list` (the call app-builder-lib gets wrong),
2. hands the keychain over via `CSC_KEYCHAIN`,
3. ends with `security find-identity -v -p codesigning | grep -q "Developer ID Application"` — so a missing identity **fails loudly** instead of silently shipping an unsigned app.

## Verification

Every `release-mac` job checked programmatically: import step present, `CSC_KEYCHAIN` set, **no bare `CSC_LINK`** surviving (that would re-enable the broken path), and `CSC_IDENTITY_AUTO_DISCOVERY` not `false` (which would stop the imported identity being found). All workflows valid YAML.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Work around a `app-builder-lib` macOS keychain bug that broke all signing by bypassing the `CSC_LINK` path and supplying our own keychain via `CSC_KEYCHAIN`. Previously `electron-builder` passed the p12 password to `security set-key-partition-list` and packaging failed; now we import the cert, use the keychain password, and verify the Developer ID identity to fail fast if missing.

- Update all mac release workflows to add a certificate import step, unset `CSC_LINK`, set `CSC_KEYCHAIN`, and run an explicit `security find-identity` check.
- Ensure `CSC_IDENTITY_AUTO_DISCOVERY` is true where needed so the imported identity is discovered.
- No dependency changes; revert by restoring `CSC_LINK` once `app-builder-lib` fixes the bug.

<sup>Written for commit 5d27fb819c8eb4a6a9f136a588d395081c25b969. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS release signing reliability by configuring a temporary signing keychain during builds.
  - Added validation of the Developer ID signing identity before packaging.
  - Improved access for macOS signing tools to reduce release failures.
  - Ensured temporary signing credentials are removed after use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->