### PR TITLE
fix(web): normalise route-relative avatar imageUrl before rendering

### DIFF
--- a/apps/web/core/components/common/avatar-stack.test.tsx
+++ b/apps/web/core/components/common/avatar-stack.test.tsx
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+
+// cspell:ignore alish julia rahul
+/**
+ * AvatarStack — same defect as AvatarImage: a ROUTE-RELATIVE `imageUrl` from the Gauzy seed
+ * (`assets/images/avatars/alish.jpg`) was handed straight to next/image, so the browser resolved it
+ * against whatever route the user was on and 404'd.
+ *
+ * The assertion decodes the rendered `src` so it holds whether next/image emits the raw path or its
+ * optimiser URL (`/_next/image?url=...`): before the fix the decoded value contains
+ * `assets/images/...` with NO leading slash, after it contains `/assets/images/...`.
+ */
+import { render, screen } from '@testing-library/react';
+import AvatarStack from './avatar-stack';
+
+const decodedSrc = (alt: string) => decodeURIComponent(screen.getByAltText(alt).getAttribute('src') || '');
+
+describe('AvatarStack', () => {
+	it('makes a route-relative seed path root-relative', () => {
+		render(<AvatarStack avatars={[{ imageUrl: 'assets/images/avatars/alish.jpg', name: 'Alish M.' }]} />);
+
+		expect(decodedSrc('Alish M.')).toContain('/assets/images/avatars/alish.jpg');
+	});
+
+	it('leaves an absolute uploaded-avatar URL untouched', () => {
+		render(<AvatarStack avatars={[{ imageUrl: 'https://cdn.ever.co/avatars/julia.png', name: 'Julia K.' }]} />);
+
+		expect(decodedSrc('Julia K.')).toContain('https://cdn.ever.co/avatars/julia.png');
+	});
+
+	it('still shows the initials fallback when there is no image', () => {
+		render(<AvatarStack avatars={[{ name: 'Rahul S.' }]} />);
+
+		expect(screen.getByLabelText('Avatar for Rahul S.')).toBeTruthy();
+	});
+});

--- a/apps/web/core/components/common/avatar-stack.test.tsx
+++ b/apps/web/core/components/common/avatar-stack.test.tsx
@@ -33,4 +33,13 @@ describe('AvatarStack', () => {
 
 		expect(screen.getByLabelText('Avatar for Rahul S.')).toBeTruthy();
 	});
+
+	// A whitespace-only value is truthy, so branching on the RAW value would render <Image src="">,
+	// which next/image rejects. The branch has to use the normalised value.
+	it('shows the initials fallback for a whitespace-only imageUrl instead of rendering an empty src', () => {
+		render(<AvatarStack avatars={[{ imageUrl: '   ', name: 'Rahul S.' }]} />);
+
+		expect(screen.getByLabelText('Avatar for Rahul S.')).toBeTruthy();
+		expect(screen.queryByAltText('Rahul S.')).toBeNull();
+	});
 });

