### PR TITLE
fix(web): restore settings scroll and My Work reports

### DIFF
--- a/apps/web/core/components/auth/must-be-a-manager.test.tsx
+++ b/apps/web/core/components/auth/must-be-a-manager.test.tsx
@@ -10,8 +10,16 @@
 import { render, screen, act } from '@testing-library/react';
 
 const mockReplace = jest.fn();
-const auth = { user: null as null | { id: string; employee?: { id: string } }, userLoading: false, isTeamManager: false };
-const teamsQ = { getOrganizationTeamsLoading: false, teams: [] as unknown[], activeTeam: null as null | { members: unknown[] } };
+const auth = {
+	user: null as null | { id: string; employee?: { id: string }; role?: { name: string } },
+	userLoading: false,
+	isTeamManager: false
+};
+const teamsQ = {
+	getOrganizationTeamsLoading: false,
+	teams: [] as unknown[],
+	activeTeam: null as null | { members: unknown[] }
+};
 const SELF = { id: 'm-self', employee: { userId: 'u1' } };
 const OTHER = { id: 'm-other', employee: { userId: 'u2' } };
 
@@ -23,7 +31,14 @@ jest.mock('../common/global-skeleton', () => () => <div data-testid="skeleton" /
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const MustBeAManager = require('./must-be-a-manager').default as typeof import('./must-be-a-manager').default;
 
-function setState(next: { user?: { id: string } | null; userLoading?: boolean; isTeamManager?: boolean; teamsLoading?: boolean; teams?: unknown[]; activeTeam?: { members: unknown[] } | null }) {
+function setState(next: {
+	user?: { id: string; employee?: { id: string }; role?: { name: string } } | null;
+	userLoading?: boolean;
+	isTeamManager?: boolean;
+	teamsLoading?: boolean;
+	teams?: unknown[];
+	activeTeam?: { members: unknown[] } | null;
+}) {
 	if ('user' in next) auth.user = next.user ?? null;
 	if ('userLoading' in next) auth.userLoading = !!next.userLoading;
 	if ('isTeamManager' in next) auth.isTeamManager = !!next.isTeamManager;
@@ -36,7 +51,14 @@ describe('MustBeAManager', () => {
 	beforeEach(() => {
 		jest.useFakeTimers();
 		mockReplace.mockReset();
-		setState({ user: null, userLoading: false, isTeamManager: false, teamsLoading: false, teams: [], activeTeam: null });
+		setState({
+			user: null,
+			userLoading: false,
+			isTeamManager: false,
+			teamsLoading: false,
+			teams: [],
+			activeTeam: null
+		});
 	});
 	afterEach(() => jest.useRealTimers());
 
@@ -67,9 +89,28 @@ describe('MustBeAManager', () => {
 	});
 
 	it('redirects a real non-manager once membership is loaded', () => {
-		setState({ user: { id: 'u1' }, teams: [{ id: 't1' }], activeTeam: { members: [OTHER, SELF] }, isTeamManager: false });
+		setState({
+			user: { id: 'u1' },
+			teams: [{ id: 't1' }],
+			activeTeam: { members: [OTHER, SELF] },
+			isTeamManager: false
+		});
 		render(<MustBeAManager useRedirect>{<div>child</div>}</MustBeAManager>);
 		expect(mockReplace).toHaveBeenCalledWith('/');
+	});
+
+	it('allows a global super admin who is not a member of the active team', () => {
+		setState({
+			user: { id: 'u1', role: { name: 'SUPER_ADMIN' } },
+			teams: [{ id: 't1' }],
+			activeTeam: { members: [OTHER] },
+			isTeamManager: false
+		});
+
+		render(<MustBeAManager useRedirect>{<div>child</div>}</MustBeAManager>);
+
+		expect(screen.getByText('child')).toBeTruthy();
+		expect(mockReplace).not.toHaveBeenCalled();
 	});
 
 	it('a user with no teams is decided only after the bounded wait (the teams atom lags the query)', () => {

--- a/apps/web/core/components/auth/must-be-a-manager.tsx
+++ b/apps/web/core/components/auth/must-be-a-manager.tsx
@@ -4,6 +4,7 @@ import { useAuthenticateUser } from '@/core/hooks';
 import { useOrganizationTeamsQuery } from '@/core/hooks/organizations';
 import GlobalSkeleton from '../common/global-skeleton';
 import { useRouter } from 'next/navigation';
+import { ERoleName } from '@/core/types/generics/enums/role';
 
 type Props = {
 	children: React.ReactNode;
@@ -18,6 +19,9 @@ export default function MustBeAManager({ children, redirectTo = '/', useRedirect
 	const router = useRouter();
 	const [checked, setChecked] = useState(false);
 	const [isRedirecting, setIsRedirecting] = useState(false);
+	const isGlobalAdmin =
+		!!user?.role?.name && [ERoleName.ADMIN, ERoleName.SUPER_ADMIN].includes(user.role.name as ERoleName);
+	const isAuthorizedManager = isTeamManager || isGlobalAdmin;
 
 	// Determine if we're still loading critical data.
 	//
@@ -40,7 +44,8 @@ export default function MustBeAManager({ children, redirectTo = '/', useRedirect
 	// NOTE: the `teams` atom lags the teams query by one effect too — right after the query resolves the
 	// atom is still [] for a render (a full page load of any /reports URL is a cold load). "No teams"
 	// therefore keeps waiting as well; a user with genuinely zero teams is decided by the bounded wait.
-	const membershipPending = !userReady || isTeamsLoading || teams.length === 0 || !selfMembershipLoaded;
+	const membershipPending =
+		!userReady || (!isGlobalAdmin && (isTeamsLoading || teams.length === 0 || !selfMembershipLoaded));
 	// Safety valve: if membership never resolves (e.g. the active-team cookie points at a team the user
 	// is no longer in), decide after a bounded wait instead of showing the skeleton forever.
 	const [waitedTooLong, setWaitedTooLong] = useState(false);
@@ -55,18 +60,18 @@ export default function MustBeAManager({ children, redirectTo = '/', useRedirect
 		// Only proceed with authorization check when both user and teams data are loaded
 		if (!isLoading) {
 			setChecked(true);
-			if (!isTeamManager && redirectTo && useRedirect) {
+			if (!isAuthorizedManager && redirectTo && useRedirect) {
 				setIsRedirecting(true);
 				router.replace(redirectTo);
 			}
 		}
-	}, [isLoading, isTeamManager, redirectTo, router, useRedirect]);
+	}, [isLoading, isAuthorizedManager, redirectTo, router, useRedirect]);
 
 	// Compute all conditions after all hooks are called
 	const shouldShowLoading = isLoading || !checked || isRedirecting;
-	const shouldShowAccessDenied = !isTeamManager && !useRedirect;
-	const shouldShowLoadingForRedirect = !isTeamManager && useRedirect;
-	const shouldShowChildren = isTeamManager;
+	const shouldShowAccessDenied = !isAuthorizedManager && !useRedirect;
+	const shouldShowLoadingForRedirect = !isAuthorizedManager && useRedirect;
+	const shouldShowChildren = isAuthorizedManager;
 
 	// Conditional rendering after all hooks
 	if (shouldShowLoading) {

--- a/apps/web/core/components/auth/must-be-a-manager.tsx
+++ b/apps/web/core/components/auth/must-be-a-manager.tsx
@@ -12,6 +12,7 @@ type Props = {
 	useRedirect?: boolean;
 };
 
+/** Restricts report content to team managers and tenant-wide administrators. */
 export default function MustBeAManager({ children, redirectTo = '/', useRedirect = true }: Props) {
 	// All hooks must be called before any conditional returns
 	const { user, userLoading: isUserLoading, isTeamManager } = useAuthenticateUser();

--- a/apps/web/core/components/layouts/app/authenticator.test.tsx
+++ b/apps/web/core/components/layouts/app/authenticator.test.tsx
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+
+import { render, screen } from '@testing-library/react';
+import { withAuthentication } from './authenticator';
+
+jest.mock('jotai', () => ({
+	useAtom: () => [{ id: 'authenticated-user' }, jest.fn()]
+}));
+
+jest.mock('@/core/stores', () => ({
+	userState: {},
+	isTeamMemberState: {}
+}));
+
+jest.mock('@/core/lib/helpers/index', () => ({
+	getNoTeamPopupShowCookie: () => false,
+	setNoTeamPopupShowCookie: jest.fn()
+}));
+
+jest.mock('@/core/hooks/queries/user-user.query', () => ({
+	useUserQuery: () => ({
+		data: { id: 'authenticated-user' },
+		isLoading: false,
+		isSuccess: true
+	})
+}));
+
+jest.mock('@/core/components', () => ({
+	BackdropLoader: () => null
+}));
+
+jest.mock('../../common/global-skeleton', () => () => null);
+jest.mock('../../common/skeleton/modal-skeleton', () => ({ ModalSkeleton: () => null }));
+jest.mock('../../optimized-components', () => ({
+	LazyCreateTeamModal: () => null,
+	LazyJoinTeamModal: () => null
+}));
+
+describe('withAuthentication', () => {
+	it('preserves the viewport height boundary for authenticated page scrollers', () => {
+		const ProtectedPage = () => <main data-testid="protected-page">Protected page</main>;
+		const AuthenticatedPage = withAuthentication(ProtectedPage, { displayName: 'ProtectedPage' });
+
+		render(<AuthenticatedPage />);
+
+		const authenticatedBoundary = screen.getByTestId('protected-page').parentElement;
+		expect(authenticatedBoundary).not.toBeNull();
+		expect(authenticatedBoundary?.className).toContain('h-full');
+		expect(authenticatedBoundary?.className).toContain('min-h-0');
+	});
+});

--- a/apps/web/core/components/layouts/app/authenticator.tsx
+++ b/apps/web/core/components/layouts/app/authenticator.tsx
@@ -65,7 +65,7 @@ export function withAuthentication(Component: NextPage<any, any>, params: Params
 		}
 
 		return (
-			<div>
+			<div className="h-full min-h-0">
 				<Component {...props} />
 				{!isTeamMember && showCreateTeamModal && (
 					<Suspense fallback={<ModalSkeleton />}>

--- a/apps/web/core/components/layouts/app/authenticator.tsx
+++ b/apps/web/core/components/layouts/app/authenticator.tsx
@@ -17,6 +17,7 @@ type Params = {
 	showPageSkeleton?: boolean;
 };
 
+/** Wraps a protected page with user loading, authentication state, and team-join/create modal handling. */
 export function withAuthentication(Component: NextPage<any, any>, params: Params) {
 	const AppComponent = (props: any) => {
 		const [user, setUser] = useAtom(userState);


### PR DESCRIPTION
## Summary
- preserve the fixed-height viewport contract across the authenticated HOC boundary so `PageContentScroller` remains the single vertical scroll owner
- authorize global `ADMIN` and `SUPER_ADMIN` users for manager reports even when the selected team has no membership row for them
- add regressions for both runtime failures found during post-merge browser validation of #4438

## Root causes
1. #4438 correctly moved vertical scrolling from the outer chat panel to `PageContentScroller`, but `withAuthentication` still inserted an unconstrained wrapper between the fixed-height panel and `PageLayout`. The wrapper expanded to settings content height while an ancestor clipped overflow.
2. My Work links had correct report URLs, but `MustBeAManager` only accepted active-team managers. The public Super Admin demo account can select teams it does not belong to, so both report routes waited eight seconds and redirected to `/` despite the account's global `SUPER_ADMIN` role.

## Verification
- both regression tests observed failing for the intended missing behavior before implementation
- 63 web test suites / 339 tests passed
- `yarn build:web` passed (8/8 build tasks; 73 static pages generated)
- Prettier check passed for all changed files
- live DOM hypothesis check at 1936x1152: the height boundary constrains `PageLayout` to 1152px, gives the single scroller 1012px viewport height, and makes the footer reachable
- live API/browser diagnosis: active Frontend Team response has no `admin@ever.co` membership; the login is the Super Admin demo account, explaining the guard redirect

## Scope
No API, database, dependency, lockfile, environment, or GitOps changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authenticated page layouts to preserve full-height viewport boundaries and prevent unwanted overflow behavior.
  - Global administrators can now access manager-restricted areas without team membership or membership-loading delays.

- **Tests**
  - Added coverage verifying protected pages render correctly with the updated layout styling.
  - Added coverage confirming global administrators can access manager-only content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->