### PR TITLE
Fix-[Web]: Guard timesheet report proxy routes and forward the access token

### DIFF
--- a/apps/web/app/api/timesheet/activity/report/route.ts
+++ b/apps/web/app/api/timesheet/activity/report/route.ts
@@ -15,7 +15,8 @@ export async function GET(req: NextRequest) {
 	const res = new NextResponse();
 
 	try {
-		// Authenticate before reading parameters so anonymous callers always get 401
+		// Authenticate before reading parameters: the guard answers 401 to a rejected token and 503 when
+		// the session check could not reach Gauzy, so an outage never looks like an expired session
 		const guard = await authenticatedGuard(req, res);
 		if (!guard.user) return guard.deny();
 		const { access_token } = guard;

--- a/apps/web/app/api/timesheet/activity/report/route.ts
+++ b/apps/web/app/api/timesheet/activity/report/route.ts
@@ -15,14 +15,9 @@ export async function GET(req: NextRequest) {
 	const res = new NextResponse();
 
 	try {
-		// Authenticate before reading parameters so anonymous callers always get 401. A session check
-		// that could not reach Gauzy is a 503, not a 401, so the client does not log the user out.
+		// Authenticate before reading parameters so anonymous callers always get 401
 		const guard = await authenticatedGuard(req, res);
-		if (!guard.user) {
-			return guard.unauthorized
-				? NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
-				: NextResponse.json({ message: 'Session check unavailable, retry later' }, { status: 503 });
-		}
+		if (!guard.user) return guard.deny();
 		const { access_token } = guard;
 
 		const searchParams = req.nextUrl.searchParams;

--- a/apps/web/app/api/timesheet/activity/report/route.ts
+++ b/apps/web/app/api/timesheet/activity/report/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticatedGuard } from '@/core/services/server/guards/authenticated-guard-app';
 import { getActivityReportRequest } from '@/core/services/server/requests/timesheet';
 import { IActivityRequestParams } from '@/core/services/server/requests/timesheet';
 import { ETimeLogType } from '@/core/types/generics/enums/timer';
@@ -11,7 +12,13 @@ export const runtime = 'nodejs';
  * Fetches activity report data based on provided query parameters
  */
 export async function GET(req: NextRequest) {
+	const res = new NextResponse();
+
 	try {
+		// Authenticate before reading parameters so anonymous callers always get 401
+		const { user, access_token } = await authenticatedGuard(req, res);
+		if (!user) return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+
 		const searchParams = req.nextUrl.searchParams;
 
 		const params: Partial<IActivityRequestParams> = {
@@ -63,7 +70,7 @@ export async function GET(req: NextRequest) {
 		}
 
 		// Fetch activity report data
-		const data = await getActivityReportRequest(params as IActivityRequestParams);
+		const { data } = await getActivityReportRequest(params as IActivityRequestParams, access_token);
 
 		return new Response(JSON.stringify(data), {
 			status: 200,

--- a/apps/web/app/api/timesheet/activity/report/route.ts
+++ b/apps/web/app/api/timesheet/activity/report/route.ts
@@ -15,9 +15,15 @@ export async function GET(req: NextRequest) {
 	const res = new NextResponse();
 
 	try {
-		// Authenticate before reading parameters so anonymous callers always get 401
-		const { user, access_token } = await authenticatedGuard(req, res);
-		if (!user) return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+		// Authenticate before reading parameters so anonymous callers always get 401. A session check
+		// that could not reach Gauzy is a 503, not a 401, so the client does not log the user out.
+		const guard = await authenticatedGuard(req, res);
+		if (!guard.user) {
+			return guard.unauthorized
+				? NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+				: NextResponse.json({ message: 'Session check unavailable, retry later' }, { status: 503 });
+		}
+		const { access_token } = guard;
 
 		const searchParams = req.nextUrl.searchParams;
 

--- a/apps/web/app/api/timesheet/time-log/report/daily/route.ts
+++ b/apps/web/app/api/timesheet/time-log/report/daily/route.ts
@@ -10,9 +10,15 @@ export async function GET(req: NextRequest) {
 	const res = new NextResponse();
 
 	try {
-		// Authenticate before reading parameters so anonymous callers always get 401
-		const { user, access_token } = await authenticatedGuard(req, res);
-		if (!user) return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+		// Authenticate before reading parameters so anonymous callers always get 401. A session check
+		// that could not reach Gauzy is a 503, not a 401, so the client does not log the user out.
+		const guard = await authenticatedGuard(req, res);
+		if (!guard.user) {
+			return guard.unauthorized
+				? NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+				: NextResponse.json({ message: 'Session check unavailable, retry later' }, { status: 503 });
+		}
+		const { access_token } = guard;
 
 		const searchParams = req.nextUrl.searchParams;
 

--- a/apps/web/app/api/timesheet/time-log/report/daily/route.ts
+++ b/apps/web/app/api/timesheet/time-log/report/daily/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticatedGuard } from '@/core/services/server/guards/authenticated-guard-app';
 import { getTimeLogReportDailyRequest } from '@/core/services/server/requests/timesheet';
 import { ITimeLogRequestParams } from '@/core/services/server/requests/timesheet';
 
@@ -6,7 +7,13 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest) {
+	const res = new NextResponse();
+
 	try {
+		// Authenticate before reading parameters so anonymous callers always get 401
+		const { user, access_token } = await authenticatedGuard(req, res);
+		if (!user) return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+
 		const searchParams = req.nextUrl.searchParams;
 
 		const params: Partial<ITimeLogRequestParams> = {
@@ -53,9 +60,9 @@ export async function GET(req: NextRequest) {
 			};
 		}
 
-		const response = await getTimeLogReportDailyRequest(params as ITimeLogRequestParams);
+		const { data } = await getTimeLogReportDailyRequest(params as ITimeLogRequestParams, access_token);
 
-		return new Response(JSON.stringify(response), {
+		return new Response(JSON.stringify(data), {
 			status: 200,
 			headers: {
 				'Content-Type': 'application/json'

--- a/apps/web/app/api/timesheet/time-log/report/daily/route.ts
+++ b/apps/web/app/api/timesheet/time-log/report/daily/route.ts
@@ -10,7 +10,8 @@ export async function GET(req: NextRequest) {
 	const res = new NextResponse();
 
 	try {
-		// Authenticate before reading parameters so anonymous callers always get 401
+		// Authenticate before reading parameters: the guard answers 401 to a rejected token and 503 when
+		// the session check could not reach Gauzy, so an outage never looks like an expired session
 		const guard = await authenticatedGuard(req, res);
 		if (!guard.user) return guard.deny();
 		const { access_token } = guard;

--- a/apps/web/app/api/timesheet/time-log/report/daily/route.ts
+++ b/apps/web/app/api/timesheet/time-log/report/daily/route.ts
@@ -10,14 +10,9 @@ export async function GET(req: NextRequest) {
 	const res = new NextResponse();
 
 	try {
-		// Authenticate before reading parameters so anonymous callers always get 401. A session check
-		// that could not reach Gauzy is a 503, not a 401, so the client does not log the user out.
+		// Authenticate before reading parameters so anonymous callers always get 401
 		const guard = await authenticatedGuard(req, res);
-		if (!guard.user) {
-			return guard.unauthorized
-				? NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
-				: NextResponse.json({ message: 'Session check unavailable, retry later' }, { status: 503 });
-		}
+		if (!guard.user) return guard.deny();
 		const { access_token } = guard;
 
 		const searchParams = req.nextUrl.searchParams;

--- a/apps/web/core/services/server/guards/authenticated-guard-app.ts
+++ b/apps/web/core/services/server/guards/authenticated-guard-app.ts
@@ -29,12 +29,18 @@ export async function authenticatedGuard(req: Request, res: NextResponse<unknown
 	});
 
 	if (!r_res || (r_res.data as any).statusCode === 401) {
+		// True when Gauzy rejected the token itself; false when the check could not be completed.
+		const unauthorized = rejectedStatus === 401 || (r_res?.data as any)?.statusCode === 401;
 		return {
 			$res: (data: any) => NextResponse.json({ statusCode: 401, message: data }),
 			user: null,
-			// True when Gauzy rejected the token itself; false when the check could not be completed,
-			// which callers should not report as 401 or the client will log the user out.
-			unauthorized: rejectedStatus === 401 || (r_res?.data as any)?.statusCode === 401
+			unauthorized,
+			// 401 only when the token was rejected: answering 401 to a failed check would make the
+			// client log the user out during a Gauzy outage.
+			deny: () =>
+				unauthorized
+					? NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+					: NextResponse.json({ message: 'Session check unavailable, retry later' }, { status: 503 })
 		};
 	}
 

--- a/apps/web/core/services/server/guards/authenticated-guard-app.ts
+++ b/apps/web/core/services/server/guards/authenticated-guard-app.ts
@@ -17,14 +17,24 @@ export async function authenticatedGuard(req: Request, res: NextResponse<unknown
 	const taskId = getActiveTaskIdCookie({ req, res });
 	const projectId = getActiveProjectIdCookie({ req, res });
 
+	// serverFetch rejects a non-2xx answer with Promise.reject(data), so Gauzy's status code sits inside
+	// that promise; a network failure rejects with a plain error that carries no status code.
+	let rejectedStatus: number | undefined;
 	const r_res = await currentAuthenticatedUserRequest({
 		bearer_token: access_token?.toString() || ''
-	}).catch(console.error);
+	}).catch(async (error: unknown) => {
+		const reason = error instanceof Promise ? await error.catch((data) => data) : error;
+		rejectedStatus = (reason as { statusCode?: number } | undefined)?.statusCode;
+		console.error(reason);
+	});
 
 	if (!r_res || (r_res.data as any).statusCode === 401) {
 		return {
 			$res: (data: any) => NextResponse.json({ statusCode: 401, message: data }),
-			user: null
+			user: null,
+			// True when Gauzy rejected the token itself; false when the check could not be completed,
+			// which callers should not report as 401 or the client will log the user out.
+			unauthorized: rejectedStatus === 401 || (r_res?.data as any)?.statusCode === 401
 		};
 	}
 

--- a/apps/web/core/services/server/guards/authenticated-guard-app.ts
+++ b/apps/web/core/services/server/guards/authenticated-guard-app.ts
@@ -31,8 +31,9 @@ export async function authenticatedGuard(req: Request, res: NextResponse<unknown
 	if (!r_res || (r_res.data as any).statusCode === 401) {
 		// Keep Gauzy's own status (401, 404, 429...); only a check that never got an answer is a 503, so
 		// an outage never looks like an expired session that the client should log out.
-		const upstreamStatus = rejection?.statusCode ?? (r_res?.data as any)?.statusCode;
-		const status = typeof upstreamStatus === 'number' && upstreamStatus >= 400 ? upstreamStatus : 503;
+		const upstream: { statusCode?: number; message?: string } | undefined = rejection ?? (r_res?.data as any);
+		const status =
+			typeof upstream?.statusCode === 'number' && upstream.statusCode >= 400 ? upstream.statusCode : 503;
 		return {
 			$res: (data: any) => NextResponse.json({ statusCode: 401, message: data }),
 			user: null,
@@ -43,7 +44,7 @@ export async function authenticatedGuard(req: Request, res: NextResponse<unknown
 						message:
 							status === 503
 								? 'Session check unavailable, retry later'
-								: rejection?.message || 'Unauthorized'
+								: upstream?.message || 'Unauthorized'
 					},
 					{ status }
 				)

--- a/apps/web/core/services/server/guards/authenticated-guard-app.ts
+++ b/apps/web/core/services/server/guards/authenticated-guard-app.ts
@@ -17,30 +17,36 @@ export async function authenticatedGuard(req: Request, res: NextResponse<unknown
 	const taskId = getActiveTaskIdCookie({ req, res });
 	const projectId = getActiveProjectIdCookie({ req, res });
 
-	// serverFetch rejects a non-2xx answer with Promise.reject(data), so Gauzy's status code sits inside
+	// serverFetch rejects a non-2xx answer with Promise.reject(data), so Gauzy's error body sits inside
 	// that promise; a network failure rejects with a plain error that carries no status code.
-	let rejectedStatus: number | undefined;
+	let rejection: { statusCode?: number; message?: string } | undefined;
 	const r_res = await currentAuthenticatedUserRequest({
 		bearer_token: access_token?.toString() || ''
 	}).catch(async (error: unknown) => {
 		const reason = error instanceof Promise ? await error.catch((data) => data) : error;
-		rejectedStatus = (reason as { statusCode?: number } | undefined)?.statusCode;
+		rejection = reason && typeof reason === 'object' ? reason : undefined;
 		console.error(reason);
 	});
 
 	if (!r_res || (r_res.data as any).statusCode === 401) {
-		// True when Gauzy rejected the token itself; false when the check could not be completed.
-		const unauthorized = rejectedStatus === 401 || (r_res?.data as any)?.statusCode === 401;
+		// Keep Gauzy's own status (401, 404, 429...); only a check that never got an answer is a 503, so
+		// an outage never looks like an expired session that the client should log out.
+		const upstreamStatus = rejection?.statusCode ?? (r_res?.data as any)?.statusCode;
+		const status = typeof upstreamStatus === 'number' && upstreamStatus >= 400 ? upstreamStatus : 503;
 		return {
 			$res: (data: any) => NextResponse.json({ statusCode: 401, message: data }),
 			user: null,
-			unauthorized,
-			// 401 only when the token was rejected: answering 401 to a failed check would make the
-			// client log the user out during a Gauzy outage.
+			status,
 			deny: () =>
-				unauthorized
-					? NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
-					: NextResponse.json({ message: 'Session check unavailable, retry later' }, { status: 503 })
+				NextResponse.json(
+					{
+						message:
+							status === 503
+								? 'Session check unavailable, retry later'
+								: rejection?.message || 'Unauthorized'
+					},
+					{ status }
+				)
 		};
 	}
 


### PR DESCRIPTION
# Fix-[Web]: Guard timesheet report proxy routes and forward the access token

## Description

In proxy mode (`NEXT_PUBLIC_GAUZY_API_SERVER_URL` unset, so the browser goes through the Next.js `app/api/**` routes), two timesheet report routes were unusable:

- `app/api/timesheet/activity/report`
- `app/api/timesheet/time-log/report/daily`

Neither applied `authenticatedGuard`, and both called their request function without a bearer token. `serverFetch` only sets the `Authorization` header when a token is given, so Gauzy rejected the call and the routes answered 500. On top of that, both routes serialised the whole `{ data, response }` object returned by `serverFetch` instead of `data`, so even with a token the client hooks would have received an empty report.

The sibling `time-log/report/daily-chart` route already does all of this correctly; this PR aligns the two routes with it.

## What Was Changed

### Major Changes

- Both routes run `authenticatedGuard` before reading any query parameter. Callers whose token Gauzy rejects get a real HTTP 401, which is what the client interceptors react to.
- When the session check itself cannot be completed (Gauzy down, network failure), the routes answer 503 rather than 401, so an outage does not start the client refresh-and-logout flow.
- The caller's `access_token` is passed to `getActivityReportRequest` / `getTimeLogReportDailyRequest`, so Gauzy receives the bearer token.
- The routes return the report payload (`data`) instead of the `serverFetch` envelope, like `daily-chart`.

### Minor Changes

- `authenticatedGuard` now records why `/user/me` failed and exposes `status` plus a `deny()` response builder in its failure branch: Gauzy's own error status (401, 404, 429, 5xx) with its message, or 503 when the check got no answer at all. Existing callers only read `user`, so nothing changes for them. Its `console.error` now logs the actual reason instead of a Promise object.
- Parameter parsing, the 400 validation and the 500 handling of both routes are untouched.

## How to Test This PR

1. Run the web app in proxy mode: leave `NEXT_PUBLIC_GAUZY_API_SERVER_URL` unset (that is what switches the browser to the Next.js routes), keep `GAUZY_API_SERVER_URL` pointing to a Gauzy API, then `yarn dev` in `apps/web`. The curl checks below do not depend on the mode.
2. Without being logged in:
   ```
   curl -i "http://localhost:3030/api/timesheet/activity/report"
   curl -i "http://localhost:3030/api/timesheet/time-log/report/daily?tenantId=<tenant>&organizationId=<org>&startDate=2026-09-01T00:00:00.000Z&endDate=2026-09-05T23:59:59.999Z"
   ```
   Both answer `401 {"message":"Unauthorized"}`, with or without parameters.
   With `GAUZY_API_SERVER_URL` pointed at a closed port (for example `http://127.0.0.1:9`), the same calls answer `503 {"message":"Session check unavailable, retry later"}`.
3. Log in, then open the Apps & URLs report and the time-and-activity page. The tables load, and in the network tab both routes answer with a JSON array rather than `{ "data": [...], "response": {} }`.

## Screenshots (if needed)

Not applicable, API routes only.

## Related Issues

None filed. Found while reviewing the proxy-mode routes against their `daily-chart` sibling.

## Type of Change

- [x] Bug fix (fixes a problem)
- [ ] New feature (adds functionality)
- [ ] Breaking change (requires changes elsewhere)
- [ ] Documentation update

## ✅ Checklist

- [x] My code follows the project coding style
- [x] I reviewed my own code and added comments where needed
- [x] I tested my changes locally
- [x] I updated or created related documentation if needed
- [x] No new warnings or errors are introduced

## Notes for the Reviewer (Optional)

- The guard runs before parameter validation, so an anonymous request always gets 401 rather than a 400 that reveals the expected parameters. `daily-chart` does it the other way round.
- These routes answer a real HTTP 401. `authenticatedGuard`'s `$res('Unauthorized')` helper answers HTTP 200 with `statusCode: 401` in the body, which the axios interceptors do not treat as unauthorized. The `organization-projects/*` and `integration/*` routes already use the real 401.
- Verified locally: anonymous and invalid-token requests on both routes (401 with Gauzy reachable, 503 with Gauzy unreachable), `daily-chart` and `organization-projects` unchanged as controls, `tsc --noEmit` on `apps/web`. An authenticated end-to-end call was not exercised, hence step 3 above. ESLint does not lint `app/api/**` with the current flat config.
- Out of scope, pre-existing on both routes: the array filters are read as `projectIds[]` while the clients send `projectIds[0]`, and `source` / `logType` are never forwarded by `buildTimeLogParams`. Worth a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling for activity and daily time-log reports.
  * Authentication failures now preserve appropriate error statuses and messages.
  * Temporary session-check failures continue to return a 503 response with retry guidance.
  * Authenticated report requests now use the correct access credentials and return the expected report data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

