### PR TITLE
chore(cascade): develop -> stage

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,9 @@
 	"caseSensitive": false,
 	"$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
 	"words": [
+		"ENOSPC",
+		"tmpfs",
+		"yarnpkg",
 		"yarnrc",
 		"USERCONFIG",
 		"cicd",

--- a/.cspell.json
+++ b/.cspell.json
@@ -847,7 +847,14 @@
 		"typeahead",
 		"antfu",
 		"conventionalcommits",
-	],
+		"DLOPEN",
+		"ENOENT",
+		"EVERDESK",
+		"EVERGR",
+		"Jimp",
+		"prebuilts",
+		"vercelignore"
+],
 	"useGitignore": true,
 	"ignorePaths": [
 		"**/locales/**",

--- a/.github/workflows/deploy-vercel-dev.yml
+++ b/.github/workflows/deploy-vercel-dev.yml
@@ -30,12 +30,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/deploy-vercel-dev.yml
+++ b/.github/workflows/deploy-vercel-dev.yml
@@ -29,13 +29,33 @@ jobs:
           node-version: "24.14.0"
           cache: "yarn"
 
+      # 🛑 DO NOT migrate this step to the shared ever-gauzy configure-registry action.
+      # It was migrated once and reverted here; this comment is why.
+      #
+      # This job does NOT ship the artifact it builds on the runner. The deploy step below
+      # (BetaHuhn/deploy-to-vercel-action@v1) passes no PREBUILT input and uses
+      # WORKING_DIRECTORY: ./, so Vercel UPLOADS this working tree and runs install + build
+      # REMOTELY on its own builders. There is no .vercelignore in this repo, so every tracked
+      # file goes up exactly as it sits on disk at that moment.
+      #
+      # The shared action mutates three TRACKED files: it appends `registry=<REGISTRY>` to
+      # .npmrc, appends `registry "<REGISTRY>"` to .yarnrc, and sed-rewrites every resolved
+      # URL in yarn.lock to that registry. On these runners <REGISTRY> is the internal
+      # Verdaccio VIP (192.168.1.183:4873), which is LAN-only. Vercel's builders cannot route
+      # to it, so the remote `yarn install` fails on every tarball and the deploy dies.
+      # A post-install restore guard does not help either: it would hand Vercel a config with
+      # no Verdaccio credentials at all.
+      #
+      # The hand-rolled step below is kept ON PURPOSE. It touches only .npmrc, and writes only
+      # the PUBLICLY reachable https://packages.ever.co/ route plus its auth token - so the
+      # config that ships to Vercel still resolves from outside our network.
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
-        with:
-          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
-          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
-          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
+            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
+            echo "registry=https://packages.ever.co/" >> .npmrc
+          fi
 
       - name: Install Packages
         run: |

--- a/.github/workflows/deploy-vercel-prod.yml
+++ b/.github/workflows/deploy-vercel-prod.yml
@@ -30,12 +30,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/deploy-vercel-prod.yml
+++ b/.github/workflows/deploy-vercel-prod.yml
@@ -29,13 +29,33 @@ jobs:
           node-version: "24.14.0"
           cache: "yarn"
 
+      # 🛑 DO NOT migrate this step to the shared ever-gauzy configure-registry action.
+      # It was migrated once and reverted here; this comment is why.
+      #
+      # This job does NOT ship the artifact it builds on the runner. The deploy step below
+      # (BetaHuhn/deploy-to-vercel-action@v1) passes no PREBUILT input and uses
+      # WORKING_DIRECTORY: ./, so Vercel UPLOADS this working tree and runs install + build
+      # REMOTELY on its own builders. There is no .vercelignore in this repo, so every tracked
+      # file goes up exactly as it sits on disk at that moment.
+      #
+      # The shared action mutates three TRACKED files: it appends `registry=<REGISTRY>` to
+      # .npmrc, appends `registry "<REGISTRY>"` to .yarnrc, and sed-rewrites every resolved
+      # URL in yarn.lock to that registry. On these runners <REGISTRY> is the internal
+      # Verdaccio VIP (192.168.1.183:4873), which is LAN-only. Vercel's builders cannot route
+      # to it, so the remote `yarn install` fails on every tarball and the deploy dies.
+      # A post-install restore guard does not help either: it would hand Vercel a config with
+      # no Verdaccio credentials at all.
+      #
+      # The hand-rolled step below is kept ON PURPOSE. It touches only .npmrc, and writes only
+      # the PUBLICLY reachable https://packages.ever.co/ route plus its auth token - so the
+      # config that ships to Vercel still resolves from outside our network.
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
-        with:
-          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
-          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
-          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
+            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
+            echo "registry=https://packages.ever.co/" >> .npmrc
+          fi
 
       - name: Install Packages
         run: |

--- a/.github/workflows/deploy-vercel-stage.yml
+++ b/.github/workflows/deploy-vercel-stage.yml
@@ -30,12 +30,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/deploy-vercel-stage.yml
+++ b/.github/workflows/deploy-vercel-stage.yml
@@ -29,13 +29,33 @@ jobs:
           node-version: "24.14.0"
           cache: "yarn"
 
+      # 🛑 DO NOT migrate this step to the shared ever-gauzy configure-registry action.
+      # It was migrated once and reverted here; this comment is why.
+      #
+      # This job does NOT ship the artifact it builds on the runner. The deploy step below
+      # (BetaHuhn/deploy-to-vercel-action@v1) passes no PREBUILT input and uses
+      # WORKING_DIRECTORY: ./, so Vercel UPLOADS this working tree and runs install + build
+      # REMOTELY on its own builders. There is no .vercelignore in this repo, so every tracked
+      # file goes up exactly as it sits on disk at that moment.
+      #
+      # The shared action mutates three TRACKED files: it appends `registry=<REGISTRY>` to
+      # .npmrc, appends `registry "<REGISTRY>"` to .yarnrc, and sed-rewrites every resolved
+      # URL in yarn.lock to that registry. On these runners <REGISTRY> is the internal
+      # Verdaccio VIP (192.168.1.183:4873), which is LAN-only. Vercel's builders cannot route
+      # to it, so the remote `yarn install` fails on every tarball and the deploy dies.
+      # A post-install restore guard does not help either: it would hand Vercel a config with
+      # no Verdaccio credentials at all.
+      #
+      # The hand-rolled step below is kept ON PURPOSE. It touches only .npmrc, and writes only
+      # the PUBLICLY reachable https://packages.ever.co/ route plus its auth token - so the
+      # config that ships to Vercel still resolves from outside our network.
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
-        with:
-          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
-          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
-          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
+            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
+            echo "registry=https://packages.ever.co/" >> .npmrc
+          fi
 
       - name: Install Packages
         run: |

--- a/.github/workflows/desktop-server-api.apps.yml
+++ b/.github/workflows/desktop-server-api.apps.yml
@@ -85,7 +85,7 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -910,7 +910,7 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/desktop-server-api.apps.yml
+++ b/.github/workflows/desktop-server-api.apps.yml
@@ -85,12 +85,12 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
@@ -910,12 +910,12 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: 'true'
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient

--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -81,7 +81,7 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -842,7 +842,7 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/desktop-server-web.apps.yml
+++ b/.github/workflows/desktop-server-web.apps.yml
@@ -81,12 +81,12 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
@@ -842,12 +842,12 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: 'true'
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient

--- a/.github/workflows/desktop.apps.yml
+++ b/.github/workflows/desktop.apps.yml
@@ -90,12 +90,12 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient
@@ -1053,12 +1053,12 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: 'true'
 
       - name: Install Yarn dependencies
         # yarn 1 does NOT retry a failed git-dependency tarball fetch, so one transient

--- a/.github/workflows/desktop.apps.yml
+++ b/.github/workflows/desktop.apps.yml
@@ -90,7 +90,7 @@ jobs:
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@^22.5.2'
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -1053,7 +1053,7 @@ jobs:
           "PYTHON=$py"            | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/extensions.dev.yml
+++ b/.github/workflows/extensions.dev.yml
@@ -30,27 +30,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route — same
-          # pattern as the mobile workflows. The public route has been seen truncating large prebuilt
-          # tarballs (e.g. @img/sharp-libvips-*), which turns into a broken sharp at build time.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/extensions.dev.yml
+++ b/.github/workflows/extensions.dev.yml
@@ -30,7 +30,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/extensions.prod.yml
+++ b/.github/workflows/extensions.prod.yml
@@ -30,27 +30,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route — same
-          # pattern as the mobile workflows. The public route has been seen truncating large prebuilt
-          # tarballs (e.g. @img/sharp-libvips-*), which turns into a broken sharp at build time.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/extensions.prod.yml
+++ b/.github/workflows/extensions.prod.yml
@@ -30,7 +30,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.apps.android.yml
+++ b/.github/workflows/mobile.apps.android.yml
@@ -70,30 +70,12 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route.
-          # These jobs run on in-cluster ARC runners that can reach the VIP directly. The public
-          # Cloudflare-fronted route runs ~280 KB/s and was measured on 2026-08-16 truncating a
-          # 14,590,565-byte tarball to 9,525,323 bytes mid-stream. A truncated prebuilt-binary
-          # package makes sharp fall back to compiling from source, which fails under Node 24.
-          # The VIP served the same file byte-exact.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.apps.android.yml
+++ b/.github/workflows/mobile.apps.android.yml
@@ -101,14 +101,35 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
-      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
-      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
-      # build archive, so the token was being uploaded to Expo (their log shows
+      # SECURITY + CORRECTNESS: "Configure Registry" appends the internal registry +
+      # VERDACCIO_TOKEN to .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked
+      # files in the build archive, so the token was being uploaded to Expo (their log shows
       # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
       # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
-      - name: Restore .npmrc before EAS upload
+      #
+      # .npmrc is NOT the only file the step mutates. The shared configure-registry action also
+      # appends `registry "<REGISTRY>"` to .yarnrc and sed-rewrites EVERY resolved URL in
+      # yarn.lock to that registry, and on these runners the registry is the LAN-only Verdaccio
+      # VIP. .easignore REPLACES .gitignore (it is not additive) and lists none of these three
+      # files, so all three ship in the archive; the Expo builder then runs
+      # `yarn install --frozen-lockfile` in the uploaded root and cannot resolve a single
+      # tarball. Restoring only .npmrc leaves that lockfile poisoned.
+      #
+      # Same per-path loop as .github/workflows/release.sdk.prod.yml: tracked files are checked
+      # out, untracked leftovers are removed. `if: always()` so a failed install still leaves
+      # the checkout clean for the next job on this self-hosted runner.
+      - name: Restore registry config before EAS upload
         shell: bash
-        run: git checkout -- .npmrc || true
+        if: always()
+        run: |
+          for f in yarn.lock .npmrc .yarnrc; do
+            if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+              git checkout -- "$f"
+            else
+              rm -f "$f"
+            fi
+          done
+          rm -f yarn.lock.rewritten package-lock.json.rewritten
 
       - name: Build on EAS
         id: eas_build

--- a/.github/workflows/mobile.apps.android.yml
+++ b/.github/workflows/mobile.apps.android.yml
@@ -70,7 +70,7 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.apps.ios.yml
+++ b/.github/workflows/mobile.apps.ios.yml
@@ -89,7 +89,7 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.apps.ios.yml
+++ b/.github/workflows/mobile.apps.ios.yml
@@ -89,30 +89,12 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route.
-          # These jobs run on in-cluster ARC runners that can reach the VIP directly. The public
-          # Cloudflare-fronted route runs ~280 KB/s and was measured on 2026-08-16 truncating a
-          # 14,590,565-byte tarball to 9,525,323 bytes mid-stream. A truncated prebuilt-binary
-          # package makes sharp fall back to compiling from source, which fails under Node 24.
-          # The VIP served the same file byte-exact.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.apps.ios.yml
+++ b/.github/workflows/mobile.apps.ios.yml
@@ -120,14 +120,35 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
-      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
-      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
-      # build archive, so the token was being uploaded to Expo (their log shows
+      # SECURITY + CORRECTNESS: "Configure Registry" appends the internal registry +
+      # VERDACCIO_TOKEN to .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked
+      # files in the build archive, so the token was being uploaded to Expo (their log shows
       # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
       # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
-      - name: Restore .npmrc before EAS upload
+      #
+      # .npmrc is NOT the only file the step mutates. The shared configure-registry action also
+      # appends `registry "<REGISTRY>"` to .yarnrc and sed-rewrites EVERY resolved URL in
+      # yarn.lock to that registry, and on these runners the registry is the LAN-only Verdaccio
+      # VIP. .easignore REPLACES .gitignore (it is not additive) and lists none of these three
+      # files, so all three ship in the archive; the Expo builder then runs
+      # `yarn install --frozen-lockfile` in the uploaded root and cannot resolve a single
+      # tarball. Restoring only .npmrc leaves that lockfile poisoned.
+      #
+      # Same per-path loop as .github/workflows/release.sdk.prod.yml: tracked files are checked
+      # out, untracked leftovers are removed. `if: always()` so a failed install still leaves
+      # the checkout clean for the next job on this self-hosted runner.
+      - name: Restore registry config before EAS upload
         shell: bash
-        run: git checkout -- .npmrc || true
+        if: always()
+        run: |
+          for f in yarn.lock .npmrc .yarnrc; do
+            if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+              git checkout -- "$f"
+            else
+              rm -f "$f"
+            fi
+          done
+          rm -f yarn.lock.rewritten package-lock.json.rewritten
 
       - name: Build on EAS
         id: eas_build

--- a/.github/workflows/mobile.apps.stage.android.yml
+++ b/.github/workflows/mobile.apps.stage.android.yml
@@ -92,7 +92,7 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.apps.stage.android.yml
+++ b/.github/workflows/mobile.apps.stage.android.yml
@@ -92,30 +92,12 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route.
-          # These jobs run on in-cluster ARC runners that can reach the VIP directly. The public
-          # Cloudflare-fronted route runs ~280 KB/s and was measured on 2026-08-16 truncating a
-          # 14,590,565-byte tarball to 9,525,323 bytes mid-stream. A truncated prebuilt-binary
-          # package makes sharp fall back to compiling from source, which fails under Node 24.
-          # The VIP served the same file byte-exact.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.apps.stage.android.yml
+++ b/.github/workflows/mobile.apps.stage.android.yml
@@ -123,14 +123,35 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
-      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
-      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
-      # build archive, so the token was being uploaded to Expo (their log shows
+      # SECURITY + CORRECTNESS: "Configure Registry" appends the internal registry +
+      # VERDACCIO_TOKEN to .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked
+      # files in the build archive, so the token was being uploaded to Expo (their log shows
       # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
       # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
-      - name: Restore .npmrc before EAS upload
+      #
+      # .npmrc is NOT the only file the step mutates. The shared configure-registry action also
+      # appends `registry "<REGISTRY>"` to .yarnrc and sed-rewrites EVERY resolved URL in
+      # yarn.lock to that registry, and on these runners the registry is the LAN-only Verdaccio
+      # VIP. .easignore REPLACES .gitignore (it is not additive) and lists none of these three
+      # files, so all three ship in the archive; the Expo builder then runs
+      # `yarn install --frozen-lockfile` in the uploaded root and cannot resolve a single
+      # tarball. Restoring only .npmrc leaves that lockfile poisoned.
+      #
+      # Same per-path loop as .github/workflows/release.sdk.prod.yml: tracked files are checked
+      # out, untracked leftovers are removed. `if: always()` so a failed install still leaves
+      # the checkout clean for the next job on this self-hosted runner.
+      - name: Restore registry config before EAS upload
         shell: bash
-        run: git checkout -- .npmrc || true
+        if: always()
+        run: |
+          for f in yarn.lock .npmrc .yarnrc; do
+            if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+              git checkout -- "$f"
+            else
+              rm -f "$f"
+            fi
+          done
+          rm -f yarn.lock.rewritten package-lock.json.rewritten
 
       - name: Build on EAS
         run: cd apps/mobile && eas build --profile internal --platform android --non-interactive

--- a/.github/workflows/mobile.apps.stage.ios.yml
+++ b/.github/workflows/mobile.apps.stage.ios.yml
@@ -113,14 +113,35 @@ jobs:
           EXPO_SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           EXPO_SENTRY_PROJECT: ${{ secrets.EXPO_SENTRY_PROJECT }}
 
-      # SECURITY: "Configure Registry" appends the internal registry + VERDACCIO_TOKEN to
-      # .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked files in the
-      # build archive, so the token was being uploaded to Expo (their log shows
+      # SECURITY + CORRECTNESS: "Configure Registry" appends the internal registry +
+      # VERDACCIO_TOKEN to .npmrc, which is a git-TRACKED file. eas-cli ships modified tracked
+      # files in the build archive, so the token was being uploaded to Expo (their log shows
       # "PREPARE_PROJECT | .npmrc found at .npmrc"). Restore it before the upload. This also
       # stops Expo builders trying to reach packages.ever.co, which they cannot resolve.
-      - name: Restore .npmrc before EAS upload
+      #
+      # .npmrc is NOT the only file the step mutates. The shared configure-registry action also
+      # appends `registry "<REGISTRY>"` to .yarnrc and sed-rewrites EVERY resolved URL in
+      # yarn.lock to that registry, and on these runners the registry is the LAN-only Verdaccio
+      # VIP. .easignore REPLACES .gitignore (it is not additive) and lists none of these three
+      # files, so all three ship in the archive; the Expo builder then runs
+      # `yarn install --frozen-lockfile` in the uploaded root and cannot resolve a single
+      # tarball. Restoring only .npmrc leaves that lockfile poisoned.
+      #
+      # Same per-path loop as .github/workflows/release.sdk.prod.yml: tracked files are checked
+      # out, untracked leftovers are removed. `if: always()` so a failed install still leaves
+      # the checkout clean for the next job on this self-hosted runner.
+      - name: Restore registry config before EAS upload
         shell: bash
-        run: git checkout -- .npmrc || true
+        if: always()
+        run: |
+          for f in yarn.lock .npmrc .yarnrc; do
+            if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+              git checkout -- "$f"
+            else
+              rm -f "$f"
+            fi
+          done
+          rm -f yarn.lock.rewritten package-lock.json.rewritten
 
       - name: Build on EAS
         run: cd apps/mobile && eas build --profile internal --platform ios --non-interactive

--- a/.github/workflows/mobile.apps.stage.ios.yml
+++ b/.github/workflows/mobile.apps.stage.ios.yml
@@ -82,7 +82,7 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.apps.stage.ios.yml
+++ b/.github/workflows/mobile.apps.stage.ios.yml
@@ -82,30 +82,12 @@ jobs:
           sed -i 's|SENTRY_PROJECT_PLACEHOLDER|${{ secrets.EXPO_SENTRY_PROJECT }}|g' ./apps/mobile/eas.json
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          # Prefer the INTERNAL Verdaccio VIP (org var VERDACCIO_REGISTRY, per
-          # docs/infrastructure/k8s-cicd-standard.md) over the public packages.ever.co route.
-          # These jobs run on in-cluster ARC runners that can reach the VIP directly. The public
-          # Cloudflare-fronted route runs ~280 KB/s and was measured on 2026-08-16 truncating a
-          # 14,590,565-byte tarball to 9,525,323 bytes mid-stream. A truncated prebuilt-binary
-          # package makes sharp fall back to compiling from source, which fails under Node 24.
-          # The VIP served the same file byte-exact.
-          REGISTRY="${VERDACCIO_REGISTRY:-https://packages.ever.co/}"
-          echo "registry=$REGISTRY" >> .npmrc
-          # The VIP allows anonymous reads; only the public route needs the token. Passed via env:
-          # so the secret is never spliced into this script.
-          case "$REGISTRY" in
-            *packages.ever.co*)
-              if [ -n "$VERDACCIO_TOKEN" ]; then
-                echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
-              fi
-              ;;
-          esac
-          echo "Using npm registry: $REGISTRY"
-        env:
-          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
-          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.before-merge.yml
+++ b/.github/workflows/mobile.before-merge.yml
@@ -44,7 +44,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.before-merge.yml
+++ b/.github/workflows/mobile.before-merge.yml
@@ -44,12 +44,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.dev.yml
+++ b/.github/workflows/mobile.dev.yml
@@ -35,12 +35,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.dev.yml
+++ b/.github/workflows/mobile.dev.yml
@@ -35,7 +35,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.prod.yml
+++ b/.github/workflows/mobile.prod.yml
@@ -35,12 +35,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.prod.yml
+++ b/.github/workflows/mobile.prod.yml
@@ -35,7 +35,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/mobile.stage.yml
+++ b/.github/workflows/mobile.stage.yml
@@ -35,12 +35,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |

