### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ Please see our [Wiki](https://github.com/ever-co/ever-teams/wiki/Deploy-to-Digit
 
 [Deploy to Northflank](https://app.northflank.com/s/account/templates/new?data=656ed069216b5d387f5379c6)
 
+### RepoCloud
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/ever-teams/)
+
 ## 📄 Content
 
 -   [`/apps/web`](apps/web) - NextJs-based (React) Web App at <https://app.ever.team> (deployed from `main` branch)


### PR DESCRIPTION
Adds RepoCloud as a one-click deployment option to the Self Hosting section, alongside existing providers (Vercel, Render, Railway, Fly, Netlify, Heroku, Koyeb, Northflank).

 - Added `### RepoCloud` subsection with deploy button (deploylobe.svg, 42px rendered height)
 - Button links to https://repocloud.io/details/ever-teams/
 - Placed after Northflank, before the Content section

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RepoCloud as a one-click deployment option in the Self Hosting section of the README, alongside the existing providers.

- Adds a `### RepoCloud` subsection with a deploy button linking to `https://repocloud.io/details/ever-teams/`, placed after Northflank and before the Content section.

<sup>Written for commit 85270408402c5c5d85f77ad9e6b4938cb328238b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added RepoCloud self-hosting instructions to the README.
  - Included a “Deploy on RepoCloud” button linking to the Ever Teams deployment template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->