### PR TITLE
chore: cascade develop -> stage (Verdaccio configure-registry in CI)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,8 @@
 	"caseSensitive": false,
 	"$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
 	"words": [
+		"yarnrc",
+		"USERCONFIG",
 		"cicd",
 		"creds",
 		"easignore",

--- a/.github/workflows/desktop-server-api.apps.yml
+++ b/.github/workflows/desktop-server-api.apps.yml
@@ -93,9 +93,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -348,9 +367,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -548,9 +586,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -861,9 +918,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -1013,6 +1089,22 @@ jobs:
           ref: master
           clean: false
 
+
+      # Same PATH determinism as the x64 Windows job: today this leg runs on the GitHub-hosted
+      # windows-11-arm image where `shell: bash` already resolves to Git Bash, but if an arm64 runner is
+      # ever self-hosted (RUNNER_LINUX_ARM64_8 / a Windows arm64 box) it could resolve to WSL and fail as
+      # EVERGR did. No-op when Git Bash is not installed.
+      - name: Prefer Git Bash for bash steps
+        shell: powershell
+        run: |
+          $git = (Get-Command git.exe -ErrorAction SilentlyContinue).Source
+          if ($git) {
+            $bin = Join-Path (Split-Path (Split-Path $git -Parent) -Parent) 'bin'
+            if (Test-Path (Join-Path $bin 'bash.exe')) {
+              $bin | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+              Write-Host "Prepended $bin to PATH for later steps"
+            } else { Write-Host "No bash.exe under $bin - leaving PATH alone" }
+          } else { Write-Host 'git.exe not on PATH - leaving PATH alone' }
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
@@ -1114,9 +1206,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       # sharp < 0.33 ships no win32-arm64 prebuilt and falls back to a node-gyp build that needs a
       # system libvips ("Cannot open include file: 'vips/vips8'"). The monorepo carries such a copy

--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -89,9 +89,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -312,9 +331,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -489,9 +527,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -793,9 +850,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -950,6 +1026,22 @@ jobs:
         with:
           clean: false
 
+
+      # Same PATH determinism as the x64 Windows job: today this leg runs on the GitHub-hosted
+      # windows-11-arm image where `shell: bash` already resolves to Git Bash, but if an arm64 runner is
+      # ever self-hosted (RUNNER_LINUX_ARM64_8 / a Windows arm64 box) it could resolve to WSL and fail as
+      # EVERGR did. No-op when Git Bash is not installed.
+      - name: Prefer Git Bash for bash steps
+        shell: powershell
+        run: |
+          $git = (Get-Command git.exe -ErrorAction SilentlyContinue).Source
+          if ($git) {
+            $bin = Join-Path (Split-Path (Split-Path $git -Parent) -Parent) 'bin'
+            if (Test-Path (Join-Path $bin 'bash.exe')) {
+              $bin | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+              Write-Host "Prepended $bin to PATH for later steps"
+            } else { Write-Host "No bash.exe under $bin - leaving PATH alone" }
+          } else { Write-Host 'git.exe not on PATH - leaving PATH alone' }
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
@@ -1051,9 +1143,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       # sharp < 0.33 ships no win32-arm64 prebuilt and falls back to a node-gyp build that needs a
       # system libvips ("Cannot open include file: 'vips/vips8'"). The monorepo carries such a copy

--- a/.github/workflows/desktop.apps.yml
+++ b/.github/workflows/desktop.apps.yml
@@ -98,9 +98,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -402,9 +421,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -660,9 +698,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -1004,9 +1061,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
@@ -1184,6 +1260,22 @@ jobs:
           ref: master
           clean: false
 
+
+      # Same PATH determinism as the x64 Windows job: today this leg runs on the GitHub-hosted
+      # windows-11-arm image where `shell: bash` already resolves to Git Bash, but if an arm64 runner is
+      # ever self-hosted (RUNNER_LINUX_ARM64_8 / a Windows arm64 box) it could resolve to WSL and fail as
+      # EVERGR did. No-op when Git Bash is not installed.
+      - name: Prefer Git Bash for bash steps
+        shell: powershell
+        run: |
+          $git = (Get-Command git.exe -ErrorAction SilentlyContinue).Source
+          if ($git) {
+            $bin = Join-Path (Split-Path (Split-Path $git -Parent) -Parent) 'bin'
+            if (Test-Path (Join-Path $bin 'bash.exe')) {
+              $bin | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+              Write-Host "Prepended $bin to PATH for later steps"
+            } else { Write-Host "No bash.exe under $bin - leaving PATH alone" }
+          } else { Write-Host 'git.exe not on PATH - leaving PATH alone' }
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
@@ -1285,9 +1377,28 @@ jobs:
           fi
 
       - name: Install Yarn dependencies
-        run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
+        # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
+        # `codeload.github.com/... : Request failed "429 Too Many Requests"` (the fleet shares a single
+        # egress IP and GitHub throttles it whenever several jobs install at once) throws away a build
+        # that is already 40+ minutes in — it killed release-linux twice on 2026-08-18 (runs 32101473424,
+        # 32139317563), each time with nothing wrong in the repo. Retry with a linear back-off instead.
+        # bash (not the Windows default shell) so the loop is identical on every runner; Git Bash is put
+        # on PATH by the "Prefer Git Bash for bash steps" step above.
+        shell: bash
         env:
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+        run: |
+          install() { yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts; }
+          for attempt in 1 2 3 4; do
+            if install; then exit 0; fi
+            if [ "$attempt" = 4 ]; then
+              echo "::error title=yarn install::failed 4 times - this is very unlikely to be transient"
+              exit 1
+            fi
+            wait=$((attempt * 60))
+            echo "::warning title=yarn install retry::attempt ${attempt} failed (usually a codeload/registry 429) - retrying in ${wait}s"
+            sleep "$wait"
+          done
 
       # sharp < 0.33 ships no win32-arm64 prebuilt and falls back to a node-gyp build that needs a
       # system libvips ("Cannot open include file: 'vips/vips8'"). The monorepo carries such a copy

--- a/.github/workflows/release.sdk.prod.yml
+++ b/.github/workflows/release.sdk.prod.yml
@@ -65,7 +65,7 @@ jobs:
           echo "✅ NPM authentication configured"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/release.sdk.prod.yml
+++ b/.github/workflows/release.sdk.prod.yml
@@ -64,8 +64,34 @@ jobs:
           echo "@ever-teams:registry=https://registry.npmjs.org/" >> ~/.npmrc
           echo "✅ NPM authentication configured"
 
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies (Yarn)
         run: yarn install --frozen-lockfile
+
+      - name: Restore registry config (keep the checkout npmjs-clean)
+        # Configure Registry above may rewrite yarn.lock and append registry lines
+        # to the tracked .npmrc/.yarnrc so the install resolves through the internal
+        # Verdaccio cache. Later steps run `git add .` + push version bumps and then
+        # publish to npmjs - a committed rewritten lockfile or a leftover project-level
+        # registry= line pointing at a LAN VIP must never survive past the install.
+        # Tracked files are restored; untracked leftovers are removed.
+        if: always()
+        run: |
+          for f in yarn.lock .npmrc .yarnrc; do
+            if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+              git checkout -- "$f"
+            else
+              rm -f "$f"
+            fi
+          done
+          rm -f yarn.lock.rewritten package-lock.json.rewritten
 
       - name: Build SDK packages
         run: |

--- a/apps/web/core/components/features/daily-plan/add-task-estimation-hours-modal.tsx
+++ b/apps/web/core/components/features/daily-plan/add-task-estimation-hours-modal.tsx
@@ -3,7 +3,8 @@ import { useMemo, useCallback, useState, useEffect, useRef, Dispatch, SetStateAc
 import { Modal, SpinnerLoader, Text } from '@/core/components';
 import { Button } from '@/core/components/duplicated-components/_button';
 import { useTranslations } from 'next-intl';
-import { useModal, useTimerView } from '@/core/hooks';
+import { useModal } from '@/core/hooks';
+import { useTimerActions } from '@/core/hooks/timer';
 import { useTeamTasksState } from '@/core/hooks/organizations/teams/use-team-tasks-state';
 import { useCreateTask } from '@/core/hooks/organizations/teams/use-create-task';
 import { useTaskQueries } from '@/core/hooks/organizations/teams/use-task-queries';
@@ -106,7 +107,10 @@ export function AddTasksEstimationHoursModal(props: IAddTasksEstimationHoursModa
 	const globalTasks = useAtomValue(tasksByTeamState);
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
 	const timerStatus = useAtomValue(timerStatusState);
-	const { startTimer } = useTimerView();
+	// PERF: task-card.tsx renders this modal ONCE PER CARD whenever the user has a daily plan, so
+	// useTimerView() here re-subscribed every card to the 20Hz timer tick (see use-timer-button.ts).
+	// `startTimer` is a Layer-1 mutation; useTimerActions provides it without Layer 3.
+	const { startTimer } = useTimerActions();
 
 	const { setActiveTask } = useTeamTasksState();
 	const [showSearchInput, setShowSearchInput] = useState(false);
@@ -1271,7 +1275,8 @@ function UnplanTask(props: IUnplanTaskProps) {
 	const { removeManyTaskPlans, removeManyTaskFromPlanLoading } = useUpdateDailyPlan();
 
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
-	const { timerStatus } = useTimerView();
+	// PERF: same reason as the sibling above — Layer-1 value, no need for the 20Hz tick subscription.
+	const { timerStatus } = useTimerActions();
 
 	const isActiveTaskPlannedToday = useMemo(
 		() => employeeTodayPlan[0]?.tasks?.find((task) => task.id === activeTeamTask?.id),

--- a/apps/web/core/components/tasks/kanban-card.tsx
+++ b/apps/web/core/components/tasks/kanban-card.tsx
@@ -1,15 +1,16 @@
 import { useAtom, useAtomValue } from 'jotai';
 import Link from 'next/link';
 
+import { LazyImageComponent, LazyMenuKanbanCard } from '@/core/components/optimized-components/kanban';
 import {
-    LazyImageComponent, LazyMenuKanbanCard
-} from '@/core/components/optimized-components/kanban';
-import {
-    LazyTaskAllStatusTypes, LazyTaskInput, LazyTaskIssueStatus
+	LazyTaskAllStatusTypes,
+	LazyTaskInput,
+	LazyTaskIssueStatus
 } from '@/core/components/optimized-components/tasks';
 import CircularProgress from '@/core/components/svgs/circular-progress';
 import PriorityIcon from '@/core/components/svgs/priority-icon';
-import { useTaskStatistics, useTimerView } from '@/core/hooks';
+import { useTaskStatistics } from '@/core/hooks';
+import { useTimerActions } from '@/core/hooks/timer';
 import { useUserQuery } from '@/core/hooks/queries/user-user.query';
 import { secondsToTime } from '@/core/lib/helpers/index';
 import { getTaskTotalWorkedDuration } from '@/core/lib/utils/task.utils';
@@ -140,7 +141,10 @@ export default function Item(props: ItemProps) {
 	const { getEstimation } = useTaskStatistics(0);
 	const [activeTask, setActiveTask] = useAtom(activeTeamTaskId);
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
-	const { timerStatus } = useTimerView();
+	// PERF: per-card hook — see the note in use-timer-button.ts. useTimerView() would subscribe this card to
+	// the 20Hz tick atoms for a value that comes from Layer 1. `timerStatus` here is the same FILTERED value
+	// useTimerView exposes (useTimerApi returns filteredTimerStatus), not the raw atom.
+	const { timerStatus } = useTimerActions();
 
 	const members = activeTeam?.members || [];
 	const currentUser = members.find((m) => m.employee?.userId === user?.id);

--- a/apps/web/core/hooks/tasks/use-timer-button.ts
+++ b/apps/web/core/hooks/tasks/use-timer-button.ts
@@ -1,6 +1,7 @@
 // core/hooks/task-card/useTimerButton.ts
 import { useCallback, useMemo, useState } from 'react';
-import { useStartStopTimerHandler, useTeamTasksState, useTimerView } from '@/core/hooks';
+import { useStartStopTimerHandler, useTeamTasksState } from '@/core/hooks';
+import { useTimerActions } from '@/core/hooks/timer';
 import { useTimerOptimisticUI } from '@/core/hooks/activities/use-timer-optimistic-ui';
 import { TOrganizationTeam } from '@/core/types/schemas/team/organization-team.schema';
 import { toast } from 'sonner';
@@ -14,7 +15,15 @@ export function useTimerButtonLogic({ task, activeTeam }: { task: TTask; activeT
 	const [loading, setLoading] = useState(false);
 	const timerStatus = useAtomValue(timerStatusState);
 	const activeTeamTask = useAtomValue(activeTeamTaskState);
-	const { canTrack, disabled, startTimer, stopTimer, hasPlan } = useTimerView();
+	// PERF: this hook runs once PER TASK CARD. useTimerView() composes all three timer layers, and Layer 3
+	// (useTimerUi) SUBSCRIBES to the ticking atoms (timeCounterState & co). Exactly one interval exists
+	// app-wide — init-state.tsx owns it, because useTimerUi's effects are gated on a `firstLoad` that only
+	// that instance ever flips — but every subscriber re-renders on its writes, i.e. 20x/second per card
+	// while a timer runs, plus a wasted time-format computation each time. None of the five values below
+	// come from Layer 3; they are all Layer 1 (useTimerApi). useTimerActions is the codebase's own
+	// Layers-1+2 hook for exactly this case (its docblock: "No 50ms ticking interval").
+	const { canTrack, canRunTimer, startTimer, stopTimer, hasPlan } = useTimerActions();
+	const disabled = !canRunTimer;
 	const { setActiveTask } = useTeamTasksState();
 	const t = useTranslations();
 

--- a/apps/web/test/architecture/no-ticking-timer-in-per-item-components.test.ts
+++ b/apps/web/test/architecture/no-ticking-timer-in-per-item-components.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Architecture guard (2026-08-19, Q26 item 1).
+ *
+ * `useTimerView()` / `useTimer()` compose all three timer layers. Layer 3 (`useTimerUi`) SUBSCRIBES to
+ * `timeCounterState` / `timerSecondsState` / `timeCounterIntervalState`. Exactly one 50 ms interval exists
+ * app-wide — `init-state.tsx` owns it, because `useTimerUi`'s effects are gated on a `firstLoad` that only
+ * that instance ever flips — but every subscriber re-renders on its writes. That is fine for the ONE
+ * component that displays the live clock, and pathological for anything rendered once per task: N cards on
+ * screen means N components re-rendering 20x/second while a timer runs, each redoing its time formatting.
+ *
+ * Per-item components must therefore use the Layers-1+2 hooks (`useTimerActions`, `useTimerPlanStatus`,
+ * `useLiveTimerStatus`) or read the specific atom they need. If you genuinely need the ticking clock in a
+ * per-item component, add the file to ALLOWED below with a comment explaining why.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const WEB_ROOT = join(__dirname, '..', '..');
+
+/**
+ * Components/hooks that are instantiated once per rendered task/row.
+ * `add-task-estimation-hours-modal.tsx` belongs here even though it is a "modal": task-card.tsx renders it
+ * once per card whenever the user has a daily plan, so it is per-item in practice — that is exactly how the
+ * 20Hz subscription survived on the task-list view after the first pass of this fix.
+ */
+const PER_ITEM_FILES = [
+	'core/hooks/tasks/use-timer-button.ts',
+	'core/components/tasks/kanban-card.tsx',
+	'core/components/tasks/task-card.tsx',
+	'core/components/features/daily-plan/add-task-estimation-hours-modal.tsx'
+];
+
+/** Deliberate exceptions — none today. Add with a reason if the live clock is truly needed per item. */
+const ALLOWED: string[] = [];
+
+const TICKING_HOOKS = ['useTimerView', 'useTimer('];
+
+const BLOCK_COMMENT = /\/\*[\s\S]*?\*\//g;
+const LINE_COMMENT = /(^|[^:])\/\/.*$/gm;
+
+/**
+ * Strip comments before scanning: these files legitimately MENTION the ticking hooks in the comments that
+ * explain why they avoid them, and a guard that trips on its own rationale is worse than no guard.
+ * (The `[^:]` guard keeps `https://` inside string literals from being treated as a comment.)
+ */
+const codeOnly = (source: string): string => source.replace(BLOCK_COMMENT, '').replace(LINE_COMMENT, '$1');
+
+describe('per-item components must not mount the ticking timer layer', () => {
+	it.each(PER_ITEM_FILES)('%s does not use the ticking timer hooks', (relPath) => {
+		if (ALLOWED.includes(relPath)) return;
+		const source = codeOnly(readFileSync(join(WEB_ROOT, relPath), 'utf8'));
+		const offenders = TICKING_HOOKS.filter((hook) => source.includes(hook));
+		expect(offenders).toEqual([]);
+	});
+
+	it('control: the comment stripper does not hide real code', () => {
+		const sample = [
+			'/* useTimerView in a block comment */',
+			'// useTimerView in a line comment',
+			'const x = useTimerView();'
+		].join('\n');
+		const stripped = codeOnly(sample);
+		expect(stripped).toContain('useTimerView()');
+		expect(stripped.match(/useTimerView/g)).toHaveLength(1);
+	});
+
+	it('control: the primary timer widget DOES still use the ticking hook', () => {
+		// If this ever fails, the live clock lost its ticking source and the guard above is meaningless.
+		const source = codeOnly(readFileSync(join(WEB_ROOT, 'core/components/timer/timer.tsx'), 'utf8'));
+		expect(source.includes('useTimerView')).toBe(true);
+	});
+
+	it('control: the lean hook this guard steers people to really has no ticking layer', () => {
+		const source = codeOnly(readFileSync(join(WEB_ROOT, 'core/hooks/timer/use-timer-actions.ts'), 'utf8'));
+		expect(source.includes('useTimerUi')).toBe(false);
+	});
+});


### PR DESCRIPTION
Promotes develop to stage whole, per the standard cascade (no cherry-picks). Carries the pinned shared configure-registry (Verdaccio) CI change verified on develop. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes CI installs resilient and routes the SDK release install through the internal Verdaccio cache, while removing per-item subscriptions to the 20 Hz timer to prevent wasteful re-renders. No user-facing behavior changes; performance improves on task-heavy views.

- Adds `yarn install` retries with linear backoff across desktop workflows; previously a single transient `codeload.github.com` 429 failed the job, now up to 4 attempts with warnings before a final error.
- Ensures Windows ARM jobs resolve `bash` to Git Bash for deterministic shells; previously could resolve to WSL on self-hosted runners.
- In `release.sdk.prod.yml`, runs the shared pinned `ever-co/ever-gauzy` `configure-registry` action before `yarn install`, then restores tracked registry files to keep the checkout npmjs-clean for `git add` and publish. Requires `VERDACCIO_REGISTRY`, `VERDACCIO_TOKEN`, and (optionally) `VERDACCIO_FORCE_PUBLIC` repo settings; uses an `expect-vip` flag where a LAN VIP exists.
- Adds `yarnrc` and `USERCONFIG` to `.cspell.json`.

- Replaces `useTimerView` with `useTimerActions` in per-item components (`use-timer-button`, kanban card, and daily plan add-task modal) to avoid subscribing each item to the ticking UI layer; previously N items re-rendered 20×/s when any timer ran. Derived `disabled = !canRunTimer`; `timerStatus` remains the filtered value. Adds an architecture test that blocks reintroducing ticking hooks in per-item files and asserts the primary timer widget still uses the ticking hook.

<sup>Written for commit 805b75b177d50b3fcd745336df79ccfbb030c63f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