--- a/.github/workflows/mobile.stage.yml
+++ b/.github/workflows/mobile.stage.yml
@@ -35,7 +35,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/release.sdk.prod.yml
+++ b/.github/workflows/release.sdk.prod.yml
@@ -72,7 +72,7 @@ jobs:
           echo "✅ NPM authentication configured"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/release.sdk.prod.yml
+++ b/.github/workflows/release.sdk.prod.yml
@@ -8,7 +8,14 @@ on:
 jobs:
   release:
     name: Version and SDK Publish with Changesets
-    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    # Prefer the -8 ARC pool: its RAM-backed volumes are work=24Gi + package cache=12Gi.
+    # The -4 pool (work=16Gi, cache=8Gi) is measurably too small for this repo's full
+    # `yarn install` — yarn 1 downloads every platform variant of the optional native
+    # deps (electron, @sentry/cli-*, @img/sharp-*), and run 32514096730 (2026-08-21)
+    # died with "ENOSPC: no space left on device" while extracting into the 8Gi cache
+    # tmpfs. Same ENOSPC hit web.before-merge.yml on the -4 pool the same day, on a run
+    # that installs straight from registry.yarnpkg.com — pool capacity, not registry.
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     permissions:
       contents: write # for changelog/version PRs
@@ -70,7 +77,7 @@ jobs:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
           force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' || vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install dependencies (Yarn)
         run: yarn install --frozen-lockfile

