### PR TITLE
fix(mobile): pin Node on EAS builders + stop uploading VERDACCIO_TOKEN to Expo

### DIFF
--- a/.github/workflows/mobile.apps.android.yml
+++ b/.github/workflows/mobile.apps.android.yml
@@ -92,6 +92,15 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
+      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
+      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
+      # build archive, so the token was being uploaded to Expo (their log shows
+      # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
+      # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
+      - name: Restore .npmrc before EAS upload
+        shell: bash
+        run: git checkout -- .npmrc || true
+
       - name: Build on EAS
         run: cd apps/mobile && eas build --profile production --platform android --non-interactive
 

--- a/.github/workflows/mobile.apps.ios.yml
+++ b/.github/workflows/mobile.apps.ios.yml
@@ -95,6 +95,15 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
+      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
+      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
+      # build archive, so the token was being uploaded to Expo (their log shows
+      # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
+      # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
+      - name: Restore .npmrc before EAS upload
+        shell: bash
+        run: git checkout -- .npmrc || true
+
       - name: Build on EAS
         run: cd apps/mobile && eas build --profile production --platform ios --non-interactive
 

--- a/.github/workflows/mobile.apps.stage.android.yml
+++ b/.github/workflows/mobile.apps.stage.android.yml
@@ -92,6 +92,15 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
+      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
+      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
+      # build archive, so the token was being uploaded to Expo (their log shows
+      # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
+      # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
+      - name: Restore .npmrc before EAS upload
+        shell: bash
+        run: git checkout -- .npmrc || true
+
       - name: Build on EAS
         run: cd apps/mobile && eas build --profile internal --platform android --non-interactive
 

--- a/.github/workflows/mobile.apps.stage.ios.yml
+++ b/.github/workflows/mobile.apps.stage.ios.yml
@@ -95,6 +95,15 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
+      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
+      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
+      # build archive, so the token was being uploaded to Expo (their log shows
+      # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
+      # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
+      - name: Restore .npmrc before EAS upload
+        shell: bash
+        run: git checkout -- .npmrc || true
+
       - name: Build on EAS
         run: cd apps/mobile && eas build --profile internal --platform ios --non-interactive
 

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -5,6 +5,7 @@
 	},
 	"build": {
 		"development": {
+			"node": "24.14.0",
 			"developmentClient": true,
 			"distribution": "internal",
 			"channel": "development",
@@ -15,6 +16,7 @@
 			}
 		},
 		"preview": {
+			"node": "24.14.0",
 			"distribution": "internal",
 			"channel": "preview",
 			"env": {
@@ -25,6 +27,7 @@
 			}
 		},
 		"production": {
+			"node": "24.14.0",
 			"autoIncrement": true,
 			"channel": "production",
 			"env": {
@@ -35,6 +38,7 @@
 			}
 		},
 		"internal": {
+			"node": "24.14.0",
 			"distribution": "internal",
 			"channel": "internal",
 			"env": {


### PR DESCRIPTION
## 1. Mobile releases broken since 2025-12-07

EAS builders run **Node 20.19.2**; the root `package.json` declares `engines.node ">=24.x.x"`, so yarn 1 aborts during *Validating package.json*:

```
error ever-teams@0.1.0: The engine "node" is incompatible with this module.
Expected version ">=24.x.x". Got "20.19.2"
```

Builds died in **17-42 s**. The GitHub side always passed (runner Node 24.14.0), so the workflow only surfaced the opaque *"Unknown error. See logs of the Install dependencies build phase"*. `eas.json` pinned neither `node` nor `image`, so the image default won.

**Fix:** pin `node: 24.14.0` in all four build profiles (matches `.nvmrc`/`.node-version`). Also fixes the `internal` profile used by the stage mobile workflows.

Regression came from ae51cb5ca (#4199), which raised `engines` without an eas.json pin. These workflows only fire on pushes to `apps`, so it sat unnoticed ~5 months (last green mobile release: 2025-11-13).

## 2. VERDACCIO_TOKEN is being uploaded to Expo

`Configure Registry` appends the internal registry **and `VERDACCIO_TOKEN`** to `.npmrc` — a **git-tracked** file. eas-cli ships modified tracked files in the build archive, and Expo's own log confirms receipt:

```
PREPARE_PROJECT | .npmrc found at .npmrc
```

**Fix:** `git checkout -- .npmrc` immediately before `eas build`. Keeps the token local, and prevents Expo's builders trying to resolve `packages.ever.co`, which they cannot reach — a failure that would have surfaced the moment the Node pin let the install proceed.

Neither lockfile references `packages.ever.co` (0 hits), so dependency resolution is unaffected.

**Recommend rotating `VERDACCIO_TOKEN`** — it has been sent to a third party on every mobile build since 3022f0c61 (2026-03-02).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Node 24.14.0 for all EAS build profiles and restores `.npmrc` before upload to stop leaking `VERDACCIO_TOKEN`. Previously EAS builders used Node 20.19.2, causing Yarn’s engine check to fail; now builds run under Node 24 and secrets are kept local.

- Sets `"node": "24.14.0"` in `apps/mobile/eas.json` for `development`, `preview`, `production`, and `internal` (matches `.nvmrc`/`.node-version`).
- Adds a “Restore .npmrc before EAS upload” step in all mobile workflows to prevent `eas-cli` from shipping a tracked `.npmrc` to Expo and to avoid attempts to resolve the internal registry from Expo builders.
- Required action: rotate `VERDACCIO_TOKEN`.

<sup>Written for commit f92fddafce5d0e9a5377f99923bfc686ce8bef63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

