### PR TITLE
ci: route the SDK release install through the internal Verdaccio cache

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,8 @@
 	"caseSensitive": false,
 	"$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
 	"words": [
+		"yarnrc",
+		"USERCONFIG",
 		"cicd",
 		"creds",
 		"easignore",

--- a/.github/workflows/release.sdk.prod.yml
+++ b/.github/workflows/release.sdk.prod.yml
@@ -65,7 +65,7 @@ jobs:
           echo "✅ NPM authentication configured"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/release.sdk.prod.yml
+++ b/.github/workflows/release.sdk.prod.yml
@@ -64,8 +64,34 @@ jobs:
           echo "@ever-teams:registry=https://registry.npmjs.org/" >> ~/.npmrc
           echo "✅ NPM authentication configured"
 
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies (Yarn)
         run: yarn install --frozen-lockfile
+
+      - name: Restore registry config (keep the checkout npmjs-clean)
+        # Configure Registry above may rewrite yarn.lock and append registry lines
+        # to the tracked .npmrc/.yarnrc so the install resolves through the internal
+        # Verdaccio cache. Later steps run `git add .` + push version bumps and then
+        # publish to npmjs - a committed rewritten lockfile or a leftover project-level
+        # registry= line pointing at a LAN VIP must never survive past the install.
+        # Tracked files are restored; untracked leftovers are removed.
+        if: always()
+        run: |
+          for f in yarn.lock .npmrc .yarnrc; do
+            if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+              git checkout -- "$f"
+            else
+              rm -f "$f"
+            fi
+          done
+          rm -f yarn.lock.rewritten package-lock.json.rewritten
 
       - name: Build SDK packages
         run: |


### PR DESCRIPTION
Part of the fleet-wide Verdaccio rollout (owner goal: **traffic reduction** — all repos resolve npm installs through the internal cache on self-hosted runners).

Uses the shared action `ever-co/ever-gauzy/.github/actions/configure-registry` pinned to `9459d29e` ([ever-co/ever-gauzy#10029](https://github.com/ever-co/ever-gauzy/pull/10029)), which probes the VIP and falls back to npmjs quietly on any runner that cannot reach it — GitHub-hosted fallback runs are unaffected.

Per-job decisions:
- **release.sdk.prod.yml** — `release` (`RUNNER_LINUX_X64_4`): Configure Registry added before `yarn install --frozen-lockfile` (yarn repo → the yarn.lock rewrite is load-bearing; `--frozen-lockfile` tolerates the registry-host rewrite because integrity hashes are unchanged).
- **Paired restore step immediately after the install** (`if: always()`): this workflow later runs `git add .` + `git push` (changeset version bumps) and then **publishes to npmjs**. A rewritten `yarn.lock` or the registry lines the action appends to the tracked `.npmrc`/`.yarnrc` must never be committed or influence `yarn publish` — the restore puts every tracked file back (`yarn.lock`, `.npmrc`, `.yarnrc`) and removes untracked leftovers before any build/version/publish step runs.

Only the install itself flows through the cache; the publish path (auth via `~/.npmrc` + `NODE_AUTH_TOKEN`) is byte-identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the SDK release job’s dependency install through the internal Verdaccio cache to reduce external npm traffic. Previously installs always hit npmjs; now they use the cache when reachable and fall back to npmjs. Publish behavior is unchanged.

- Adds Configure Registry before `yarn install --frozen-lockfile` in `.github/workflows/release.sdk.prod.yml`, using `ever-co/ever-gauzy/.github/actions/configure-registry` (now pinned to a version with an errexit-guarded tracked-file probe). The action probes the VIP and silently falls back to npmjs when unreachable.
- Adds a restore step (`if: always()`) immediately after install to revert any `yarn.lock` rewrite and remove registry lines from tracked `.npmrc`/`.yarnrc`, preventing accidental commits and ensuring `yarn publish` uses npmjs via `~/.npmrc` and `NODE_AUTH_TOKEN`.
- Updates `.cspell.json` to include `yarnrc` and `USERCONFIG` to avoid false positives in CI.

<sup>Written for commit eee7f23a9bbd1e28d2290a90616112c4ea8ea0d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability for package publishing.
  * Added safeguards to restore registry settings after dependency installation, helping ensure consistent versioning and publishing.
  * Updated project tooling to recognize additional registry configuration terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->