### PR TITLE
fix(ci): complete the ARM64 signing gate (drop WIN_CSC_LINK on ARM64)

### DIFF
--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -821,14 +821,14 @@ jobs:
           USE_HARD_LINKS: false
           ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\.cache\electron-builder
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          # Windows Authenticode signing: electron-builder signs automatically when WIN_CSC_LINK is set.
           # Empty secret => signing is skipped (no error). Trusted-cert verification engages only when
           # WINDOWS_PUBLISHER_NAME is also set (see .scripts/bump-version-electron.js).
-          WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+          # WIN_CSC_LINK is deliberately NOT passed on ARM64. electron-builder auto-signs
+          # whenever it is set, independently of azureSignOptions, and then spawns a signtool
+          # that does not exist for ARM64 in its bundled winCodeSign package:
+          #   spawn ...\winCodeSign-2.6.0\windows-10\arm64\signtool.exe ENOENT
+          # ARM64 therefore ships unsigned (see the Bump step). x64 still signs via Azure.
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
-          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
Follow-up to the ARM64 signing gate. That change stopped `azureSignOptions` being written, but ARM64 still failed:

```
Exit code: ENOENT. spawn
...\.cache\electron-builder\winCodeSign\winCodeSign-2.6.0\windows-10\arm64\signtool.exe ENOENT
```

**There were two independent signing triggers, and I only closed one.** electron-builder v26 auto-signs whenever `WIN_CSC_LINK` is in the environment (`windowsSignToolManager: getCscLink("WIN_CSC_LINK")`) regardless of `azureSignOptions` — and on ARM64 it reaches for a signtool that does not ship in its bundled `winCodeSign` package.

**Fix:** drop `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` from the ARM64 Build step. ARM64 now builds **unsigned and succeeds**; x64 keeps both and still signs via Azure.

The first gate did work as far as it went — the log confirms `SignTool failed with exit code 3` is gone and Azure signing is no longer attempted on ARM64.

**Verified** per job with the YAML parser: every `release-windows` Build step still carries both PFX vars; every `release-windows-arm64` Build step carries neither.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the ARM64 signing gate by removing the PFX-based auto-sign trigger. Previously `electron-builder` auto-signed whenever `WIN_CSC_LINK` was set, which on ARM64 attempted a missing `winCodeSign` ARM64 signtool and failed; now ARM64 builds unsigned and succeeds while x64 continues signing via Azure.

- Remove `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD` from the `release-windows-arm64` Build step; keep them for `release-windows`.
- Result: ARM64 artifacts are unsigned; x64 signing and publishing are unchanged.

<sup>Written for commit 4afea42f02519f0d5c193d0e14953e18ec9297df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows ARM64 build configuration to reflect that these builds are unsigned.
  * Windows x64 builds continue using Azure-based code signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->