### PR TITLE
ci(sdk-release): move the SDK release job to the -8 ARC pool (ENOSPC on -4)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,9 @@
 	"caseSensitive": false,
 	"$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
 	"words": [
+		"ENOSPC",
+		"tmpfs",
+		"yarnpkg",
 		"yarnrc",
 		"USERCONFIG",
 		"cicd",

--- a/.github/workflows/release.sdk.prod.yml
+++ b/.github/workflows/release.sdk.prod.yml
@@ -8,7 +8,14 @@ on:
 jobs:
   release:
     name: Version and SDK Publish with Changesets
-    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    # Prefer the -8 ARC pool: its RAM-backed volumes are work=24Gi + package cache=12Gi.
+    # The -4 pool (work=16Gi, cache=8Gi) is measurably too small for this repo's full
+    # `yarn install` — yarn 1 downloads every platform variant of the optional native
+    # deps (electron, @sentry/cli-*, @img/sharp-*), and run 32514096730 (2026-08-21)
+    # died with "ENOSPC: no space left on device" while extracting into the 8Gi cache
+    # tmpfs. Same ENOSPC hit web.before-merge.yml on the -4 pool the same day, on a run
+    # that installs straight from registry.yarnpkg.com — pool capacity, not registry.
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     permissions:
       contents: write # for changelog/version PRs
@@ -70,7 +77,7 @@ jobs:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
           force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' || vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install dependencies (Yarn)
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## What

Moves the `release.sdk.prod.yml` job from the `-4` ARC pool to the `-8` pool (fallback chain `RUNNER_LINUX_X64_8 || RUNNER_LINUX_X64_4 || ubuntu-latest`) and updates the Configure Registry `expect-vip` expression to follow the same runner-var chain.

## Why

Run [32514096730](https://github.com/ever-co/ever-teams/actions/runs/32514096730) (first run after the Verdaccio configure-registry step landed via #4426/#4431) failed at `yarn install` with `ENOSPC: no space left on device` while extracting tarballs into the `-4` pool's 8Gi RAM-backed package-cache volume. yarn 1 downloads every platform variant of the optional native deps (electron, `@sentry/cli-*`, `@img/sharp-*`), which overflows 8Gi for this repo.

**This is pool capacity, not the registry change:** [web.before-merge.yml run](https://github.com/ever-co/ever-teams/actions/runs/32514089608) hit the identical ENOSPC the same day on the same `-4` pool while installing straight from `registry.yarnpkg.com` (no Verdaccio involved), and both workflows were green on 2026-08-17, before the pools' package cache moved to RAM-backed tmpfs. The Verdaccio step itself worked: `EXPECT_VIP: true`, "Verdaccio VIP is reachable (attempt 1)", tarballs streamed from `192.168.1.183:4873`.

The `-8` pool carries work=24Gi + cache=12Gi (gauzy's measured yarn cache is 4.66GB there).

## Notes

- `web.before-merge.yml` has the same ENOSPC and is not touched here (kept to the one workflow in scope); flagged in the rollout report.
- The publish step's `E404 Not Found - PUT @ever-teams/tracking|extensions` failures pre-date all of this (red since at least 2026-08-17) and are an npm-side permission/package issue, unaffected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the SDK release workflow on the `-8` ARC pool to prevent `ENOSPC` during `yarn install`. Old behavior: preferred `RUNNER_LINUX_X64_4`; new behavior: prefers `RUNNER_LINUX_X64_8` with fallback to `RUNNER_LINUX_X64_4` or `ubuntu-latest`. The larger RAM-backed volumes on `-8` avoid cache overflow.

- Sets `runs-on` to `${{ vars.RUNNER_LINUX_X64_8 || vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` and updates Configure Registry `expect-vip` to the same chain.
- Adds `ENOSPC`, `tmpfs`, and `yarnpkg` to `cspell` to keep CI checks green.

<sup>Written for commit 8b6687c85bbced236c7328bf9aad941929af7a8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow runner selection for better availability.
  * Added fallback options to maintain reliable release processing.
  * Updated registry configuration to support both enhanced runner pools.
  * These improvements help releases complete more consistently during periods of limited runner capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->