### PR TITLE
fix(mobile): unblock iOS EAS builds (Storybook's nested sharp) + supply the Apple Team ID

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,20 @@
+# Files excluded from the archive uploaded to EAS Build.
+#
+# EAS uploads the repo root (apps/mobile is a yarn workspace) and runs
+# `yarn install --frozen-lockfile --production false` at the root, which installs the deps of
+# EVERY workspace it finds — including ones a mobile build has no use for.
+#
+# apps/storybook pulls @storybook/nextjs, which carries its own nested legacy `sharp`. That copy
+# has no prebuilt binary for Node 24 + darwin-arm64, so node-gyp compiles it from source on the
+# EAS macOS builder and fails:
+#
+#   node_modules/@storybook/nextjs/node_modules/sharp .. metadata.cc:
+#   error: no member named 'NewOrCopy' in 'Napi::Buffer<char>'  (x5)  -> make: *** exit 2
+#   -> yarn install --frozen-lockfile --production false exited with non-zero code: 1
+#
+# That broke every iOS build. Excluding the workspace keeps it out of the archive, so yarn never
+# installs its dependencies. Safe with --frozen-lockfile: yarn 1 fails when the lockfile would need
+# to CHANGE, not when it contains extra entries.
+#
+# Kept deliberately narrow — only the workspace that actually breaks the build.
+apps/storybook

--- a/.github/workflows/mobile.apps.ios.yml
+++ b/.github/workflows/mobile.apps.ios.yml
@@ -55,8 +55,14 @@ jobs:
           # reads these two env vars directly (credentials/ios/appstore/resolveCredentials.js).
           # Without them the build still proceeds, but Apple-side provisioning-profile validation
           # is silently SKIPPED — so set them and keep that check active.
-          echo "EXPO_APPLE_TEAM_ID=${{ secrets.APPLE_TEAM_ID }}" >> $GITHUB_ENV
+          #
+          # Referenced via the step's env: block rather than interpolated with ${{ }} directly in
+          # this script — expanding a secret inline splices its value into the shell source, which
+          # is a script-injection risk (SonarCloud: "Avoid expanding secrets in a run block").
+          echo "EXPO_APPLE_TEAM_ID=$APPLE_TEAM_ID_VALUE" >> $GITHUB_ENV
           echo "EXPO_APPLE_TEAM_TYPE=COMPANY_OR_ORGANIZATION" >> $GITHUB_ENV
+        env:
+          APPLE_TEAM_ID_VALUE: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Replace Secrets in eas.json
         run: |

--- a/.github/workflows/mobile.apps.ios.yml
+++ b/.github/workflows/mobile.apps.ios.yml
@@ -49,6 +49,14 @@ jobs:
           echo "APPLE_ID=${{ secrets.APPLE_ID }}" >> $GITHUB_ENV
           echo "APPSTORE_ISSUER_ID=${{ secrets.APPSTORE_ISSUER_ID }}" >> $GITHUB_ENV
           echo "APPSTORE_API_KEY_ID=${{ secrets.APPSTORE_API_KEY_ID }}" >> $GITHUB_ENV
+          # The App Store Connect API key stored in the EAS credentials service has no Apple Team
+          # associated, so eas-cli receives teamId=undefined and falls through to an interactive
+          # prompt ("Apple Team ID:") that cannot be answered under --non-interactive. eas-cli
+          # reads these two env vars directly (credentials/ios/appstore/resolveCredentials.js).
+          # Without them the build still proceeds, but Apple-side provisioning-profile validation
+          # is silently SKIPPED — so set them and keep that check active.
+          echo "EXPO_APPLE_TEAM_ID=${{ secrets.APPLE_TEAM_ID }}" >> $GITHUB_ENV
+          echo "EXPO_APPLE_TEAM_TYPE=COMPANY_OR_ORGANIZATION" >> $GITHUB_ENV
 
       - name: Replace Secrets in eas.json
         run: |


### PR DESCRIPTION
## 1. The actual iOS blocker — Storybook's nested `sharp`

EAS uploads the repo root (`apps/mobile` is a yarn workspace) and runs `yarn install --frozen-lockfile --production false` there, installing **every** workspace's deps. `apps/storybook` pulls `@storybook/nextjs`, which carries its own **nested legacy `sharp`**. That copy has no prebuilt for Node 24 + darwin-arm64, so node-gyp compiles from source on the EAS macOS builder and dies:

```
node_modules/@storybook/nextjs/node_modules/sharp .. metadata.cc:
error: no member named 'NewOrCopy' in 'Napi::Buffer<char>'  (x5)  ->  make: exit 2
-> yarn install --frozen-lockfile --production false exited with non-zero code: 1
```

**This — not the Apple credentials warning — is what fails every iOS build.** It surfaced only after the Node 24 pin (#4419): the nested sharp had a usable prebuilt on Node 20. Android is unaffected because its Linux builder finds one.

**Fix:** `.easignore` excluding `apps/storybook` so yarn never installs its deps. Safe with `--frozen-lockfile` — yarn 1 fails when the lockfile would need to **change**, not on extra entries. Kept deliberately narrow: only the workspace that actually breaks.

## 2. Apple Team ID — not the blocker, but worth fixing

`Failed to authenticate with the App Store Connect API key ... Apple Team ID:` is **non-fatal** — that eas-cli path never throws, and the log continues to `All credentials are ready to build`. But when it fails, **Apple-side provisioning-profile validation is silently skipped**.

The ASC key in the EAS credentials service has no Apple Team attached, so eas-cli gets `teamId=undefined` and prompts. Setting `EXPO_APPLE_TEAM_ID` / `EXPO_APPLE_TEAM_TYPE` (both read directly by eas-cli in `credentials/ios/appstore/resolveCredentials.js`) restores the check.

**`9YKEUZ3T24` is not a guess** — it is printed in the job's own EAS credential summary (`Apple Team 9YKEUZ3T24 (EVER CO. LTD (Company/Organization))`) and matches the ever-gauzy macOS Developer ID. Stored as the `APPLE_TEAM_ID` repo secret.

> The durable fix for (2) is attaching the Apple Team to the ASC key in the **Expo dashboard** — an owner action. These env vars make CI correct regardless.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks iOS EAS builds by excluding Storybook from the EAS archive and supplying the Apple Team ID in CI. Previously, root `yarn install` failed from `@storybook/nextjs`’s nested legacy `sharp` on Node 24 (darwin-arm64), and App Store Connect validation was skipped when `eas-cli` lacked a Team ID.

- Add `.easignore` to omit `apps/storybook` so EAS does not install its deps. This avoids the `sharp` source-build failure and is safe with Yarn 1 `--frozen-lockfile` (scope is limited to the breaking workspace).
- In `.github/workflows/mobile.apps.ios.yml`, set `EXPO_APPLE_TEAM_ID` from the `APPLE_TEAM_ID` secret via a step env var and `EXPO_APPLE_TEAM_TYPE=COMPANY_OR_ORGANIZATION`. This prevents the non-interactive prompt, re-enables App Store Connect provisioning-profile validation, and avoids inline secret expansion.

<sup>Written for commit 7b15901411689bf2ce5fb5fc7df85002e028f718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS Node 24 iOS build reliability by excluding incompatible Storybook dependencies from EAS archives.
  * Prevented non-interactive iOS builds from pausing for Apple team selection.
  * Preserved Apple provisioning-profile validation during automated builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->