### PR TITLE
ci: route the self-hosted jobs through the shared configure-registry action

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -847,7 +847,14 @@
 		"typeahead",
 		"antfu",
 		"conventionalcommits",
-	],
+		"DLOPEN",
+		"ENOENT",
+		"EVERDESK",
+		"EVERGR",
+		"Jimp",
+		"prebuilts",
+		"vercelignore"
+],
 	"useGitignore": true,
 	"ignorePaths": [
 		"**/locales/**",

--- a/.github/workflows/deploy-vercel-dev.yml
+++ b/.github/workflows/deploy-vercel-dev.yml
@@ -30,12 +30,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/deploy-vercel-dev.yml
+++ b/.github/workflows/deploy-vercel-dev.yml
@@ -29,13 +29,33 @@ jobs:
           node-version: "24.14.0"
           cache: "yarn"
 
+      # 🛑 DO NOT migrate this step to the shared ever-gauzy configure-registry action.
+      # It was migrated once and reverted here; this comment is why.
+      #
+      # This job does NOT ship the artifact it builds on the runner. The deploy step below
+      # (BetaHuhn/deploy-to-vercel-action@v1) passes no PREBUILT input and uses
+      # WORKING_DIRECTORY: ./, so Vercel UPLOADS this working tree and runs install + build
+      # REMOTELY on its own builders. There is no .vercelignore in this repo, so every tracked
+      # file goes up exactly as it sits on disk at that moment.
+      #
+      # The shared action mutates three TRACKED files: it appends `registry=<REGISTRY>` to
+      # .npmrc, appends `registry "<REGISTRY>"` to .yarnrc, and sed-rewrites every resolved
+      # URL in yarn.lock to that registry. On these runners <REGISTRY> is the internal
+      # Verdaccio VIP (192.168.1.183:4873), which is LAN-only. Vercel's builders cannot route
+      # to it, so the remote `yarn install` fails on every tarball and the deploy dies.
+      # A post-install restore guard does not help either: it would hand Vercel a config with
+      # no Verdaccio credentials at all.
+      #
+      # The hand-rolled step below is kept ON PURPOSE. It touches only .npmrc, and writes only
+      # the PUBLICLY reachable https://packages.ever.co/ route plus its auth token - so the
+      # config that ships to Vercel still resolves from outside our network.
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
-        with:
-          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
-          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
-          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
+            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
+            echo "registry=https://packages.ever.co/" >> .npmrc
+          fi
 
       - name: Install Packages
         run: |

--- a/.github/workflows/deploy-vercel-prod.yml
+++ b/.github/workflows/deploy-vercel-prod.yml
@@ -30,12 +30,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/deploy-vercel-prod.yml
+++ b/.github/workflows/deploy-vercel-prod.yml
@@ -29,13 +29,33 @@ jobs:
           node-version: "24.14.0"
           cache: "yarn"
 
+      # 🛑 DO NOT migrate this step to the shared ever-gauzy configure-registry action.
+      # It was migrated once and reverted here; this comment is why.
+      #
+      # This job does NOT ship the artifact it builds on the runner. The deploy step below
+      # (BetaHuhn/deploy-to-vercel-action@v1) passes no PREBUILT input and uses
+      # WORKING_DIRECTORY: ./, so Vercel UPLOADS this working tree and runs install + build
+      # REMOTELY on its own builders. There is no .vercelignore in this repo, so every tracked
+      # file goes up exactly as it sits on disk at that moment.
+      #
+      # The shared action mutates three TRACKED files: it appends `registry=<REGISTRY>` to
+      # .npmrc, appends `registry "<REGISTRY>"` to .yarnrc, and sed-rewrites every resolved
+      # URL in yarn.lock to that registry. On these runners <REGISTRY> is the internal
+      # Verdaccio VIP (192.168.1.183:4873), which is LAN-only. Vercel's builders cannot route
+      # to it, so the remote `yarn install` fails on every tarball and the deploy dies.
+      # A post-install restore guard does not help either: it would hand Vercel a config with
+      # no Verdaccio credentials at all.
+      #
+      # The hand-rolled step below is kept ON PURPOSE. It touches only .npmrc, and writes only
+      # the PUBLICLY reachable https://packages.ever.co/ route plus its auth token - so the
+      # config that ships to Vercel still resolves from outside our network.
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
-        with:
-          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
-          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
-          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
+            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
+            echo "registry=https://packages.ever.co/" >> .npmrc
+          fi
 
       - name: Install Packages
         run: |

--- a/.github/workflows/deploy-vercel-stage.yml
+++ b/.github/workflows/deploy-vercel-stage.yml
@@ -30,12 +30,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/deploy-vercel-stage.yml
+++ b/.github/workflows/deploy-vercel-stage.yml
@@ -29,13 +29,33 @@ jobs:
           node-version: "24.14.0"
           cache: "yarn"
 
+      # 🛑 DO NOT migrate this step to the shared ever-gauzy configure-registry action.
+      # It was migrated once and reverted here; this comment is why.
+      #
+      # This job does NOT ship the artifact it builds on the runner. The deploy step below
+      # (BetaHuhn/deploy-to-vercel-action@v1) passes no PREBUILT input and uses
+      # WORKING_DIRECTORY: ./, so Vercel UPLOADS this working tree and runs install + build
+      # REMOTELY on its own builders. There is no .vercelignore in this repo, so every tracked
+      # file goes up exactly as it sits on disk at that moment.
+      #
+      # The shared action mutates three TRACKED files: it appends `registry=<REGISTRY>` to
+      # .npmrc, appends `registry "<REGISTRY>"` to .yarnrc, and sed-rewrites every resolved
+      # URL in yarn.lock to that registry. On these runners <REGISTRY> is the internal
+      # Verdaccio VIP (192.168.1.183:4873), which is LAN-only. Vercel's builders cannot route
+      # to it, so the remote `yarn install` fails on every tarball and the deploy dies.
+      # A post-install restore guard does not help either: it would hand Vercel a config with
+      # no Verdaccio credentials at all.
+      #
+      # The hand-rolled step below is kept ON PURPOSE. It touches only .npmrc, and writes only
+      # the PUBLICLY reachable https://packages.ever.co/ route plus its auth token - so the
+      # config that ships to Vercel still resolves from outside our network.
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
-        with:
-          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
-          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
-          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
+            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
+            echo "registry=https://packages.ever.co/" >> .npmrc
+          fi
 
       - name: Install Packages
         run: |

--- a/.github/workflows/desktop-server-api.apps.yml
+++ b/.github/workflows/desktop-server-api.apps.yml
@@ -85,7 +85,7 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -910,7 +910,7 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/desktop-server-api.apps.yml
+++ b/.github/workflows/desktop-server-api.apps.yml
@@ -85,12 +85,12 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
@@ -910,12 +910,12 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: 'true'
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient

--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -81,7 +81,7 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -842,7 +842,7 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -81,12 +81,12 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
@@ -842,12 +842,12 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: 'true'
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient

--- a/.github/workflows/desktop.apps.yml
+++ b/.github/workflows/desktop.apps.yml
@@ -90,12 +90,12 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
@@ -1053,12 +1053,12 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: 'true'
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient

--- a/.github/workflows/desktop.apps.yml
+++ b/.github/workflows/desktop.apps.yml
@@ -90,7 +90,7 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -1053,7 +1053,7 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/extensions.dev.yml
+++ b/.github/workflows/extensions.dev.yml
@@ -30,27 +30,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route — same
-          # pattern as the mobile workflows. The public route has been seen truncating large prebuilt
-          # tarballs (e.g. @img/sharp-libvips-*), which turns into a broken sharp at build time.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/extensions.dev.yml
+++ b/.github/workflows/extensions.dev.yml
@@ -30,7 +30,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/extensions.prod.yml
+++ b/.github/workflows/extensions.prod.yml
@@ -30,27 +30,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route — same
-          # pattern as the mobile workflows. The public route has been seen truncating large prebuilt
-          # tarballs (e.g. @img/sharp-libvips-*), which turns into a broken sharp at build time.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/extensions.prod.yml
+++ b/.github/workflows/extensions.prod.yml
@@ -30,7 +30,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.apps.android.yml
+++ b/.github/workflows/mobile.apps.android.yml
@@ -70,30 +70,12 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route.
-          # These jobs run on in-cluster ARC runners that can reach the VIP directly. The public
-          # Cloudflare-fronted route runs ~280 KB/s and was measured on 2026-08-16 truncating a
-          # 14,590,565-byte tarball to 9,525,323 bytes mid-stream. A truncated prebuilt-binary
-          # package makes sharp fall back to compiling from source, which fails under Node 24.
-          # The VIP served the same file byte-exact.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.apps.android.yml
+++ b/.github/workflows/mobile.apps.android.yml
@@ -101,14 +101,35 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
-      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
-      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
-      # build archive, so the token was being uploaded to Expo (their log shows
+      # SECURITY + CORRECTNESS: "Configure Registry" appends the internal registry +
+      # VERDACCIO_TOKEN to .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked
+      # files in the build archive, so the token was being uploaded to Expo (their log shows
       # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
       # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
-      - name: Restore .npmrc before EAS upload
+      #
+      # .npmrc is NOT the only file the step mutates. The shared configure-registry action also
+      # appends `registry "<REGISTRY>"` to .yarnrc and sed-rewrites EVERY resolved URL in
+      # yarn.lock to that registry, and on these runners the registry is the LAN-only Verdaccio
+      # VIP. .easignore REPLACES .gitignore (it is not additive) and lists none of these three
+      # files, so all three ship in the archive; the Expo builder then runs
+      # `yarn install --frozen-lockfile` in the uploaded root and cannot resolve a single
+      # tarball. Restoring only .npmrc leaves that lockfile poisoned.
+      #
+      # Same per-path loop as .github/workflows/release.sdk.prod.yml: tracked files are checked
+      # out, untracked leftovers are removed. `if: always()` so a failed install still leaves
+      # the checkout clean for the next job on this self-hosted runner.
+      - name: Restore registry config before EAS upload
         shell: bash
-        run: git checkout -- .npmrc || true
+        if: always()
+        run: |
+          for f in yarn.lock .npmrc .yarnrc; do
+            if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+              git checkout -- "$f"
+            else
+              rm -f "$f"
+            fi
+          done
+          rm -f yarn.lock.rewritten package-lock.json.rewritten
 
       - name: Build on EAS
         id: eas_build

--- a/.github/workflows/mobile.apps.android.yml
+++ b/.github/workflows/mobile.apps.android.yml
@@ -70,7 +70,7 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.apps.ios.yml
+++ b/.github/workflows/mobile.apps.ios.yml
@@ -89,7 +89,7 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.apps.ios.yml
+++ b/.github/workflows/mobile.apps.ios.yml
@@ -89,30 +89,12 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route.
-          # These jobs run on in-cluster ARC runners that can reach the VIP directly. The public
-          # Cloudflare-fronted route runs ~280 KB/s and was measured on 2026-08-16 truncating a
-          # 14,590,565-byte tarball to 9,525,323 bytes mid-stream. A truncated prebuilt-binary
-          # package makes sharp fall back to compiling from source, which fails under Node 24.
-          # The VIP served the same file byte-exact.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.apps.ios.yml
+++ b/.github/workflows/mobile.apps.ios.yml
@@ -120,14 +120,35 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
-      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
-      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
-      # build archive, so the token was being uploaded to Expo (their log shows
+      # SECURITY + CORRECTNESS: "Configure Registry" appends the internal registry +
+      # VERDACCIO_TOKEN to .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked
+      # files in the build archive, so the token was being uploaded to Expo (their log shows
       # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
       # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
-      - name: Restore .npmrc before EAS upload
+      #
+      # .npmrc is NOT the only file the step mutates. The shared configure-registry action also
+      # appends `registry "<REGISTRY>"` to .yarnrc and sed-rewrites EVERY resolved URL in
+      # yarn.lock to that registry, and on these runners the registry is the LAN-only Verdaccio
+      # VIP. .easignore REPLACES .gitignore (it is not additive) and lists none of these three
+      # files, so all three ship in the archive; the Expo builder then runs
+      # `yarn install --frozen-lockfile` in the uploaded root and cannot resolve a single
+      # tarball. Restoring only .npmrc leaves that lockfile poisoned.
+      #
+      # Same per-path loop as .github/workflows/release.sdk.prod.yml: tracked files are checked
+      # out, untracked leftovers are removed. `if: always()` so a failed install still leaves
+      # the checkout clean for the next job on this self-hosted runner.
+      - name: Restore registry config before EAS upload
         shell: bash
-        run: git checkout -- .npmrc || true
+        if: always()
+        run: |
+          for f in yarn.lock .npmrc .yarnrc; do
+            if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+              git checkout -- "$f"
+            else
+              rm -f "$f"
+            fi
+          done
+          rm -f yarn.lock.rewritten package-lock.json.rewritten
 
       - name: Build on EAS
         id: eas_build

--- a/.github/workflows/mobile.apps.stage.android.yml
+++ b/.github/workflows/mobile.apps.stage.android.yml
@@ -92,7 +92,7 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.apps.stage.android.yml
+++ b/.github/workflows/mobile.apps.stage.android.yml
@@ -92,30 +92,12 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route.
-          # These jobs run on in-cluster ARC runners that can reach the VIP directly. The public
-          # Cloudflare-fronted route runs ~280 KB/s and was measured on 2026-08-16 truncating a
-          # 14,590,565-byte tarball to 9,525,323 bytes mid-stream. A truncated prebuilt-binary
-          # package makes sharp fall back to compiling from source, which fails under Node 24.
-          # The VIP served the same file byte-exact.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.apps.stage.android.yml
+++ b/.github/workflows/mobile.apps.stage.android.yml
@@ -123,14 +123,35 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
-      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
-      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
-      # build archive, so the token was being uploaded to Expo (their log shows
+      # SECURITY + CORRECTNESS: "Configure Registry" appends the internal registry +
+      # VERDACCIO_TOKEN to .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked
+      # files in the build archive, so the token was being uploaded to Expo (their log shows
       # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
       # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
-      - name: Restore .npmrc before EAS upload
+      #
+      # .npmrc is NOT the only file the step mutates. The shared configure-registry action also
+      # appends `registry "<REGISTRY>"` to .yarnrc and sed-rewrites EVERY resolved URL in
+      # yarn.lock to that registry, and on these runners the registry is the LAN-only Verdaccio
+      # VIP. .easignore REPLACES .gitignore (it is not additive) and lists none of these three
+      # files, so all three ship in the archive; the Expo builder then runs
+      # `yarn install --frozen-lockfile` in the uploaded root and cannot resolve a single
+      # tarball. Restoring only .npmrc leaves that lockfile poisoned.
+      #
+      # Same per-path loop as .github/workflows/release.sdk.prod.yml: tracked files are checked
+      # out, untracked leftovers are removed. `if: always()` so a failed install still leaves
+      # the checkout clean for the next job on this self-hosted runner.
+      - name: Restore registry config before EAS upload
         shell: bash
-        run: git checkout -- .npmrc || true
+        if: always()
+        run: |
+          for f in yarn.lock .npmrc .yarnrc; do
+            if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+              git checkout -- "$f"
+            else
+              rm -f "$f"
+            fi
+          done
+          rm -f yarn.lock.rewritten package-lock.json.rewritten
 
       - name: Build on EAS
         run: cd apps/mobile && eas build --profile internal --platform android --non-interactive

--- a/.github/workflows/mobile.apps.stage.ios.yml
+++ b/.github/workflows/mobile.apps.stage.ios.yml
@@ -113,14 +113,35 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
-      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
-      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
-      # build archive, so the token was being uploaded to Expo (their log shows
+      # SECURITY + CORRECTNESS: "Configure Registry" appends the internal registry +
+      # VERDACCIO_TOKEN to .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked
+      # files in the build archive, so the token was being uploaded to Expo (their log shows
       # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
       # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
-      - name: Restore .npmrc before EAS upload
+      #
+      # .npmrc is NOT the only file the step mutates. The shared configure-registry action also
+      # appends `registry "<REGISTRY>"` to .yarnrc and sed-rewrites EVERY resolved URL in
+      # yarn.lock to that registry, and on these runners the registry is the LAN-only Verdaccio
+      # VIP. .easignore REPLACES .gitignore (it is not additive) and lists none of these three
+      # files, so all three ship in the archive; the Expo builder then runs
+      # `yarn install --frozen-lockfile` in the uploaded root and cannot resolve a single
+      # tarball. Restoring only .npmrc leaves that lockfile poisoned.
+      #
+      # Same per-path loop as .github/workflows/release.sdk.prod.yml: tracked files are checked
+      # out, untracked leftovers are removed. `if: always()` so a failed install still leaves
+      # the checkout clean for the next job on this self-hosted runner.
+      - name: Restore registry config before EAS upload
         shell: bash
-        run: git checkout -- .npmrc || true
+        if: always()
+        run: |
+          for f in yarn.lock .npmrc .yarnrc; do
+            if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+              git checkout -- "$f"
+            else
+              rm -f "$f"
+            fi
+          done
+          rm -f yarn.lock.rewritten package-lock.json.rewritten
 
       - name: Build on EAS
         run: cd apps/mobile && eas build --profile internal --platform ios --non-interactive

--- a/.github/workflows/mobile.apps.stage.ios.yml
+++ b/.github/workflows/mobile.apps.stage.ios.yml
@@ -82,7 +82,7 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.apps.stage.ios.yml
+++ b/.github/workflows/mobile.apps.stage.ios.yml
@@ -82,30 +82,12 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route.
-          # These jobs run on in-cluster ARC runners that can reach the VIP directly. The public
-          # Cloudflare-fronted route runs ~280 KB/s and was measured on 2026-08-16 truncating a
-          # 14,590,565-byte tarball to 9,525,323 bytes mid-stream. A truncated prebuilt-binary
-          # package makes sharp fall back to compiling from source, which fails under Node 24.
-          # The VIP served the same file byte-exact.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.before-merge.yml
+++ b/.github/workflows/mobile.before-merge.yml
@@ -44,7 +44,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.before-merge.yml
+++ b/.github/workflows/mobile.before-merge.yml
@@ -44,12 +44,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.dev.yml
+++ b/.github/workflows/mobile.dev.yml
@@ -35,12 +35,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.dev.yml
+++ b/.github/workflows/mobile.dev.yml
@@ -35,7 +35,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.prod.yml
+++ b/.github/workflows/mobile.prod.yml
@@ -35,12 +35,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.prod.yml
+++ b/.github/workflows/mobile.prod.yml
@@ -35,7 +35,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.stage.yml
+++ b/.github/workflows/mobile.stage.yml
@@ -35,12 +35,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.stage.yml
+++ b/.github/workflows/mobile.stage.yml
@@ -35,7 +35,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/release.sdk.prod.yml
+++ b/.github/workflows/release.sdk.prod.yml
@@ -72,7 +72,7 @@ jobs:
           echo "✅ NPM authentication configured"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/web.before-merge.yml
+++ b/.github/workflows/web.before-merge.yml
@@ -54,7 +54,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/web.before-merge.yml
+++ b/.github/workflows/web.before-merge.yml
@@ -54,12 +54,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |


### PR DESCRIPTION
## What

Replaces the hand-rolled `Configure Registry` step with the shared composite action
`ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548`
in the **20 jobs that run on self-hosted runners**. 17 workflow files touched, `+120 / -222`.

No workflow, job, or step is deleted — every changed site is a like-for-like replacement of one
step by the shared action that serves the same purpose.

## Why

14 of those jobs wrote the **public** route into `.npmrc` unconditionally:

```yaml
if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
  echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
  echo "registry=https://packages.ever.co/" >> .npmrc
fi
```

`packages.ever.co` is the Cloudflare-fronted Verdaccio route. It sustains ~280 KB/s and is known to
**truncate large tarballs mid-stream** — measured 2026-08-16 on `@rspack/binding-win32-arm64-msvc@1.7.6`:
9,525,323 bytes from `packages.ever.co` against 14,590,565 bytes byte-exact from both the internal VIP
and npmjs. The truncation is undetectable client-side (Cloudflare re-gzips, so a cut stream is a
complete-looking HTTP 200 whose body fails gunzip), which is how it shows up as a random
`unexpected end of file` or a `sharp` that silently falls back to compiling from source.

The shared action probes the internal Verdaccio VIP (org var `VERDACCIO_REGISTRY`) first, falls back
to public npm when it does not answer, and keeps `packages.ever.co` available behind the
`VERDACCIO_FORCE_PUBLIC` opt-in (no-removal rule — the public path is gated, not deleted).

The other 6 migrated jobs (`extensions.{dev,prod}`, `mobile.apps.{android,ios}`,
`mobile.apps.stage.{android,ios}`) already read `vars.VERDACCIO_REGISTRY`, but only wrote a
`registry=` line. With a committed `yarn.lock` that is close to a no-op: yarn follows the `resolved`
URLs in the lockfile, which still point at `registry.yarnpkg.com`. The shared action rewrites those,
so the internal cache is actually used.

Incidental hardening: the old step spliced `${{ secrets.VERDACCIO_TOKEN }}` straight into the shell
script; the action receives it through `env:`.

## Jobs changed (20)

| Workflow | Job | `runs-on` |
| --- | --- | --- |
| `deploy-vercel-{dev,prod,stage}.yml` | `deploy` | `${{ vars.RUNNER_LINUX_X64_4 \|\| 'ubuntu-latest' }}` |
| `extensions.{dev,prod}.yml` | `build` | `${{ vars.RUNNER_LINUX_X64_4 \|\| 'ubuntu-latest' }}` |
| `mobile.apps.{android,ios}.yml` | `deploy` | `${{ vars.RUNNER_LINUX_X64_4 \|\| 'ubuntu-latest' }}` |
| `mobile.apps.stage.{android,ios}.yml` | `deploy` | `${{ vars.RUNNER_LINUX_X64_4 \|\| 'ubuntu-latest' }}` |
| `mobile.{before-merge,dev,prod,stage}.yml` | `deploy` | `${{ vars.RUNNER_LINUX_X64_4 \|\| 'ubuntu-latest' }}` |
| `web.before-merge.yml` | `deploy` | `${{ vars.RUNNER_LINUX_X64_4 \|\| 'ubuntu-latest' }}` |
| `desktop.apps.yml`, `desktop-server-{api,web}.apps.yml` | `release-linux` | `${{ vars.RUNNER_LINUX_X64_8 \|\| 'ubuntu-latest' }}` |
| `desktop.apps.yml`, `desktop-server-{api,web}.apps.yml` | `release-windows` | `[self-hosted, Windows, X64]` |

`RUNNER_LINUX_X64_4` / `_8` are set at the org (`ever-k8s-linux-x64-4` / `-8`), so these resolve to
the in-cluster ARC pools that can reach the VIP.

## Jobs deliberately NOT changed (9) — they cannot reach the private VIP

Their existing steps are left byte-for-byte as they are, in each of `desktop.apps.yml`,
`desktop-server-api.apps.yml` and `desktop-server-web.apps.yml`:

| Job | `matrix.os` | Why skipped |
| --- | --- | --- |
| `release-mac` | `ghcr.io/cirruslabs/macos-runner:tahoe` | external Cirrus runner, no route to `192.168.1.183` |
| `release-windows-arm64` | `windows-11-arm` | GitHub-hosted |
| `release-linux-arm64` | `${{ vars.RUNNER_LINUX_ARM64_8 \|\| 'ubicloud-standard-8-arm' }}` | external Ubicloud pool; `RUNNER_LINUX_ARM64_8` is unset today so the job is gated off entirely by its `if:` |

`release.sdk.prod.yml` was already migrated to this exact action and pin — untouched.

## Placement / cache safety

The action stays exactly where the old step was: **after** the lockfile-keyed cache restore
(`actions/setup-node` with `cache: yarn`, or `actions/cache@v4` keyed on
`hashFiles('yarn.lock')` in the desktop jobs) and **before** the install.

No cache key needed pinning. Both `actions/setup-node` (`cache-save.ts` reads
`State.CachePrimaryKey`) and `actions/cache@v4` save under the primary key captured at restore
time, not a re-derived `hashFiles()` — so the action's lockfile rewrite cannot bifurcate either
cache. Verified against the upstream sources rather than assumed.

## Verification

- All 43 workflows in `.github/workflows` parse as YAML after the change (0 failures).
- Structural check over the parsed tree: every `Configure Registry` step in a migrated job is a
  `uses:` step on the canonical pin with the three canonical inputs; the 9 skipped jobs still carry
  their original `run:` step (they act as the known-dirty control proving the check discriminates).
- `expect-vip` is derived from the runner rather than hardcoded, matching the idiom already used in
  `release.sdk.prod.yml`: `${{ vars.RUNNER_LINUX_X64_4 != '' }}` / `_8`, and `'true'` for the
  explicit `[self-hosted, Windows, X64]` jobs. It only controls whether an unreachable VIP is
  retried once and warned about; it never fails a job.
- None of these workflows commit or push, so a rewritten `yarn.lock` cannot leak into the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes self-hosted CI jobs through the shared `configure-registry` action and re‑pins it to restore a tracked `.yarnrc`, preserving the repo’s `yarn-path` and avoiding slow/truncated installs over the public route.

- Scope and exceptions: 17 self-hosted jobs now use the shared action. The three Vercel deploy jobs keep their inline registry step (they upload the working tree and build on Vercel). `release.sdk.prod` only updates the action pin. External/GitHub-hosted jobs are unchanged.
- Behavior: the action probes `vars.VERDACCIO_REGISTRY`, rewrites lockfile resolved URLs, falls back to public npm, and allows opting into the public route via `vars.VERDACCIO_FORCE_PUBLIC`. `expect-vip` derives from self-hosted Linux runner vars; Windows self-hosted jobs set it to 'true'.
- Mobile EAS uploads: restore `.npmrc`, `.yarnrc`, and `yarn.lock` and remove `*.rewritten` artifacts before `eas build` so VIP URLs/tokens do not ship and Expo installs succeed.
- Setup: ensure `vars.VERDACCIO_REGISTRY` and `secrets.VERDACCIO_TOKEN` exist; use `vars.VERDACCIO_FORCE_PUBLIC` only if needed.
- Lint: extend `.cspell.json` with seven project terms (e.g., EVERDESK, `Jimp`, `vercelignore`) to satisfy `cspell` on changed files; no behavior change.

<sup>Written for commit 451bba911daf1633c13d4e0a21b2d23446129ae6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized package registry configuration across development, staging, production, desktop, mobile, web, extension, and SDK workflows.
  - Improved compatibility with remote build environments and dedicated build runners.
  - Added safeguards to restore temporary registry and lockfile changes before mobile submissions.
  - Updated workflow documentation and validation terminology.
  - Existing build, validation, publishing, and submission processes remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->