--- a/.github/workflows/web.before-merge.yml
+++ b/.github/workflows/web.before-merge.yml
@@ -54,7 +54,7 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@727973d766f3968d3f1184300af085872abcb20b
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/web.before-merge.yml
+++ b/.github/workflows/web.before-merge.yml
@@ -54,12 +54,12 @@ jobs:
           cache: "yarn"
 
       - name: Configure Registry
-        shell: bash
-        run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
-          fi
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install Packages
         run: |


### PR DESCRIPTION
Whole-branch cascade `develop` -> `stage` (no cherry-picking, golden rule #14). Owner instruction 2026-08-23.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies registry configuration across CI, protects remote-builder workflows from leaked config, and moves the SDK release to a larger ARC pool to eliminate ENOSPC failures. No application code or runtime behavior changes.

- Self‑hosted jobs now use the shared `ever-co/ever-gauzy/.github/actions/configure-registry` action. It prefers the internal Verdaccio VIP, safely passes the token via env, and rewrites lockfiles so installs actually use the intended registry.
- Vercel deploy workflows keep the hand‑rolled .npmrc step on purpose. They upload the working tree and build remotely; the shared action’s lockfile rewrite would break Vercel installs.
- Expo EAS Android/iOS jobs add a pre‑upload guard that restores `.npmrc`, `.yarnrc`, and `yarn.lock` to HEAD (or removes untracked rewrites) to avoid leaking tokens and unroutable VIP URLs. The cleanup runs even if install fails.
- The SDK release workflow runs on the `RUNNER_LINUX_X64_8` pool to prevent `ENOSPC` on RAM‑backed volumes; the VIP expectation follows the same runner‑var chain as the job.
- `.cspell.json` adds CI terms (`ENOSPC`, `tmpfs`, `yarnpkg`, and a few project/library names) surfaced by workflow comments.

<sup>Written for commit 7a75a102464779008f4b6e9fa61bb69e2cde8621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