--- a/apps/web/core/components/common/avatar-stack.tsx
+++ b/apps/web/core/components/common/avatar-stack.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { useMemo } from 'react';
+import { normalizeImageUrl } from '@/core/lib/utils/normalize-image-url';
 
 interface AvatarStackProps {
 	avatars: { imageUrl?: string; name: string }[];
@@ -27,8 +28,10 @@ const AvatarStack: React.FC<AvatarStackProps> = ({ avatars, maxVisible = 5 }) =>
 				<div key={index} className="relative group">
 					<div className="relative w-8 h-8 rounded-full shrink-0 aspect-square">
 						{avatar?.imageUrl ? (
+							// `src` is normalised because the API can return a route-relative path, which
+							// Next.js would otherwise resolve against the current route and 404.
 							<Image
-								src={avatar?.imageUrl}
+								src={normalizeImageUrl(avatar?.imageUrl ?? '')}
 								alt={avatar?.name}
 								width={32}
 								height={32}

--- a/apps/web/core/components/common/avatar-stack.tsx
+++ b/apps/web/core/components/common/avatar-stack.tsx
@@ -24,35 +24,41 @@ const AvatarStack: React.FC<AvatarStackProps> = ({ avatars, maxVisible = 5 }) =>
 
 	return (
 		<div className="flex -space-x-3">
-			{avatars.slice(0, maxItemsToShow).map((avatar, index) => (
-				<div key={index} className="relative group">
-					<div className="relative w-8 h-8 rounded-full shrink-0 aspect-square">
-						{avatar?.imageUrl ? (
-							// `src` is normalised because the API can return a route-relative path, which
-							// Next.js would otherwise resolve against the current route and 404.
-							<Image
-								src={normalizeImageUrl(avatar?.imageUrl ?? '')}
-								alt={avatar?.name}
-								width={32}
-								height={32}
-								className="object-cover border-2 border-white rounded-full size-full aspect-square"
-							/>
-						) : (
-							<div
-								className="flex items-center justify-center w-8 h-8 font-medium text-white bg-gray-500 border-2 border-white rounded-full"
-								role="img"
-								aria-label={`Avatar for ${avatar?.name}`}
-							>
-								{avatar?.name?.substring(0, 2).toUpperCase()}
-							</div>
-						)}
+			{avatars.slice(0, maxItemsToShow).map((avatar, index) => {
+				// Normalised because the API can return a route-relative path, which Next.js would
+				// otherwise resolve against the current route and 404. The branch below tests the
+				// NORMALISED value: a whitespace-only `imageUrl` is truthy but normalises to '', and
+				// next/image rejects an empty `src`.
+				const src = normalizeImageUrl(avatar?.imageUrl ?? '');
+
+				return (
+					<div key={index} className="relative group">
+						<div className="relative w-8 h-8 rounded-full shrink-0 aspect-square">
+							{src ? (
+								<Image
+									src={src}
+									alt={avatar?.name}
+									width={32}
+									height={32}
+									className="object-cover border-2 border-white rounded-full size-full aspect-square"
+								/>
+							) : (
+								<div
+									className="flex items-center justify-center w-8 h-8 font-medium text-white bg-gray-500 border-2 border-white rounded-full"
+									role="img"
+									aria-label={`Avatar for ${avatar?.name}`}
+								>
+									{avatar?.name?.substring(0, 2).toUpperCase()}
+								</div>
+							)}
+						</div>
+						{/* Tooltip */}
+						<div className="absolute p-1.5 text-xs text-white transition transform -translate-x-1/2 bg-gray-800 rounded-sm shadow-lg opacity-0 bottom-12 left-1/2 group-hover:opacity-100 whitespace-nowrap">
+							{avatar?.name}
+						</div>
 					</div>
-					{/* Tooltip */}
-					<div className="absolute p-1.5 text-xs text-white transition transform -translate-x-1/2 bg-gray-800 rounded-sm shadow-lg opacity-0 bottom-12 left-1/2 group-hover:opacity-100 whitespace-nowrap">
-						{avatar?.name}
-					</div>
-				</div>
-			))}
+				);
+			})}
 			{avatars.length > maxItemsToShow && (
 				<div className="flex items-center justify-center w-8 h-8 text-xs font-medium bg-gray-300 border-2 border-white rounded-full">
 					+{avatars.length - maxItemsToShow}

--- a/apps/web/core/components/common/avatar.test.tsx
+++ b/apps/web/core/components/common/avatar.test.tsx
@@ -1,0 +1,45 @@
+// cspell:ignore alish julia rahul
+/**
+ * AvatarImage — every user avatar 404'd on demo.ever.team. The Gauzy API returns a ROUTE-RELATIVE
+ * `imageUrl` for seeded users/employees (`assets/images/avatars/avatar-default.svg`), and this
+ * primitive passed it straight to Radix, so the browser resolved it against the current route:
+ * `/dashboard/team-dashboard/assets/images/avatars/alish.jpg` -> 404. The team dashboard
+ * (`team-stats-table.tsx`) renders through exactly this component.
+ *
+ * These assert on the element the component actually returns rather than on rendered DOM, because
+ * `AvatarPrimitive.Image` only commits an <img> once a real image load resolves — which never
+ * happens under jsdom, so a DOM-based test here would pass vacuously.
+ */
+import { AvatarImage } from './avatar';
+
+type ForwardRefWithRender = {
+	render: (props: Record<string, unknown>, ref: unknown) => { props: Record<string, unknown> };
+};
+
+const renderProps = (props: Record<string, unknown>) =>
+	(AvatarImage as unknown as ForwardRefWithRender).render(props, null).props;
+
+describe('AvatarImage', () => {
+	it('makes a route-relative seed path root-relative so it cannot resolve against the current route', () => {
+		expect(renderProps({ src: 'assets/images/avatars/alish.jpg' }).src).toBe('/assets/images/avatars/alish.jpg');
+	});
+
+	it('leaves an absolute uploaded-avatar URL untouched', () => {
+		expect(renderProps({ src: 'https://cdn.ever.co/avatars/alish.jpg' }).src).toBe(
+			'https://cdn.ever.co/avatars/alish.jpg'
+		);
+	});
+
+	it('leaves an already root-relative path untouched', () => {
+		expect(renderProps({ src: '/assets/images/avatars/alish.jpg' }).src).toBe('/assets/images/avatars/alish.jpg');
+	});
+
+	it('passes undefined through so the fallback still renders', () => {
+		expect(renderProps({ src: undefined }).src).toBeUndefined();
+	});
+
+	it('still forwards the other props it is given', () => {
+		const props = renderProps({ src: 'assets/a.png', alt: 'Alish M.' });
+		expect(props.alt).toBe('Alish M.');
+	});
+});

--- a/apps/web/core/components/common/avatar.test.tsx
+++ b/apps/web/core/components/common/avatar.test.tsx
@@ -48,6 +48,14 @@ describe('AvatarImage', () => {
 		expect(renderProps({ src: '   ' }).src).toBeUndefined();
 	});
 
+	// React 19 types an <img> `src` as `string | Blob | undefined`. A Blob carries its own data and
+	// cannot resolve against a route, so it must be forwarded untouched.
+	it('forwards a Blob src untouched', () => {
+		const blob = new Blob(['x'], { type: 'image/png' });
+
+		expect(renderProps({ src: blob }).src).toBe(blob);
+	});
+
 	it('still forwards the other props it is given', () => {
 		const props = renderProps({ src: 'assets/a.png', alt: 'Alish M.' });
 		expect(props.alt).toBe('Alish M.');

--- a/apps/web/core/components/common/avatar.test.tsx
+++ b/apps/web/core/components/common/avatar.test.tsx
@@ -38,6 +38,16 @@ describe('AvatarImage', () => {
 		expect(renderProps({ src: undefined }).src).toBeUndefined();
 	});
 
+	// An empty `src` makes the underlying <img> request the current document URL, so it must become
+	// `undefined` — which is also what tells Radix to show the fallback.
+	it('turns an empty src into undefined rather than requesting the current document', () => {
+		expect(renderProps({ src: '' }).src).toBeUndefined();
+	});
+
+	it('turns a whitespace-only src into undefined', () => {
+		expect(renderProps({ src: '   ' }).src).toBeUndefined();
+	});
+
 	it('still forwards the other props it is given', () => {
 		const props = renderProps({ src: 'assets/a.png', alt: 'Alish M.' });
 		expect(props.alt).toBe('Alish M.');

--- a/apps/web/core/components/common/avatar.tsx
+++ b/apps/web/core/components/common/avatar.tsx
@@ -19,17 +19,24 @@ Avatar.displayName = AvatarPrimitive.Root.displayName;
 const AvatarImage = React.forwardRef<
 	React.ElementRef<typeof AvatarPrimitive.Image>,
 	React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
->(({ className, src, ...props }, ref) => (
+>(({ className, src, ...props }, ref) => {
 	// `src` is normalised because the API can return a route-relative path (e.g. the seeded
 	// `assets/images/avatars/avatar-default.svg`), which Next.js would otherwise resolve against the
 	// current route and 404. See `normalizeImageUrl`.
-	<AvatarPrimitive.Image
-		ref={ref}
-		className={cn('aspect-square h-full w-full', className)}
-		src={normalizeImageUrl(src)}
-		{...props}
-	/>
-));
+	//
+	// `|| undefined` because an empty `src` makes the underlying <img> request the current document
+	// URL; `undefined` is also what tells Radix to show the fallback instead.
+	const normalizedSrc = normalizeImageUrl(src) || undefined;
+
+	return (
+		<AvatarPrimitive.Image
+			ref={ref}
+			className={cn('aspect-square h-full w-full', className)}
+			src={normalizedSrc}
+			{...props}
+		/>
+	);
+});
 AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 
 const AvatarFallback = React.forwardRef<

--- a/apps/web/core/components/common/avatar.tsx
+++ b/apps/web/core/components/common/avatar.tsx
@@ -26,7 +26,10 @@ const AvatarImage = React.forwardRef<
 	//
 	// `|| undefined` because an empty `src` makes the underlying <img> request the current document
 	// URL; `undefined` is also what tells Radix to show the fallback instead.
-	const normalizedSrc = normalizeImageUrl(src) || undefined;
+	//
+	// React 19 types an <img> `src` as `string | Blob | undefined`. A Blob carries its own data and
+	// cannot resolve against a route, so it is forwarded untouched.
+	const normalizedSrc = typeof src === 'string' ? normalizeImageUrl(src) || undefined : src;
 
 	return (
 		<AvatarPrimitive.Image

--- a/apps/web/core/components/common/avatar.tsx
+++ b/apps/web/core/components/common/avatar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
 
 import { cn } from '@/core/lib/helpers';
+import { normalizeImageUrl } from '@/core/lib/utils/normalize-image-url';
 
 const Avatar = React.forwardRef<
 	React.ElementRef<typeof AvatarPrimitive.Root>,
@@ -18,8 +19,16 @@ Avatar.displayName = AvatarPrimitive.Root.displayName;
 const AvatarImage = React.forwardRef<
 	React.ElementRef<typeof AvatarPrimitive.Image>,
 	React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
->(({ className, ...props }, ref) => (
-	<AvatarPrimitive.Image ref={ref} className={cn('aspect-square h-full w-full', className)} {...props} />
+>(({ className, src, ...props }, ref) => (
+	// `src` is normalised because the API can return a route-relative path (e.g. the seeded
+	// `assets/images/avatars/avatar-default.svg`), which Next.js would otherwise resolve against the
+	// current route and 404. See `normalizeImageUrl`.
+	<AvatarPrimitive.Image
+		ref={ref}
+		className={cn('aspect-square h-full w-full', className)}
+		src={normalizeImageUrl(src)}
+		{...props}
+	/>
 ));
 AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 

--- a/apps/web/core/components/duplicated-components/avatar.test.tsx
+++ b/apps/web/core/components/duplicated-components/avatar.test.tsx
@@ -1,0 +1,48 @@
+/** @jest-environment jsdom */
+
+// cspell:ignore alish
+
+/**
+ * Avatar (duplicated-components) — same defect as AvatarImage/AvatarStack: a ROUTE-RELATIVE
+ * `imageUrl` from the Gauzy seed (`assets/images/avatars/avatar-default.svg`) went straight into
+ * next/image, so the browser resolved it against the current route and 404'd. This component renders
+ * the profile header, the collaborate panel and the sidebar avatars.
+ *
+ * The rendered `src` is decoded before asserting so the expectation holds whether next/image emits
+ * the raw path or its optimiser URL (`/_next/image?url=...`).
+ */
+import { render, screen } from '@testing-library/react';
+import { Avatar } from './avatar';
+
+jest.mock('jotai', () => ({
+	useAtom: () => [{}, jest.fn()]
+}));
+
+jest.mock('@/core/stores', () => ({
+	avatarState: {}
+}));
+
+const decodedSrc = (alt: string) => decodeURIComponent(screen.getByAltText(alt).getAttribute('src') || '');
+
+describe('Avatar', () => {
+	it('makes a route-relative seed path root-relative', () => {
+		render(<Avatar size={32} imageUrl="assets/images/avatars/alish.jpg" alt="Alish M." />);
+
+		expect(decodedSrc('Alish M.')).toContain('/assets/images/avatars/alish.jpg');
+	});
+
+	it('leaves an absolute uploaded-avatar URL untouched', () => {
+		render(<Avatar size={32} imageUrl="https://cdn.ever.co/avatars/alish.jpg" alt="Alish M." />);
+
+		expect(decodedSrc('Alish M.')).toContain('https://cdn.ever.co/avatars/alish.jpg');
+	});
+
+	// A whitespace-only value is truthy, so branching on the RAW value would render <Image src="">,
+	// which next/image rejects. The branch has to use the normalised value.
+	it('renders the initial instead of an empty src when imageUrl is whitespace only', () => {
+		render(<Avatar size={32} imageUrl="   " imageTitle="Rahul" alt="Rahul S." />);
+
+		expect(screen.queryByAltText('Rahul S.')).toBeNull();
+		expect(screen.getByText('R')).toBeTruthy();
+	});
+});

--- a/apps/web/core/components/duplicated-components/avatar.tsx
+++ b/apps/web/core/components/duplicated-components/avatar.tsx
@@ -2,7 +2,7 @@
 
 /* eslint-disable no-mixed-spaces-and-tabs */
 import { avatarState } from '@/core/stores';
-import { clsxm, isValidUrl } from '@/core/lib/utils';
+import { clsxm, isValidUrl, normalizeImageUrl } from '@/core/lib/utils';
 import Image from 'next/image';
 import { PropsWithChildren, useEffect, useMemo } from 'react';
 import { useAtom } from 'jotai';
@@ -70,10 +70,13 @@ export function Avatar({
 			{imageTitle && !imgUrl && <span className="text-lg font-normal uppercase">{imageTitle[0] || ''}</span>}
 
 			{imgUrl && (
+				// `src` is normalised because the API can return a route-relative path (e.g. the seeded
+				// `assets/images/avatars/avatar-default.svg`), which Next.js would otherwise resolve
+				// against the current route and 404. See `normalizeImageUrl`.
 				<Image
 					fill
 					sizes={`${size}px`}
-					src={imgUrl}
+					src={normalizeImageUrl(imgUrl)}
 					className={clsxm(
 						'w-full h-full object-cover',
 						shape === 'circle' && ['rounded-full'],

--- a/apps/web/core/components/duplicated-components/avatar.tsx
+++ b/apps/web/core/components/duplicated-components/avatar.tsx
@@ -36,11 +36,13 @@ export function Avatar({
 	const avatarPresent = hasOwn(avatar, imagePathName);
 
 	const imgUrl = useMemo(() => {
-		if (avatarPresent) {
-			return avatar[imagePathName];
-		} else {
-			return imageUrl;
-		}
+		const raw = avatarPresent ? avatar[imagePathName] : imageUrl;
+
+		// Normalised here so the fallback branch below and the <Image> `src` agree on one value: the
+		// API can return a route-relative path (e.g. the seeded `assets/images/avatars/…`) which
+		// Next.js would resolve against the current route and 404, and a whitespace-only value is
+		// truthy while normalising to '' — which next/image rejects. See `normalizeImageUrl`.
+		return normalizeImageUrl(raw) || undefined;
 		/* eslint-disable react-hooks/exhaustive-deps */
 	}, [imagePathName, avatarPresent]);
 
@@ -70,13 +72,10 @@ export function Avatar({
 			{imageTitle && !imgUrl && <span className="text-lg font-normal uppercase">{imageTitle[0] || ''}</span>}
 
 			{imgUrl && (
-				// `src` is normalised because the API can return a route-relative path (e.g. the seeded
-				// `assets/images/avatars/avatar-default.svg`), which Next.js would otherwise resolve
-				// against the current route and 404. See `normalizeImageUrl`.
 				<Image
 					fill
 					sizes={`${size}px`}
-					src={normalizeImageUrl(imgUrl)}
+					src={imgUrl}
 					className={clsxm(
 						'w-full h-full object-cover',
 						shape === 'circle' && ['rounded-full'],

--- a/apps/web/core/lib/utils/index.ts
+++ b/apps/web/core/lib/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './clsxm';
 export * from './is-valid-url';
+export * from './normalize-image-url';
 export * from './scroll-to-element';
 export * from './queue';
 export * from './wait';

--- a/apps/web/core/lib/utils/normalize-image-url.test.ts
+++ b/apps/web/core/lib/utils/normalize-image-url.test.ts
@@ -1,0 +1,75 @@
+// cspell:ignore alish julia rahul
+/**
+ * normalizeImageUrl — every user avatar 404'd on demo.ever.team. The Gauzy seed stores a
+ * ROUTE-RELATIVE `imageUrl` (`assets/images/avatars/avatar-default.svg`, no leading slash, no origin
+ * — see `packages/core/src/lib/user/default-users.ts` in ever-gauzy). The Angular Gauzy app renders
+ * it correctly because it ships `<base href="/">`; Next.js ships no `<base>`, so the browser resolves
+ * the value against the CURRENT ROUTE and requests
+ * `/dashboard/team-dashboard/assets/images/avatars/alish.jpg` -> 404. The 404 path therefore changed
+ * with whatever page the user was on.
+ *
+ * The fix normalises such values to root-relative before they ever reach an <img>/<Image> `src`.
+ * Absolute, protocol-relative, data:, blob: and already-root-relative values must pass through
+ * untouched so real uploaded avatars (S3/MinIO/CDN) keep working.
+ */
+import { normalizeImageUrl } from './normalize-image-url';
+
+describe('normalizeImageUrl', () => {
+	it('prefixes a route-relative seed path so it resolves from the site root', () => {
+		expect(normalizeImageUrl('assets/images/avatars/avatar-default.svg')).toBe(
+			'/assets/images/avatars/avatar-default.svg'
+		);
+	});
+
+	it('prefixes any other route-relative path', () => {
+		expect(normalizeImageUrl('images/foo.png')).toBe('/images/foo.png');
+	});
+
+	it('leaves an already root-relative path untouched', () => {
+		expect(normalizeImageUrl('/assets/images/avatars/alish.jpg')).toBe('/assets/images/avatars/alish.jpg');
+	});
+
+	it('leaves an absolute https URL untouched', () => {
+		expect(normalizeImageUrl('https://cdn.ever.co/avatars/alish.jpg')).toBe(
+			'https://cdn.ever.co/avatars/alish.jpg'
+		);
+	});
+
+	it('leaves an absolute http URL untouched', () => {
+		expect(normalizeImageUrl('http://localhost:3000/a.png')).toBe('http://localhost:3000/a.png');
+	});
+
+	it('leaves a protocol-relative URL untouched', () => {
+		expect(normalizeImageUrl('//cdn.ever.co/avatars/alish.jpg')).toBe('//cdn.ever.co/avatars/alish.jpg');
+	});
+
+	it('leaves a data: URI untouched', () => {
+		expect(normalizeImageUrl('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=')).toBe(
+			'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4='
+		);
+	});
+
+	it('leaves a blob: URL untouched', () => {
+		expect(normalizeImageUrl('blob:https://demo.ever.team/1234')).toBe('blob:https://demo.ever.team/1234');
+	});
+
+	it('trims surrounding whitespace before deciding', () => {
+		expect(normalizeImageUrl('  assets/images/avatars/alish.jpg  ')).toBe('/assets/images/avatars/alish.jpg');
+	});
+
+	it('returns undefined for undefined', () => {
+		expect(normalizeImageUrl(undefined)).toBeUndefined();
+	});
+
+	it('returns null for null', () => {
+		expect(normalizeImageUrl(null)).toBeNull();
+	});
+
+	it('returns an empty string unchanged so falsy fallback rendering still works', () => {
+		expect(normalizeImageUrl('')).toBe('');
+	});
+
+	it('treats a whitespace-only value as empty rather than turning it into "/"', () => {
+		expect(normalizeImageUrl('   ')).toBe('');
+	});
+});

--- a/apps/web/core/lib/utils/normalize-image-url.ts
+++ b/apps/web/core/lib/utils/normalize-image-url.ts
@@ -1,6 +1,6 @@
 // cspell:ignore alish julia rahul
 /**
- * Makes an image URL safe to hand to an `<img>` / next `<Image>` `src`.
+ * Makes an image URL resolve independently of the route the user happens to be on.
  *
  * The Gauzy API can return a ROUTE-RELATIVE image path — the seeded users and employees carry
  * `imageUrl: 'assets/images/avatars/avatar-default.svg'` (no leading slash, no origin). The Angular
@@ -12,6 +12,11 @@
  * Anything already resolvable on its own — absolute (`https:`, `data:`, `blob:`, ...),
  * protocol-relative (`//host/...`) or root-relative (`/...`) — is returned untouched, so real
  * uploaded avatars served from S3/MinIO/the CDN keep working.
+ *
+ * Note: a protocol-relative value is deliberately left alone. It already resolves against the
+ * origin's scheme rather than the route, so it is not this function's problem — and rewriting its
+ * scheme would be a behaviour change well beyond "stop resolving against the current route".
+ * (`next/image` rejects protocol-relative sources, but it did so before this helper existed too.)
  */
 
 /** Matches a URI scheme such as `https:`, `data:` or `blob:` at the start of the value. */

--- a/apps/web/core/lib/utils/normalize-image-url.ts
+++ b/apps/web/core/lib/utils/normalize-image-url.ts
@@ -1,0 +1,37 @@
+// cspell:ignore alish julia rahul
+/**
+ * Makes an image URL safe to hand to an `<img>` / next `<Image>` `src`.
+ *
+ * The Gauzy API can return a ROUTE-RELATIVE image path — the seeded users and employees carry
+ * `imageUrl: 'assets/images/avatars/avatar-default.svg'` (no leading slash, no origin). The Angular
+ * Gauzy app renders that correctly only because it ships `<base href="/">`. Next.js ships no
+ * `<base>`, so the browser resolves the same value against the CURRENT ROUTE and requests
+ * `/dashboard/team-dashboard/assets/images/avatars/alish.jpg`, which 404s — and the failing path
+ * changes with whatever page the user happens to be on.
+ *
+ * Anything already resolvable on its own — absolute (`https:`, `data:`, `blob:`, ...),
+ * protocol-relative (`//host/...`) or root-relative (`/...`) — is returned untouched, so real
+ * uploaded avatars served from S3/MinIO/the CDN keep working.
+ */
+
+/** Matches a URI scheme such as `https:`, `data:` or `blob:` at the start of the value. */
+const HAS_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+export function normalizeImageUrl(url: string): string;
+export function normalizeImageUrl(url: string | undefined): string | undefined;
+export function normalizeImageUrl(url: string | null): string | null;
+export function normalizeImageUrl(url: string | null | undefined): string | null | undefined;
+export function normalizeImageUrl(url?: string | null): string | null | undefined {
+	if (url === null || url === undefined) return url;
+
+	const trimmed = url.trim();
+
+	// Keep empty values empty so callers' `imageUrl ? <Image/> : <Fallback/>` branches still work,
+	// and so a whitespace-only value never becomes the site root "/".
+	if (!trimmed) return '';
+
+	// Already resolvable without a base: absolute, protocol-relative, or root-relative.
+	if (HAS_SCHEME.test(trimmed) || trimmed.startsWith('//') || trimmed.startsWith('/')) return trimmed;
+
+	return `/${trimmed}`;
+}


### PR DESCRIPTION
## The bug

Every user avatar 404s on `https://demo.ever.team`. Six per team-dashboard load:

```
/dashboard/team-dashboard/assets/images/avatars/alish.jpg           -> 404
/dashboard/team-dashboard/assets/images/avatars/avatar-default.svg  -> 404
...rahul.png, julia.png, chetan.png, ruslan.jpg
```

## Root cause

The Gauzy API returns a **route-relative** image path. Verified live:

```
GET https://apidev.ever.team/api/user/me?relations[0]=role&includeEmployee=true
-> { "imageUrl": "assets/images/avatars/avatar-default.svg", ... }
```

No leading slash, no origin. It comes from the seed —
`packages/core/src/lib/user/default-users.ts` and
`packages/core/src/lib/employee/default-employees.ts` in `ever-gauzy`.

The **Angular** Gauzy app renders it correctly only because `apps/gauzy/src/index.html`
ships `<base href="/" />`. **Next.js ships no `<base>`**, so the browser resolves the same
value against the *current route* — which is why the failing path changes with whatever
page you happen to be on.

## The fix

Adds `normalizeImageUrl()` and applies it in the three shared image primitives, so the
value is repaired before it can reach an `<img>` / `<Image>` `src`:

| primitive | used by |
|---|---|
| `common/avatar.tsx` -> `AvatarImage` | team dashboard (`team-stats-table.tsx`), productivity tables, ... |
| `duplicated-components/avatar.tsx` -> `Avatar` | profile, header, collaborate, ... |
| `common/avatar-stack.tsx` -> `AvatarStack` | stacked member avatars |

Absolute, protocol-relative, `data:`, `blob:` and already root-relative values pass
through untouched, so **real uploaded avatars (S3/MinIO/CDN) are unaffected**.

## Why the client and not the seed

Deliberate, and worth stating because the obvious instinct is to "fix the data":

- The seed value is **correct** for the Angular app (`<base href="/">`). It is the Next.js
  client that is unguarded.
- Changing the seed **repairs no existing row** — seeds run only against a fresh database.
- `createDefaultAdminUsers` is called from `seedBasicDefaultData()`, i.e. it is **not**
  demo-only — it feeds **Gauzy production** seeding. Editing it carries real risk for zero
  immediate benefit.

A follow-up in `ever-gauzy` to store root-relative values is still reasonable, but it is a
separate change and does not block this one.

## Scope

All three environments are affected: `develop`, `stage` and `main` all carry the identical
unguarded primitive (verified per-branch), and stage/prod run `DEMO=false` on Postgres but
still receive the seeded admin rows via `seedBasicDefaultData()`.

## Tests

Failing-first regressions:

- `core/lib/utils/normalize-image-url.test.ts` — 13 cases covering the seed path, other
  route-relative paths, root-relative, absolute http/https, protocol-relative, `data:`,
  `blob:`, whitespace trimming, and `null` / `undefined` / empty / whitespace-only
  (a whitespace-only value must not become `"/"`).
- `core/components/common/avatar.test.tsx` — asserts on the element `AvatarImage` actually
  returns. Deliberately not a DOM test: `AvatarPrimitive.Image` only commits an `<img>`
  once a real image load resolves, which never happens under jsdom, so a DOM assertion
  here would pass vacuously.
- `core/components/common/avatar-stack.test.tsx` — renders and decodes the emitted `src`,
  so it holds whether next/image emits the raw path or its optimiser URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404'd user avatars on `demo.ever.team` by normalizing route-relative `imageUrl` values before they reach an `<img>` or next `<Image>` src. The Gauzy API returns seeded avatar paths without a leading slash, which Next.js resolves against the current route and 404s; the Angular app renders them correctly only because it ships `<base href="/">`.

Adds `normalizeImageUrl()` and applies it in `AvatarImage`, `Avatar`, and `AvatarStack`. Absolute, protocol-relative, `data:`, `blob:`, and already root-relative URLs pass through untouched, so uploaded avatars (S3/MinIO/CDN) are unaffected. `AvatarImage` also forwards `Blob` src values as-is since they carry their own data and can't resolve against a route. A whitespace-only `imageUrl` now shows the initials fallback instead of rendering an empty `src`.

**Why the client and not the seed**
- Changing the seed repairs no existing rows — seeds run only against fresh databases.
- `createDefaultAdminUsers` also feeds production seeding, so editing it carries real risk.

**Testing**
- Adds failing-first regression tests for `normalizeImageUrl` and all three avatar primitives.

<sup>Written for commit 59e1c0bfe44005b746a7d1023f4b550eabaab6c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-teams/pull/4441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed avatar images using relative paths that could fail to load on nested routes.
  * Preserved absolute, root-relative, data, and blob image URLs.
  * Prevented empty or whitespace-only image paths from rendering broken images.
  * Maintained initials fallback behavior when no avatar image is available.

* **Tests**
  * Added coverage for avatar URL normalization, supported image sources, and fallback rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->